### PR TITLE
release: v0.1.7

### DIFF
--- a/.claude/skills/token-efficiency-audit/SKILL.md
+++ b/.claude/skills/token-efficiency-audit/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: token-efficiency-audit
+description: Audit and tune Claude/Codex settings for lower token usage without changing code
+scope: package
+argument-hint: "[audit|apply-interactive|apply-ci|status]"
+user-invocable: true
+---
+
+# Token Efficiency Audit
+
+Audit and tune Claude Code / Codex configuration for better token efficiency.
+
+This skill is for configuration-level optimization, not runtime behavior shaping. It complements:
+
+- `guides/cc-token-saver/README.md` for plugin-level token protection
+- R013 ecomode for runtime compression
+- `omcodex:monitoring-setup` for telemetry and usage visibility
+
+## Modes
+
+### `audit` (default)
+
+Inspect the current token-efficiency posture without changing files.
+
+Check these sources when they exist:
+
+- `.codex/settings.local.json`
+- `.codex/settings.json`
+- `~/.codex/config.toml`
+- shell startup files such as `~/.zshrc`, `~/.bashrc`, `~/.bash_profile`
+
+Audit for:
+
+- Claude-side knobs
+  - `includeGitInstructions`
+  - `autoConnectIde`
+  - output caps such as `BASH_MAX_OUTPUT_LENGTH`
+  - file-read / MCP output token caps
+- Codex-side knobs
+  - `features.apps`
+  - `web_search`
+  - `tool_output_token_limit`
+- worker-only flags that should not be silently enabled in normal interactive sessions
+
+Report:
+
+1. current settings found
+2. low-risk improvements
+3. high-risk / CI-only improvements
+4. expected tradeoffs
+
+### `status`
+
+Summarize the current posture in a compact status report:
+
+- configuration files found
+- safe interactive settings present / missing
+- CI-only settings present / missing
+- main token-risk hotspots
+
+### `apply-interactive`
+
+Apply only low-risk settings suitable for human interactive sessions.
+
+Preferred targets:
+
+- `.codex/settings.local.json` for session-local settings
+- user shell rc files only when environment variables are the right fit
+
+Safe defaults to consider:
+
+- disable unnecessary git instruction injection when not needed
+- disable unnecessary IDE auto-connect when not needed
+- set sane output ceilings to reduce runaway tool output without over-truncating
+- reduce Codex tool output limits to a practical level
+- disable unneeded app surfaces when they are not part of the user workflow
+
+Guardrails:
+
+- preserve existing user config
+- never overwrite unrelated settings
+- do not apply CI-only flags here
+- explain tradeoffs before writing
+
+### `apply-ci`
+
+Apply stronger settings for non-interactive worker / CI contexts.
+
+This mode is intentionally stricter and must call out risk clearly.
+
+Examples of CI-only candidates:
+
+- disable auto-memory features
+- disable built-in agent surfaces not needed for batch execution
+- disable nonessential MCP / app surfaces
+- tighten output limits more aggressively than interactive mode
+
+Required warning:
+
+- these settings can reduce convenience or disable important harness behaviors
+- they should be scoped to CI/worker environments, not broad local defaults
+
+## Output Contract
+
+### Audit / Status
+
+```text
+[Token Efficiency]
+
+Mode: audit|status
+Posture: good|mixed|wasteful
+
+Safe interactive wins:
+- ...
+
+CI-only wins:
+- ...
+
+Watchouts:
+- ...
+```
+
+### Apply Modes
+
+```text
+[Token Efficiency]
+
+Mode: apply-interactive|apply-ci
+Files updated:
+- ...
+
+Settings applied:
+- ...
+
+Tradeoffs:
+- ...
+
+Rollback:
+- restore prior values from git diff / file backup
+```
+
+## Heuristics
+
+- Prefer smaller, reversible config edits over broad environment mutation
+- Keep interactive and CI profiles separate
+- Do not set output limits so low that users trigger repeated re-runs and spend more tokens overall
+- When uncertain, recommend `audit` first and `apply-*` second

