### PR TITLE
release: v0.1.5

### DIFF
--- a/.claude/hooks/scripts/skill-extractor-analyzer.sh
+++ b/.claude/hooks/scripts/skill-extractor-analyzer.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 # Pass through stdin (Stop hook protocol)
 input=$(cat)
 
-OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
-PROPOSALS_FILE="/tmp/.codex-skill-proposals-${PPID}"
+OUTCOMES_FILE="${CODEX_TASK_OUTCOMES_FILE:-/tmp/.codex-task-outcomes-${PPID}}"
+PROPOSALS_FILE="${CODEX_SKILL_PROPOSALS_FILE:-/tmp/.codex-skill-proposals-${PPID}}"
 
 # Early exit if no outcomes
 if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
@@ -16,24 +16,55 @@ if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
   exit 0
 fi
 
-# Count qualifying patterns (3+ successes with 80%+ rate)
-# Group by agent_type+skill, count successes
-CANDIDATES=0
+# Count qualifying patterns (3+ successes with 80%+ rate).
+# Parse the JSONL conservatively with awk to avoid external jq dependency
+# and reduce batch-test flakiness around optional PATH/tool availability.
+CANDIDATES=$(
+  awk '
+    {
+      agent = ""
+      skill = "none"
+      outcome = ""
 
-if command -v jq &>/dev/null; then
-  # Parse JSONL and group by agent_type+skill
-  CANDIDATES=$(cat "$OUTCOMES_FILE" | \
-    jq -s '
-      group_by(.agent_type + "|" + (.skill // "none"))
-      | map({
-          key: .[0].agent_type + "|" + (.[0].skill // "none"),
-          total: length,
-          successes: [.[] | select(.outcome == "success")] | length
-        })
-      | map(select(.successes >= 3 and (.successes / .total) >= 0.8))
-      | length
-    ' 2>/dev/null || echo "0")
-fi
+      if (match($0, /"agent_type"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        agent = substr($0, RSTART, RLENGTH)
+        sub(/^.*"agent_type"[[:space:]]*:[[:space:]]*"/, "", agent)
+        sub(/"$/, "", agent)
+      }
+
+      if (match($0, /"skill"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        skill = substr($0, RSTART, RLENGTH)
+        sub(/^.*"skill"[[:space:]]*:[[:space:]]*"/, "", skill)
+        sub(/"$/, "", skill)
+      }
+
+      if (match($0, /"outcome"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        outcome = substr($0, RSTART, RLENGTH)
+        sub(/^.*"outcome"[[:space:]]*:[[:space:]]*"/, "", outcome)
+        sub(/"$/, "", outcome)
+      }
+
+      if (agent != "" && outcome != "") {
+        key = agent "|" skill
+        total[key]++
+        if (outcome == "success") {
+          successes[key]++
+        }
+      }
+    }
+
+    END {
+      candidates = 0
+      for (key in total) {
+        success_count = successes[key] + 0
+        if (success_count >= 3 && (success_count / total[key]) >= 0.8) {
+          candidates++
+        }
+      }
+      print candidates + 0
+    }
+  ' "$OUTCOMES_FILE" 2>/dev/null || echo "0"
+)
 
 if [ "$CANDIDATES" -gt 0 ] 2>/dev/null; then
   echo "[skill-extractor] ${CANDIDATES} skill candidate(s) detected from session outcomes" >&2

--- a/.codex/hooks/scripts/skill-extractor-analyzer.sh
+++ b/.codex/hooks/scripts/skill-extractor-analyzer.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 # Pass through stdin (Stop hook protocol)
 input=$(cat)
 
-OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
-PROPOSALS_FILE="/tmp/.codex-skill-proposals-${PPID}"
+OUTCOMES_FILE="${CODEX_TASK_OUTCOMES_FILE:-/tmp/.codex-task-outcomes-${PPID}}"
+PROPOSALS_FILE="${CODEX_SKILL_PROPOSALS_FILE:-/tmp/.codex-skill-proposals-${PPID}}"
 
 # Early exit if no outcomes
 if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
@@ -16,24 +16,55 @@ if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
   exit 0
 fi
 
-# Count qualifying patterns (3+ successes with 80%+ rate)
-# Group by agent_type+skill, count successes
-CANDIDATES=0
+# Count qualifying patterns (3+ successes with 80%+ rate).
+# Parse the JSONL conservatively with awk to avoid external jq dependency
+# and reduce batch-test flakiness around optional PATH/tool availability.
+CANDIDATES=$(
+  awk '
+    {
+      agent = ""
+      skill = "none"
+      outcome = ""
 
-if command -v jq &>/dev/null; then
-  # Parse JSONL and group by agent_type+skill
-  CANDIDATES=$(cat "$OUTCOMES_FILE" | \
-    jq -s '
-      group_by(.agent_type + "|" + (.skill // "none"))
-      | map({
-          key: .[0].agent_type + "|" + (.[0].skill // "none"),
-          total: length,
-          successes: [.[] | select(.outcome == "success")] | length
-        })
-      | map(select(.successes >= 3 and (.successes / .total) >= 0.8))
-      | length
-    ' 2>/dev/null || echo "0")
-fi
+      if (match($0, /"agent_type"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        agent = substr($0, RSTART, RLENGTH)
+        sub(/^.*"agent_type"[[:space:]]*:[[:space:]]*"/, "", agent)
+        sub(/"$/, "", agent)
+      }
+
+      if (match($0, /"skill"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        skill = substr($0, RSTART, RLENGTH)
+        sub(/^.*"skill"[[:space:]]*:[[:space:]]*"/, "", skill)
+        sub(/"$/, "", skill)
+      }
+
+      if (match($0, /"outcome"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        outcome = substr($0, RSTART, RLENGTH)
+        sub(/^.*"outcome"[[:space:]]*:[[:space:]]*"/, "", outcome)
+        sub(/"$/, "", outcome)
+      }
+
+      if (agent != "" && outcome != "") {
+        key = agent "|" skill
+        total[key]++
+        if (outcome == "success") {
+          successes[key]++
+        }
+      }
+    }
+
+    END {
+      candidates = 0
+      for (key in total) {
+        success_count = successes[key] + 0
+        if (success_count >= 3 && (success_count / total[key]) >= 0.8) {
+          candidates++
+        }
+      }
+      print candidates + 0
+    }
+  ' "$OUTCOMES_FILE" 2>/dev/null || echo "0"
+)
 
 if [ "$CANDIDATES" -gt 0 ] 2>/dev/null; then
   echo "[skill-extractor] ${CANDIDATES} skill candidate(s) detected from session outcomes" >&2

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.1.1",
-  "generatedAt": "2026-04-19T00:11:55.434Z",
-  "templateVersion": "0.1.1",
+  "generatorVersion": "0.1.5",
+  "generatedAt": "2026-04-19T06:53:30.796Z",
+  "templateVersion": "0.1.5",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -1030,8 +1030,8 @@
       "component": "hooks"
     },
     ".codex/hooks/scripts/skill-extractor-analyzer.sh": {
-      "templateHash": "70b9cffa3ef0d20116fe41fd5aed203733959a63a9fefe39a3c9b7c87e0f2627",
-      "size": 1578,
+      "templateHash": "0339a890c08b0d4208922e7f8542776cd7b8c28d73290e07a62edf28cbc339fc",
+      "size": 2455,
       "component": "hooks"
     },
     ".codex/hooks/scripts/user-prompt-preprocessor.sh": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-04-19
+
+### Fixed
+- Normalize pipeline command/state references for the Codex port so the `auto-dev` template, pipeline wiki entry, and pipeline design spec all point at `/pipeline` and `.codex-pipeline` state files.
+- Harden `skill-extractor-analyzer.sh` and its hook test to avoid flaky release-batch failures under Bun's multi-file runner.
+
 ## [0.35.0] - 2026-03-14
 
 ### Added

--- a/docs/superpowers/specs/2026-04-02-pipeline-skill-design.md
+++ b/docs/superpowers/specs/2026-04-02-pipeline-skill-design.md
@@ -97,7 +97,7 @@ Load YAML -> Validate -> Execute steps sequentially -> Track state -> Report com
 
 ### State File
 
-`/tmp/.claude-pipeline-{name}-{PPID}.json`:
+`/tmp/.codex-pipeline-{name}-{PPID}.json`:
 
 ```json
 {
@@ -123,7 +123,7 @@ Load YAML -> Validate -> Execute steps sequentially -> Track state -> Report com
 
 ```
 /pipeline resume
--> Scan /tmp/.claude-pipeline-*-$PPID.json
+-> Scan /tmp/.codex-pipeline-*-$PPID.json
 -> Show halted pipeline info
 -> Options: Retry | Skip | Abort
 ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.1.1",
+  "version": "0.1.5",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/scripts/skill-extractor-analyzer.sh
+++ b/templates/.claude/hooks/scripts/skill-extractor-analyzer.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 # Pass through stdin (Stop hook protocol)
 input=$(cat)
 
-OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
-PROPOSALS_FILE="/tmp/.codex-skill-proposals-${PPID}"
+OUTCOMES_FILE="${CODEX_TASK_OUTCOMES_FILE:-/tmp/.codex-task-outcomes-${PPID}}"
+PROPOSALS_FILE="${CODEX_SKILL_PROPOSALS_FILE:-/tmp/.codex-skill-proposals-${PPID}}"
 
 # Early exit if no outcomes
 if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
@@ -16,24 +16,55 @@ if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
   exit 0
 fi
 
-# Count qualifying patterns (3+ successes with 80%+ rate)
-# Group by agent_type+skill, count successes
-CANDIDATES=0
+# Count qualifying patterns (3+ successes with 80%+ rate).
+# Parse the JSONL conservatively with awk to avoid external jq dependency
+# and reduce batch-test flakiness around optional PATH/tool availability.
+CANDIDATES=$(
+  awk '
+    {
+      agent = ""
+      skill = "none"
+      outcome = ""
 
-if command -v jq &>/dev/null; then
-  # Parse JSONL and group by agent_type+skill
-  CANDIDATES=$(cat "$OUTCOMES_FILE" | \
-    jq -s '
-      group_by(.agent_type + "|" + (.skill // "none"))
-      | map({
-          key: .[0].agent_type + "|" + (.[0].skill // "none"),
-          total: length,
-          successes: [.[] | select(.outcome == "success")] | length
-        })
-      | map(select(.successes >= 3 and (.successes / .total) >= 0.8))
-      | length
-    ' 2>/dev/null || echo "0")
-fi
+      if (match($0, /"agent_type"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        agent = substr($0, RSTART, RLENGTH)
+        sub(/^.*"agent_type"[[:space:]]*:[[:space:]]*"/, "", agent)
+        sub(/"$/, "", agent)
+      }
+
+      if (match($0, /"skill"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        skill = substr($0, RSTART, RLENGTH)
+        sub(/^.*"skill"[[:space:]]*:[[:space:]]*"/, "", skill)
+        sub(/"$/, "", skill)
+      }
+
+      if (match($0, /"outcome"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        outcome = substr($0, RSTART, RLENGTH)
+        sub(/^.*"outcome"[[:space:]]*:[[:space:]]*"/, "", outcome)
+        sub(/"$/, "", outcome)
+      }
+
+      if (agent != "" && outcome != "") {
+        key = agent "|" skill
+        total[key]++
+        if (outcome == "success") {
+          successes[key]++
+        }
+      }
+    }
+
+    END {
+      candidates = 0
+      for (key in total) {
+        success_count = successes[key] + 0
+        if (success_count >= 3 && (success_count / total[key]) >= 0.8) {
+          candidates++
+        }
+      }
+      print candidates + 0
+    }
+  ' "$OUTCOMES_FILE" 2>/dev/null || echo "0"
+)
 
 if [ "$CANDIDATES" -gt 0 ] 2>/dev/null; then
   echo "[skill-extractor] ${CANDIDATES} skill candidate(s) detected from session outcomes" >&2

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.1",
-  "lastUpdated": "2026-04-18T00:00:00.000Z",
+  "version": "0.1.5",
+  "lastUpdated": "2026-04-19T07:00:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -1,4 +1,4 @@
-# /omcustom:workflow auto-dev — Full-auto release pipeline
+# /pipeline auto-dev — Full-auto release pipeline
 # Pre-triages open issues → triage verify-done → plan → implement → verify → PR → followup
 
 name: auto-dev

--- a/tests/unit/core/hooks-scripts.test.ts
+++ b/tests/unit/core/hooks-scripts.test.ts
@@ -79,6 +79,20 @@ function bashSyntaxCheck(scriptPath: string): Promise<{ exitCode: number; stderr
   });
 }
 
+async function waitForFile(path: string, timeoutMs = 250): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  return existsSync(path);
+}
+
 /** Build a minimal Claude Code hook JSON payload for Task tool calls. */
 function makeTaskInput(subagentType: string, prompt: string): string {
   return JSON.stringify({
@@ -878,8 +892,14 @@ describe('feedback-collector.sh', () => {
 // -------------------------------------------------------------------
 
 describe('skill-extractor-analyzer.sh', () => {
-  const outcomesFile = `/tmp/.codex-task-outcomes-${process.pid}`;
-  const proposalsFile = `/tmp/.codex-skill-proposals-${process.pid}`;
+  let outcomesFile: string;
+  let proposalsFile: string;
+
+  beforeEach(() => {
+    const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    outcomesFile = join(tmpdir(), `.codex-task-outcomes-${suffix}`);
+    proposalsFile = join(tmpdir(), `.codex-skill-proposals-${suffix}`);
+  });
 
   afterEach(async () => {
     await unlink(outcomesFile).catch(() => undefined);
@@ -888,7 +908,15 @@ describe('skill-extractor-analyzer.sh', () => {
 
   it('should always exit 0 and pass stdin through when no outcomes file exists', async () => {
     const input = makeStopInput({ session_id: 'skill-extractor-test' });
-    const result = await runHookScript(SKILL_EXTRACTOR_ANALYZER_SCRIPT, input, {}, tmpdir());
+    const result = await runHookScript(
+      SKILL_EXTRACTOR_ANALYZER_SCRIPT,
+      input,
+      {
+        CODEX_TASK_OUTCOMES_FILE: outcomesFile,
+        CODEX_SKILL_PROPOSALS_FILE: proposalsFile,
+      },
+      tmpdir()
+    );
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toBe(input);
@@ -917,12 +945,43 @@ describe('skill-extractor-analyzer.sh', () => {
     );
 
     const input = makeStopInput({ session_id: 'skill-extractor-proposal' });
-    const result = await runHookScript(SKILL_EXTRACTOR_ANALYZER_SCRIPT, input, {}, tmpdir());
+    const result = await runHookScript(
+      SKILL_EXTRACTOR_ANALYZER_SCRIPT,
+      input,
+      {
+        CODEX_TASK_OUTCOMES_FILE: outcomesFile,
+        CODEX_SKILL_PROPOSALS_FILE: proposalsFile,
+      },
+      tmpdir()
+    );
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.trim()).toBe(input);
-    expect(result.stderr).toContain('skill candidate');
-    expect(existsSync(proposalsFile)).toBe(true);
+    const proposalExists = await waitForFile(proposalsFile);
+
+    expect(
+      {
+        exitCode: result.exitCode,
+        stdout: result.stdout.trim(),
+        stderr: result.stderr,
+        proposalExists,
+      },
+      JSON.stringify(
+        {
+          exitCode: result.exitCode,
+          stdout: result.stdout.trim(),
+          stderr: result.stderr,
+          proposalExists,
+          outcomesFile,
+          proposalsFile,
+        },
+        null,
+        2
+      )
+    ).toEqual({
+      exitCode: 0,
+      stdout: input,
+      stderr: expect.stringContaining('skill candidate'),
+      proposalExists: true,
+    });
 
     const proposal = JSON.parse(await readFile(proposalsFile, 'utf-8'));
     expect(proposal.candidates).toBe(1);

--- a/wiki/skills/pipeline.md
+++ b/wiki/skills/pipeline.md
@@ -16,7 +16,7 @@ Invoke and resume YAML-defined pipelines — `/pipeline auto-dev` runs the full 
 
 ## Overview
 
-YAML-based pipeline executor. In list mode, scans `workflows/*.yaml` and displays available pipelines. In run mode, loads and validates a pipeline YAML, then executes steps sequentially (skill steps via Skill tool, prompt steps via agent delegation, parallel steps via Agent tool). Tracks state per step in `/tmp/.claude-pipeline-{name}-{PPID}.json`. Resume mode re-executes from the failed step. Max 4 concurrent parallel steps (pipeline-guards).
+YAML-based pipeline executor. In list mode, scans `workflows/*.yaml` and displays available pipelines. In run mode, loads and validates a pipeline YAML, then executes steps sequentially (skill steps via Skill tool, prompt steps via agent delegation, parallel steps via Agent tool). Tracks state per step in `/tmp/.codex-pipeline-{name}-{PPID}.json`. Resume mode re-executes from the failed step. Max 4 concurrent parallel steps (pipeline-guards).
 
 ## Key Details
 


### PR DESCRIPTION
## Summary
- align pipeline command/state references for the Codex port
- stabilize skill-extractor-analyzer hook behavior and its release-batch test
- bump release metadata to 0.1.5 and refresh packaged manifest/lock state

## Verification
- bun run lint
- bun run typecheck
- bun run .github/scripts/validate-docs.ts --programmatic-only
- bun run build
- npm pack --dry-run
- release CI batch suite
- bun test tests/unit/core/template-validation.test.ts

## Notes
- local pre-commit still uses plain `bun run test`, which hit the known Bun termination quirk; the release CI batch suite passed and was used as the release gate here.