### PR TITLE
release: v0.1.6

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,11 +18,98 @@ jobs:
     permissions:
       contents: write
       issues: write
+      actions: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Wait for required develop workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          MAX_ATTEMPTS: "36"
+          SLEEP_SECONDS: "10"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MERGE_SHA}" ] || [ "${MERGE_SHA}" = "null" ]; then
+            echo "::error::Missing merge commit SHA for merged release PR"
+            exit 1
+          fi
+
+          mapfile -t changed_files < <(git show --pretty="" --name-only "${MERGE_SHA}" | sed '/^$/d' | sort -u)
+          required_workflows=("CI")
+
+          for path in "${changed_files[@]}"; do
+            if [[ "${path}" == "README.md" || "${path}" == "README_ko.md" || "${path}" == wiki/* || "${path}" == templates/* ]]; then
+              required_workflows+=("Docs Sync")
+              break
+            fi
+          done
+
+          for path in "${changed_files[@]}"; do
+            if [[ "${path}" == .codex/agents/* || "${path}" == .codex/skills/* || "${path}" == .codex/rules/* || "${path}" == guides/* || "${path}" == wiki/* ]]; then
+              required_workflows+=("Wiki Sync")
+              break
+            fi
+          done
+
+          echo "Required workflows: ${required_workflows[*]}"
+
+          for ((attempt=1; attempt<=MAX_ATTEMPTS; attempt++)); do
+            runs_json=$(gh run list \
+              --commit "${MERGE_SHA}" \
+              --limit 100 \
+              --json workflowName,status,conclusion,event,headSha)
+
+            pending=0
+            success_count=0
+
+            for workflow in "${required_workflows[@]}"; do
+              run_json=$(echo "${runs_json}" | jq -c --arg workflow "${workflow}" --arg sha "${MERGE_SHA}" '
+                map(select(.workflowName == $workflow and .event == "push" and .headSha == $sha))
+                | first
+              ')
+
+              if [ "${run_json}" = "null" ]; then
+                echo "::notice::Waiting for workflow '${workflow}' on ${MERGE_SHA} to appear"
+                pending=1
+                continue
+              fi
+
+              status=$(echo "${run_json}" | jq -r '.status')
+              conclusion=$(echo "${run_json}" | jq -r '.conclusion // ""')
+
+              if [ "${status}" != "completed" ]; then
+                echo "::notice::Workflow '${workflow}' is still ${status}"
+                pending=1
+                continue
+              fi
+
+              if [ "${conclusion}" != "success" ]; then
+                echo "::error::Workflow '${workflow}' finished with conclusion '${conclusion}' on ${MERGE_SHA}"
+                exit 1
+              fi
+
+              success_count=$((success_count + 1))
+            done
+
+            if [ "${pending}" -eq 0 ] && [ "${success_count}" -eq "${#required_workflows[@]}" ]; then
+              echo "All required workflows succeeded for ${MERGE_SHA}"
+              exit 0
+            fi
+
+            if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
+              sleep "${SLEEP_SECONDS}"
+            fi
+          done
+
+          echo "::error::Timed out waiting for required workflows on ${MERGE_SHA}"
+          exit 1
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -53,10 +140,11 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
+          git tag -a "$TAG" "${MERGE_SHA}" -m "Release $TAG"
           git push origin "$TAG"
 
       - name: Close linked issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,104 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  actions: read
 
 jobs:
+  gate:
+    name: Gate Release On CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Wait for required commit workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+          MAX_ATTEMPTS: "36"
+          SLEEP_SECONDS: "10"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag_sha=$(git rev-list -n 1 "${TAG_NAME}")
+          echo "Tag ${TAG_NAME} points to ${tag_sha}"
+
+          mapfile -t changed_files < <(git show --pretty="" --name-only "${tag_sha}" | sed '/^$/d' | sort -u)
+          required_workflows=("CI")
+
+          for path in "${changed_files[@]}"; do
+            if [[ "${path}" == "README.md" || "${path}" == "README_ko.md" || "${path}" == wiki/* || "${path}" == templates/* ]]; then
+              required_workflows+=("Docs Sync")
+              break
+            fi
+          done
+
+          for path in "${changed_files[@]}"; do
+            if [[ "${path}" == .codex/agents/* || "${path}" == .codex/skills/* || "${path}" == .codex/rules/* || "${path}" == guides/* || "${path}" == wiki/* ]]; then
+              required_workflows+=("Wiki Sync")
+              break
+            fi
+          done
+
+          echo "Required workflows: ${required_workflows[*]}"
+
+          for ((attempt=1; attempt<=MAX_ATTEMPTS; attempt++)); do
+            runs_json=$(gh run list \
+              --commit "${tag_sha}" \
+              --limit 100 \
+              --json workflowName,status,conclusion,event,headSha)
+
+            pending=0
+            success_count=0
+
+            for workflow in "${required_workflows[@]}"; do
+              run_json=$(echo "${runs_json}" | jq -c --arg workflow "${workflow}" --arg sha "${tag_sha}" '
+                map(select(.workflowName == $workflow and .event == "push" and .headSha == $sha))
+                | first
+              ')
+
+              if [ "${run_json}" = "null" ]; then
+                echo "::notice::Waiting for workflow '${workflow}' on ${tag_sha} to appear"
+                pending=1
+                continue
+              fi
+
+              status=$(echo "${run_json}" | jq -r '.status')
+              conclusion=$(echo "${run_json}" | jq -r '.conclusion // ""')
+
+              if [ "${status}" != "completed" ]; then
+                echo "::notice::Workflow '${workflow}' is still ${status}"
+                pending=1
+                continue
+              fi
+
+              if [ "${conclusion}" != "success" ]; then
+                echo "::error::Workflow '${workflow}' finished with conclusion '${conclusion}' on ${tag_sha}"
+                exit 1
+              fi
+
+              success_count=$((success_count + 1))
+            done
+
+            if [ "${pending}" -eq 0 ] && [ "${success_count}" -eq "${#required_workflows[@]}" ]; then
+              echo "All required workflows succeeded for ${tag_sha}"
+              exit 0
+            fi
+
+            if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
+              sleep "${SLEEP_SECONDS}"
+            fi
+          done
+
+          echo "::error::Timed out waiting for required workflows on ${tag_sha}"
+          exit 1
+
   test:
     name: Test
+    needs: [gate]
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -143,6 +237,7 @@ jobs:
 
   docs-validate:
     name: Validate Documentation
+    needs: [gate]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.1.5",
-  "generatedAt": "2026-04-19T06:53:30.796Z",
-  "templateVersion": "0.1.5",
+  "generatorVersion": "0.1.6",
+  "generatedAt": "2026-04-19T07:21:12.277Z",
+  "templateVersion": "0.1.6",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-04-19
+
+### Fixed
+- Block auto-tag creation until required `develop` workflows complete successfully, and fail fast when any required workflow concludes non-success.
+- Add a release gate so manual or early tag pushes cannot publish while required commit CI is still running or has failed.
+
 ## [0.1.5] - 2026-04-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.5",
-  "lastUpdated": "2026-04-19T07:00:00.000Z",
+  "version": "0.1.6",
+  "lastUpdated": "2026-04-19T07:21:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/tests/unit/core/auto-tag-workflow.test.ts
+++ b/tests/unit/core/auto-tag-workflow.test.ts
@@ -213,6 +213,33 @@ describe('auto-tag.yml — version extraction', () => {
 });
 
 // ---------------------------------------------------------------------------
+// CI gating
+// ---------------------------------------------------------------------------
+
+describe('auto-tag.yml — CI gating', () => {
+  it('should wait for required develop workflows before creating a tag', async () => {
+    const content = await readWorkflow();
+    expect(content).toContain('Wait for required develop workflows');
+    expect(content).toContain('gh run list');
+    expect(content).toContain('merge_commit_sha');
+  });
+
+  it('should derive required workflows from the merged commit changed files', async () => {
+    const content = await readWorkflow();
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal shell snippet assertion
+    expect(content).toContain('git show --pretty="" --name-only "${MERGE_SHA}"');
+    expect(content).toContain('required_workflows=("CI")');
+    expect(content).toContain('required_workflows+=("Docs Sync")');
+    expect(content).toContain('required_workflows+=("Wiki Sync")');
+  });
+
+  it('should not hard-code Docs Sync and Wiki Sync as unconditional requirements', async () => {
+    const content = await readWorkflow();
+    expect(content).not.toContain('REQUIRED_WORKFLOWS: "CI,Docs Sync,Wiki Sync"');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Idempotency: existing tag check
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/core/release-workflow.test.ts
+++ b/tests/unit/core/release-workflow.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const RELEASE_WORKFLOW = resolve(import.meta.dir, '../../../.github/workflows/release.yml');
+
+async function readWorkflow(): Promise<string> {
+  return readFile(RELEASE_WORKFLOW, 'utf-8');
+}
+
+describe('release.yml — file existence', () => {
+  it('should exist at .github/workflows/release.yml', async () => {
+    const content = await readWorkflow();
+    expect(content.length).toBeGreaterThan(0);
+  });
+});
+
+describe('release.yml — trigger conditions', () => {
+  it('should trigger on v* tag pushes', async () => {
+    const content = await readWorkflow();
+    expect(content).toContain('tags:');
+    expect(content).toContain("- 'v*'");
+  });
+});
+
+describe('release.yml — CI gate', () => {
+  it('should define a gate job before publish work begins', async () => {
+    const content = await readWorkflow();
+    expect(content).toContain('gate:');
+    expect(content).toContain('name: Gate Release On CI');
+  });
+
+  it('should compute required workflows from the tagged commit changed files', async () => {
+    const content = await readWorkflow();
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal shell snippet assertion
+    expect(content).toContain('git show --pretty="" --name-only "${tag_sha}"');
+    expect(content).toContain('required_workflows=("CI")');
+    expect(content).toContain('required_workflows+=("Docs Sync")');
+    expect(content).toContain('required_workflows+=("Wiki Sync")');
+  });
+
+  it('should make test and docs validation depend on the gate job', async () => {
+    const content = await readWorkflow();
+    expect(content).toContain('test:');
+    expect(content).toContain('needs: [gate]');
+    expect(content).toContain('docs-validate:');
+  });
+});


### PR DESCRIPTION
## Summary
- gate auto-tag on required merge-commit workflows
- gate tag-driven release publish on required tagged-commit workflows
- derive docs/wiki workflow requirements from changed paths so unrelated releases do not deadlock
- add workflow tests for the new gating behavior

## Verification
- bun run lint
- bun run typecheck
- bun run .github/scripts/validate-docs.ts --programmatic-only
- bun run build
- npm pack --dry-run
- bun test tests/unit/core/template-validation.test.ts
- bun test tests/unit/core/auto-tag-workflow.test.ts tests/unit/core/release-workflow.test.ts
- release CI batch suite

Closes #285