--- a/.codex/skills/token-efficiency-audit/SKILL.md
+++ b/.codex/skills/token-efficiency-audit/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: token-efficiency-audit
+description: Audit and tune Claude/Codex settings for lower token usage without changing code
+scope: package
+argument-hint: "[audit|apply-interactive|apply-ci|status]"
+user-invocable: true
+---
+
+# Token Efficiency Audit
+
+Audit and tune Claude Code / Codex configuration for better token efficiency.
+
+This skill is for configuration-level optimization, not runtime behavior shaping. It complements:
+
+- `guides/cc-token-saver/README.md` for plugin-level token protection
+- R013 ecomode for runtime compression
+- `omcodex:monitoring-setup` for telemetry and usage visibility
+
+## Modes
+
+### `audit` (default)
+
+Inspect the current token-efficiency posture without changing files.
+
+Check these sources when they exist:
+
+- `.codex/settings.local.json`
+- `.codex/settings.json`
+- `~/.codex/config.toml`
+- shell startup files such as `~/.zshrc`, `~/.bashrc`, `~/.bash_profile`
+
+Audit for:
+
+- Claude-side knobs
+  - `includeGitInstructions`
+  - `autoConnectIde`
+  - output caps such as `BASH_MAX_OUTPUT_LENGTH`
+  - file-read / MCP output token caps
+- Codex-side knobs
+  - `features.apps`
+  - `web_search`
+  - `tool_output_token_limit`
+- worker-only flags that should not be silently enabled in normal interactive sessions
+
+Report:
+
+1. current settings found
+2. low-risk improvements
+3. high-risk / CI-only improvements
+4. expected tradeoffs
+
+### `status`
+
+Summarize the current posture in a compact status report:
+
+- configuration files found
+- safe interactive settings present / missing
+- CI-only settings present / missing
+- main token-risk hotspots
+
+### `apply-interactive`
+
+Apply only low-risk settings suitable for human interactive sessions.
+
+Preferred targets:
+
+- `.codex/settings.local.json` for session-local settings
+- user shell rc files only when environment variables are the right fit
+
+Safe defaults to consider:
+
+- disable unnecessary git instruction injection when not needed
+- disable unnecessary IDE auto-connect when not needed
+- set sane output ceilings to reduce runaway tool output without over-truncating
+- reduce Codex tool output limits to a practical level
+- disable unneeded app surfaces when they are not part of the user workflow
+
+Guardrails:
+
+- preserve existing user config
+- never overwrite unrelated settings
+- do not apply CI-only flags here
+- explain tradeoffs before writing
+
+### `apply-ci`
+
+Apply stronger settings for non-interactive worker / CI contexts.
+
+This mode is intentionally stricter and must call out risk clearly.
+
+Examples of CI-only candidates:
+
+- disable auto-memory features
+- disable built-in agent surfaces not needed for batch execution
+- disable nonessential MCP / app surfaces
+- tighten output limits more aggressively than interactive mode
+
+Required warning:
+
+- these settings can reduce convenience or disable important harness behaviors
+- they should be scoped to CI/worker environments, not broad local defaults
+
+## Output Contract
+
+### Audit / Status
+
+```text
+[Token Efficiency]
+
+Mode: audit|status
+Posture: good|mixed|wasteful
+
+Safe interactive wins:
+- ...
+
+CI-only wins:
+- ...
+
+Watchouts:
+- ...
+```
+
+### Apply Modes
+
+```text
+[Token Efficiency]
+
+Mode: apply-interactive|apply-ci
+Files updated:
+- ...
+
+Settings applied:
+- ...
+
+Tradeoffs:
+- ...
+
+Rollback:
+- restore prior values from git diff / file backup
+```
+
+## Heuristics
+
+- Prefer smaller, reversible config edits over broad environment mutation
+- Keep interactive and CI profiles separate
+- Do not set output limits so low that users trigger repeated re-runs and spend more tokens overall
+- When uncertain, recommend `audit` first and `apply-*` second

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.1.6",
-  "generatedAt": "2026-04-19T07:21:12.277Z",
-  "templateVersion": "0.1.6",
+  "generatorVersion": "0.1.7",
+  "generatedAt": "2026-04-19T08:21:29.566Z",
+  "templateVersion": "0.1.7",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -437,6 +437,11 @@
     ".codex/skills/springboot-best-practices/SKILL.md": {
       "templateHash": "1b8642c9993b4f89aee7d6769288587274a3afc27a0cff06c9d92861232b171d",
       "size": 2539,
+      "component": "skills"
+    },
+    ".codex/skills/token-efficiency-audit/SKILL.md": {
+      "templateHash": "413eff441296cd913f2c8dedfe113df3f2f22c33efa77fa6e54fae9d71f54442",
+      "size": 3592,
       "component": "skills"
     },
     ".codex/skills/qa-lead-routing/SKILL.md": {
@@ -1280,13 +1285,18 @@
       "component": "guides"
     },
     "guides/claude-code/13-cli-flags.md": {
-      "templateHash": "da13ae95b0e5c58e5315390f9a1b1017e260187ed798826b256963b430d4d4dc",
-      "size": 4782,
+      "templateHash": "e752de67d30ffd435f046243ac5936322ba129e5c826b61c924dca04e685e077",
+      "size": 4881,
       "component": "guides"
     },
     "guides/claude-code/12-workflow-patterns.md": {
       "templateHash": "6381a632b7fc8793b5b29fc26ac02c45ceaf088a6087f430470173aec59cc5de",
       "size": 6348,
+      "component": "guides"
+    },
+    "guides/claude-code/14-token-efficiency.md": {
+      "templateHash": "4766988fcac011c78137d5b425458bd6c73ac2b6180f200979e3bbc9a0ed438b",
+      "size": 2320,
       "component": "guides"
     },
     "guides/claude-code/09-guardrails.md": {
@@ -1295,8 +1305,8 @@
       "component": "guides"
     },
     "guides/claude-code/index.yaml": {
-      "templateHash": "746e403f0b003b3e58512d290bc8786318633ef4174eaab88462ccec22334836",
-      "size": 1836,
+      "templateHash": "750a812b624c3e48a62c9272f91aa65e2c5096cab8d8f2e44cff30a78dad7f21",
+      "size": 2040,
       "component": "guides"
     },
     "guides/claude-code/05-agent-sdk.md": {
@@ -1380,8 +1390,8 @@
       "component": "guides"
     },
     "guides/cc-token-saver/README.md": {
-      "templateHash": "6f84b326ae73dbc9340b47e2dbf774b0ebc5c6ab82cd538971113ee5d3ccf6c7",
-      "size": 3634,
+      "templateHash": "136a71fcb2907a92d6541ca3ed79575e7d441ef7b6b353379f885974b9602f44",
+      "size": 3904,
       "component": "guides"
     },
     "guides/dbt/README.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-04-19
+
+### Added
+- Add `/token-efficiency-audit` to audit and apply token-efficiency settings for Claude/Codex usage.
+- Add a new Claude Code guide covering plugin, runtime, and settings-level token-efficiency layers.
+
+### Changed
+- Link the new token-efficiency guidance from existing CLI flag and cc-token-saver documentation.
+
 ## [0.1.6] - 2026-04-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ NO EXCEPTIONS. NO EXCUSES.
 | `/memory-save` | Save session context to omx-memory |
 | `/memory-recall` | Search and recall memories |
 | `/omcodex:monitoring-setup` | Enable/disable OTel console monitoring |
+| `/token-efficiency-audit` | Audit and tune token-efficiency settings |
 | `/omcodex:npm-publish` | Publish package to npm registry |
 | `/omcodex:npm-version` | Manage semantic versions |
 | `/omcodex:npm-audit` | Audit dependencies |
@@ -130,7 +131,7 @@ project/
 +-- AGENTS.md                    # Entry point
 +-- .codex/
 |   +-- agents/                  # Subagent definitions (48 files)
-|   +-- skills/                  # Skills (106 directories)
+|   +-- skills/                  # Skills (108 directories)
 |   +-- rules/                   # Global rules (22 files)
 |   +-- hooks/                   # Hook scripts (security, validation, HUD)
 |   +-- contexts/                # Context files (4 files)
@@ -174,7 +175,6 @@ This is the core oh-my-customcodex philosophy: **"No expert? CREATE one, connect
 | QA Team | 3 | qa-planner, qa-writer, qa-engineer |
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, wiki-curator |
-| Auxiliary | 1 | slack-cli-expert |
 | **Total** | **48** | |
 
 ## Agent Teams (MUST when enabled)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-48 agents. 107 skills. 22 rules. One command.
+48 agents. 108 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcodex init
@@ -132,7 +132,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (107)
+### Skills (108)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -140,7 +140,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 | Routing | 4 | secretary, dev-lead, de-lead, qa-lead |
 | Workflow | 13 | structured-dev-cycle, deep-plan, research, evaluator-optimizer, dag-orchestration, worker-reviewer-pipeline, reasoning-sandwich, pipeline, and more |
 | Development | 9 | dev-review, dev-refactor, analysis, create-agent, intent-detection, web-design-guidelines, omcodex:takeover, skill-extractor, idea |
-| Operations | 9 | update-docs, audit-agents, sauron-watch, monitoring-setup, fix-refs, release-notes, and more |
+| Operations | 10 | update-docs, audit-agents, sauron-watch, monitoring-setup, token-efficiency-audit, fix-refs, release-notes, and more |
 | Memory | 3 | memory-save, memory-recall, memory-management |
 | Package | 3 | npm-publish, npm-version, npm-audit |
 | Optimization | 3 | optimize-analyze, optimize-bundle, optimize-report |
@@ -205,6 +205,7 @@ All commands are invoked inside the oh-my-customcodex GPT Codex + OMX session.
 | `/memory-save` | Save session context |
 | `/memory-recall` | Search and recall memories |
 | `/omcodex:monitoring-setup` | OTel monitoring toggle |
+| `/token-efficiency-audit` | Audit and tune token-efficiency settings |
 | `/omcodex:loop` | Auto-continue background agent workflows (3-continue safety limit) |
 | `/omcodex:lists` | Show all commands |
 | `/omcodex:status` | System health check |
@@ -273,7 +274,7 @@ your-project/
 ├── AGENTS.md                   # Entry point
 ├── .codex/
 │   ├── agents/                 # 48 agent definitions
-│   ├── skills/                 # 107 skill modules
+│   ├── skills/                 # 108 skill modules
 │   ├── rules/                  # 22 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,9 +13,9 @@
 
 **[English Documentation](./README.md)**
 
-48개 에이전트. 107개 스킬. 22개 규칙. 명령어 하나.
+48개 에이전트. 108개 스킬. 22개 규칙. 명령어 하나.
 
-> **v0.74.0** — omcodex sync, init --from-snapshot, analysis --interview, skill-extractor (100번째 스킬), User Model, 릴리즈 정리 자동화
+> **v0.1.7** — token-efficiency-audit 스킬, 토큰 효율 3계층 가이드, cc-token-saver/CLI flags cross-reference 추가
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcodex init
@@ -25,16 +25,14 @@ npm install -g oh-my-customcodex && cd your-project && omcodex init
 
 ---
 
-## v0.74.0의 새로운 기능
+## v0.1.7의 새로운 기능
 
 | 기능 | 설명 |
 |------|------|
-| **`omcodex sync`** | `.codex/` 설정 드리프트 감지 — lockfile 비교, 팀 스냅샷 내보내기 |
-| **`omcodex init --from-snapshot`** | 팀 재현성 — 사전 구성된 스냅샷에서 설치 |
-| **`analysis --interview`** | 파일 기반 탐지 전 대화형 AI 아키텍처 인터뷰 |
-| **skill-extractor** | 100번째 스킬 — 성공한 작업 궤적에서 재사용 가능한 SKILL.md 후보 제안 |
-| **User Model** | 교정 패턴, 스킬 선호도, 전문 분야 구조적 추적 |
-| **릴리즈 정리 자동화** | PR 머지 시 연관 이슈 자동 close + 릴리즈 브랜치 자동 삭제 |
+| **`/token-efficiency-audit`** | Claude/Codex 설정을 점검하고 토큰 낭비를 줄이기 위한 감사/적용 워크플로우 |
+| **Token Efficiency Layers guide** | 플러그인, 런타임, 설정 레이어를 분리한 토큰 효율 최적화 가이드 |
+| **cc-token-saver cross-reference** | 기존 플러그인 가이드에서 Layer 3 설정 기반 최적화로 바로 이동 가능 |
+| **CLI flags cross-reference** | Claude Code CLI 플래그 문서에서 토큰 효율 가이드로 바로 이동 가능 |
 
 ---
 
@@ -149,7 +147,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (107개)
+## 스킬 (108개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -157,7 +155,7 @@ Agent(arch-documenter):haiku      ┘
 | 라우팅 | 4 | secretary, dev-lead, de-lead, qa-lead |
 | 워크플로우 | 13 | structured-dev-cycle, deep-plan, research, evaluator-optimizer, dag-orchestration, worker-reviewer-pipeline, reasoning-sandwich, pipeline 외 |
 | 개발 | 9 | dev-review, dev-refactor, analysis, create-agent, intent-detection, web-design-guidelines, omcodex:takeover, skill-extractor, idea |
-| 운영 | 9 | update-docs, audit-agents, sauron-watch, monitoring-setup, fix-refs, release-notes 외 |
+| 운영 | 10 | update-docs, audit-agents, sauron-watch, monitoring-setup, token-efficiency-audit, fix-refs, release-notes 외 |
 | 메모리 | 3 | memory-save, memory-recall, memory-management |
 | 패키지 | 3 | npm-publish, npm-version, npm-audit |
 | 최적화 | 3 | optimize-analyze, optimize-bundle, optimize-report |
@@ -224,6 +222,7 @@ Agent(arch-documenter):haiku      ┘
 | `/memory-save` | 세션 컨텍스트 저장 |
 | `/memory-recall` | 메모리 검색 및 리콜 |
 | `/omcodex:monitoring-setup` | OTel 모니터링 토글 |
+| `/token-efficiency-audit` | 토큰 효율 설정 감사 및 조정 |
 | `/omcodex:lists` | 전체 커맨드 표시 |
 | `/omcodex:status` | 시스템 상태 확인 |
 
@@ -287,7 +286,7 @@ your-project/
 ├── AGENTS.md                   # 진입점
 ├── .codex/
 │   ├── agents/                 # 48개 에이전트 정의
-│   ├── skills/                 # 107개 스킬 모듈
+│   ├── skills/                 # 108개 스킬 모듈
 │   ├── rules/                  # 22개 거버넌스 규칙 (R000-R022)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/guides/cc-token-saver/README.md
+++ b/guides/cc-token-saver/README.md
@@ -61,6 +61,15 @@ These two components solve different problems and can run simultaneously:
 
 **No conflict** — Token Guardian fires on idle time, R013 fires on context percentage. Both warnings are useful.
 
+## Layer 3 Cross-Reference
+
+`cc-token-saver` is Layer 1 of the token-efficiency stack. For settings-level optimization before the session starts, use `/token-efficiency-audit`.
+
+See also:
+
+- `guides/claude-code/14-token-efficiency.md`
+- `/token-efficiency-audit audit`
+
 ## Usage Scenarios
 
 ### `/continue` — Zero-cost context restore

--- a/guides/claude-code/13-cli-flags.md
+++ b/guides/claude-code/13-cli-flags.md
@@ -149,3 +149,4 @@ claude auto-mode critique    # Review auto mode decisions
 - [Monitoring Guide](10-monitoring.md) — OTel metrics and events
 - [Sub-agents Guide](11-sub-agents.md) — Agent spawning and coordination
 - [Workflow Patterns](12-workflow-patterns.md) — Workflow automation
+- [Token Efficiency Layers](14-token-efficiency.md) — plugin/runtime/settings optimization stack

--- a/guides/claude-code/14-token-efficiency.md
+++ b/guides/claude-code/14-token-efficiency.md
@@ -1,0 +1,73 @@
+# Token Efficiency Layers
+
+Token efficiency in oh-my-customcodex has three layers. They solve different problems and should not be mixed together blindly.
+
+## Layer 1: Plugin-Level Protection
+
+Use `cc-token-saver` when you want cache- and resume-oriented protection:
+
+- Token Guardian for prompt-cache expiry awareness
+- `/continue` for low-cost session resumption
+- usage dashboards and rate-limit reporting
+
+This layer is documented in `guides/cc-token-saver/README.md`.
+
+## Layer 2: Runtime Compression
+
+Use R013 ecomode and existing runtime guards when you want to compress active-session behavior:
+
+- shorter outputs
+- tighter budget awareness
+- safer handling of long-running, batch, or parallel tasks
+
+This layer changes how the session behaves while work is running.
+
+## Layer 3: Settings-Level Optimization
+
+Use `/token-efficiency-audit` when you want configuration-level changes before the session burns tokens.
+
+Typical settings-level levers:
+
+### Claude-side
+
+- `includeGitInstructions`
+- `autoConnectIde`
+- output ceilings such as `BASH_MAX_OUTPUT_LENGTH`
+- file-read / MCP output token caps
+
+### Codex-side
+
+- `features.apps`
+- `web_search`
+- `tool_output_token_limit`
+
+### CI / Worker-only
+
+- disable convenience features that are useful for humans but wasteful in headless runs
+- apply stronger output ceilings than interactive defaults
+
+## Recommended Usage
+
+| Goal | Best layer |
+|------|------------|
+| Protect cache value across pauses | Layer 1 |
+| Compress runtime behavior in large sessions | Layer 2 |
+| Reduce baseline token spend from configuration | Layer 3 |
+
+Use layers together, but keep responsibilities separate:
+
+- plugin layer for cache and resume
+- runtime layer for in-session behavior
+- settings layer for pre-session defaults
+
+## Tradeoffs
+
+| Lever | Benefit | Risk |
+|-------|---------|------|
+| lower output limits | prevents runaway logs | too low causes repeated reruns and extra token spend |
+| disable auto-connect / extra surfaces | less idle context and less noise | may remove convenience features users expect |
+| aggressive CI-only flags | efficient headless execution | can weaken local interactive ergonomics if applied too broadly |
+
+## Rule of Thumb
+
+Start with `audit`, then apply only the smallest reversible setting changes that address your dominant cost source.

--- a/guides/claude-code/index.yaml
+++ b/guides/claude-code/index.yaml
@@ -59,3 +59,8 @@ documents:
     title: CLI 플래그 및 모드
     description: CLI 플래그, 헤드리스 모드, 스케줄링, 환경변수 레퍼런스
     path: ./13-cli-flags.md
+
+  - name: token-efficiency
+    title: 토큰 효율 레이어
+    description: 플러그인, 런타임, 설정 레이어를 분리한 토큰 효율 최적화 가이드
+    path: ./14-token-efficiency.md

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/token-efficiency-audit/SKILL.md
+++ b/templates/.claude/skills/token-efficiency-audit/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: token-efficiency-audit
+description: Audit and tune Claude/Codex settings for lower token usage without changing code
+scope: package
+argument-hint: "[audit|apply-interactive|apply-ci|status]"
+user-invocable: true
+---
+
+# Token Efficiency Audit
+
+Audit and tune Claude Code / Codex configuration for better token efficiency.
+
+This skill is for configuration-level optimization, not runtime behavior shaping. It complements:
+
+- `guides/cc-token-saver/README.md` for plugin-level token protection
+- R013 ecomode for runtime compression
+- `omcodex:monitoring-setup` for telemetry and usage visibility
+
+## Modes
+
+### `audit` (default)
+
+Inspect the current token-efficiency posture without changing files.
+
+Check these sources when they exist:
+
+- `.codex/settings.local.json`
+- `.codex/settings.json`
+- `~/.codex/config.toml`
+- shell startup files such as `~/.zshrc`, `~/.bashrc`, `~/.bash_profile`
+
+Audit for:
+
+- Claude-side knobs
+  - `includeGitInstructions`
+  - `autoConnectIde`
+  - output caps such as `BASH_MAX_OUTPUT_LENGTH`
+  - file-read / MCP output token caps
+- Codex-side knobs
+  - `features.apps`
+  - `web_search`
+  - `tool_output_token_limit`
+- worker-only flags that should not be silently enabled in normal interactive sessions
+
+Report:
+
+1. current settings found
+2. low-risk improvements
+3. high-risk / CI-only improvements
+4. expected tradeoffs
+
+### `status`
+
+Summarize the current posture in a compact status report:
+
+- configuration files found
+- safe interactive settings present / missing
+- CI-only settings present / missing
+- main token-risk hotspots
+
+### `apply-interactive`
+
+Apply only low-risk settings suitable for human interactive sessions.
+
+Preferred targets:
+
+- `.codex/settings.local.json` for session-local settings
+- user shell rc files only when environment variables are the right fit
+
+Safe defaults to consider:
+
+- disable unnecessary git instruction injection when not needed
+- disable unnecessary IDE auto-connect when not needed
+- set sane output ceilings to reduce runaway tool output without over-truncating
+- reduce Codex tool output limits to a practical level
+- disable unneeded app surfaces when they are not part of the user workflow
+
+Guardrails:
+
+- preserve existing user config
+- never overwrite unrelated settings
+- do not apply CI-only flags here
+- explain tradeoffs before writing
+
+### `apply-ci`
+
+Apply stronger settings for non-interactive worker / CI contexts.
+
+This mode is intentionally stricter and must call out risk clearly.
+
+Examples of CI-only candidates:
+
+- disable auto-memory features
+- disable built-in agent surfaces not needed for batch execution
+- disable nonessential MCP / app surfaces
+- tighten output limits more aggressively than interactive mode
+
+Required warning:
+
+- these settings can reduce convenience or disable important harness behaviors
+- they should be scoped to CI/worker environments, not broad local defaults
+
+## Output Contract
+
+### Audit / Status
+
+```text
+[Token Efficiency]
+
+Mode: audit|status
+Posture: good|mixed|wasteful
+
+Safe interactive wins:
+- ...
+
+CI-only wins:
+- ...
+
+Watchouts:
+- ...
+```
+
+### Apply Modes
+
+```text
+[Token Efficiency]
+
+Mode: apply-interactive|apply-ci
+Files updated:
+- ...
+
+Settings applied:
+- ...
+
+Tradeoffs:
+- ...
+
+Rollback:
+- restore prior values from git diff / file backup
+```
+
+## Heuristics
+
+- Prefer smaller, reversible config edits over broad environment mutation
+- Keep interactive and CI profiles separate
+- Do not set output limits so low that users trigger repeated re-runs and spend more tokens overall
+- When uncertain, recommend `audit` first and `apply-*` second

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -104,7 +104,7 @@ oh-my-customcodex로 구동됩니다.
 | 릴리즈 | `/pipeline auto-dev`, `/omcodex-release-notes`, `/release-plan` | 자동 개발, 릴리즈 노트 |
 | 리서치 | `/research`, `/scout`, `/deep-plan`, `/omcodex:agora` | 병렬 분석, URL 평가, 연구 계획 |
 | 메모리 | `/memory-save`, `/memory-recall` | 세션 메모리 관리 |
-| 시스템 | `/omcodex:lists`, `/omcodex:status`, `/omcodex:help` | 전체 목록, 상태, 도움말 |
+| 시스템 | `/token-efficiency-audit`, `/omcodex:lists`, `/omcodex:status`, `/omcodex:help` | 토큰 효율 감사, 전체 목록, 상태, 도움말 |
 
 > 전체 커맨드 목록 (60+ 커맨드): `/omcodex:lists` 실행
 
@@ -115,7 +115,7 @@ project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (106 디렉토리)
+|   +-- skills/                  # 스킬 (108 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -107,6 +107,7 @@ NO EXCEPTIONS. NO EXCUSES.
 | `/memory-save` | Save session context to omx-memory |
 | `/memory-recall` | Search and recall memories |
 | `/omcodex:monitoring-setup` | Enable/disable OTel console monitoring |
+| `/token-efficiency-audit` | Audit and tune token-efficiency settings |
 | `/omcodex:npm-publish` | Publish package to npm registry |
 | `/omcodex:npm-version` | Manage semantic versions |
 | `/omcodex:npm-audit` | Audit dependencies |
@@ -130,7 +131,7 @@ project/
 +-- AGENTS.md                    # Entry point
 +-- .codex/
 |   +-- agents/                  # Subagent definitions (48 files)
-|   +-- skills/                  # Skills (106 directories)
+|   +-- skills/                  # Skills (108 directories)
 |   +-- rules/                   # Global rules (22 files)
 |   +-- hooks/                   # Hook scripts (security, validation, HUD)
 |   +-- contexts/                # Context files (4 files)
@@ -174,7 +175,6 @@ This is the core oh-my-customcodex philosophy: **"No expert? CREATE one, connect
 | QA Team | 3 | qa-planner, qa-writer, qa-engineer |
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, wiki-curator |
-| Auxiliary | 1 | slack-cli-expert |
 | **Total** | **48** | |
 
 ## Agent Teams (MUST when enabled)

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -107,6 +107,7 @@ oh-my-customcodex로 구동됩니다.
 | `/memory-save` | 세션 컨텍스트를 omx-memory에 저장 |
 | `/memory-recall` | 메모리 검색 및 리콜 |
 | `/omcodex:monitoring-setup` | OTel 콘솔 모니터링 활성화/비활성화 |
+| `/token-efficiency-audit` | 토큰 효율 설정 감사 및 조정 |
 | `/omcodex:npm-publish` | npm 레지스트리에 패키지 배포 |
 | `/omcodex:npm-version` | 시맨틱 버전 관리 |
 | `/omcodex:npm-audit` | 의존성 감사 |
@@ -130,7 +131,7 @@ project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (106 디렉토리)
+|   +-- skills/                  # 스킬 (108 디렉토리)
 |   +-- rules/                   # 전역 규칙 (22 파일)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (4 파일)
@@ -174,7 +175,6 @@ project/
 | QA Team | 3 | qa-planner, qa-writer, qa-engineer |
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, wiki-curator |
-| 보조 | 1 | slack-cli-expert |
 | **총계** | **48** | |
 
 ## Agent Teams (MUST when enabled)

--- a/templates/guides/cc-token-saver/README.md
+++ b/templates/guides/cc-token-saver/README.md
@@ -61,6 +61,15 @@ These two components solve different problems and can run simultaneously:
 
 **No conflict** — Token Guardian fires on idle time, R013 fires on context percentage. Both warnings are useful.
 
+## Layer 3 Cross-Reference
+
+`cc-token-saver` is Layer 1 of the token-efficiency stack. For settings-level optimization before the session starts, use `/token-efficiency-audit`.
+
+See also:
+
+- `guides/claude-code/14-token-efficiency.md`
+- `/token-efficiency-audit audit`
+
 ## Usage Scenarios
 
 ### `/continue` — Zero-cost context restore

--- a/templates/guides/claude-code/13-cli-flags.md
+++ b/templates/guides/claude-code/13-cli-flags.md
@@ -149,3 +149,4 @@ claude auto-mode critique    # Review auto mode decisions
 - [Monitoring Guide](10-monitoring.md) — OTel metrics and events
 - [Sub-agents Guide](11-sub-agents.md) — Agent spawning and coordination
 - [Workflow Patterns](12-workflow-patterns.md) — Workflow automation
+- [Token Efficiency Layers](14-token-efficiency.md) — plugin/runtime/settings optimization stack

--- a/templates/guides/claude-code/14-token-efficiency.md
+++ b/templates/guides/claude-code/14-token-efficiency.md
@@ -1,0 +1,73 @@
+# Token Efficiency Layers
+
+Token efficiency in oh-my-customcodex has three layers. They solve different problems and should not be mixed together blindly.
+
+## Layer 1: Plugin-Level Protection
+
+Use `cc-token-saver` when you want cache- and resume-oriented protection:
+
+- Token Guardian for prompt-cache expiry awareness
+- `/continue` for low-cost session resumption
+- usage dashboards and rate-limit reporting
+
+This layer is documented in `guides/cc-token-saver/README.md`.
+
+## Layer 2: Runtime Compression
+
+Use R013 ecomode and existing runtime guards when you want to compress active-session behavior:
+
+- shorter outputs
+- tighter budget awareness
+- safer handling of long-running, batch, or parallel tasks
+
+This layer changes how the session behaves while work is running.
+
+## Layer 3: Settings-Level Optimization
+
+Use `/token-efficiency-audit` when you want configuration-level changes before the session burns tokens.
+
+Typical settings-level levers:
+
+### Claude-side
+
+- `includeGitInstructions`
+- `autoConnectIde`
+- output ceilings such as `BASH_MAX_OUTPUT_LENGTH`
+- file-read / MCP output token caps
+
+### Codex-side
+
+- `features.apps`
+- `web_search`
+- `tool_output_token_limit`
+
+### CI / Worker-only
+
+- disable convenience features that are useful for humans but wasteful in headless runs
+- apply stronger output ceilings than interactive defaults
+
+## Recommended Usage
+
+| Goal | Best layer |
+|------|------------|
+| Protect cache value across pauses | Layer 1 |
+| Compress runtime behavior in large sessions | Layer 2 |
+| Reduce baseline token spend from configuration | Layer 3 |
+
+Use layers together, but keep responsibilities separate:
+
+- plugin layer for cache and resume
+- runtime layer for in-session behavior
+- settings layer for pre-session defaults
+
+## Tradeoffs
+
+| Lever | Benefit | Risk |
+|-------|---------|------|
+| lower output limits | prevents runaway logs | too low causes repeated reruns and extra token spend |
+| disable auto-connect / extra surfaces | less idle context and less noise | may remove convenience features users expect |
+| aggressive CI-only flags | efficient headless execution | can weaken local interactive ergonomics if applied too broadly |
+
+## Rule of Thumb
+
+Start with `audit`, then apply only the smallest reversible setting changes that address your dominant cost source.

--- a/templates/guides/claude-code/index.yaml
+++ b/templates/guides/claude-code/index.yaml
@@ -59,3 +59,8 @@ documents:
     title: CLI 플래그 및 모드
     description: CLI 플래그, 헤드리스 모드, 스케줄링, 환경변수 레퍼런스
     path: ./13-cli-flags.md
+
+  - name: token-efficiency
+    title: 토큰 효율 레이어
+    description: 플러그인, 런타임, 설정 레이어를 분리한 토큰 효율 최적화 가이드
+    path: ./14-token-efficiency.md

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.6",
-  "lastUpdated": "2026-04-19T07:21:00.000Z",
+  "version": "0.1.7",
+  "lastUpdated": "2026-04-19T08:21:30.000Z",
   "components": [
     {
       "name": "rules",
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".codex/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 107
+      "files": 108
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary
- internalize token-efficiency-audit as a package skill for Claude/Codex settings
- add a new token-efficiency layers guide and cross-link it from cc-token-saver and CLI flags docs
- sync command surfaces, counts, manifest metadata, and packaged templates for the new skill

## Verification
- bun run build
- bun run lint
- bun run typecheck
- bun run .github/scripts/validate-docs.ts --programmatic-only
- npm pack --dry-run
- bun test tests/unit/core/template-validation.test.ts tests/unit/core/auto-tag-workflow.test.ts tests/unit/core/release-workflow.test.ts
- bun test tests/unit/core/layout.test.ts
- release CI batch suite

Closes #203