### PR TITLE
release: v0.1.9

### DIFF
--- a/.claude/rules/SHOULD-ecomode.md
+++ b/.claude/rules/SHOULD-ecomode.md
@@ -18,6 +18,8 @@ Auto-activates when: 4+ parallel tasks, batch operations, 80%+ context usage, or
 
 **Compression**: File lists -> count only (unless < 5), error traces -> first/last 3 lines, code -> path:line ref only.
 
+**Pruning Transparency**: When input pruning occurs, include a compact report line such as `[Pruned] {n} files, ~{tokens} tokens saved` so the user can see what was compressed away.
+
 ## Config
 
 ```yaml

--- a/.claude/skills/pre-generation-arch-check/SKILL.md
+++ b/.claude/skills/pre-generation-arch-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pre-generation-arch-check
+description: Check planned code changes for architecture and responsibility violations before implementation
+scope: package
+argument-hint: "<change-request-summary>"
+user-invocable: true
+---
+
+# Pre-Generation Architecture Check
+
+Review a requested change before code generation begins and warn about likely architecture violations.
+
+This skill fills a gap between planning and implementation:
+
+- `adversarial-review` focuses on attacker-minded risk after code exists
+- `deep-verify` focuses on release-quality verification after code exists
+- `pre-generation-arch-check` focuses on architecture hygiene before code is written
+
+## What It Checks
+
+The skill looks for likely violations of:
+
+- R006 separation of concerns
+- compilation metaphor integrity
+- wrong-layer ownership
+- accidental orchestrator responsibility expansion
+- speculative wrappers or abstractions that do not earn their cost
+
+## Inputs
+
+Provide a short request summary, optionally including likely files or modules.
+
+Examples:
+
+```text
+/pre-generation-arch-check add a background sync service to updater.ts
+/pre-generation-arch-check move routing logic into the agent file instead of the routing skill
+```
+
+## Output Contract
+
+### No concern
+
+```text
+[ARCH-CHECK] CLEAR
+
+Request appears consistent with current architecture.
+```
+
+### Warning
+
+```text
+[ARCH-WARNING] Severity: MEDIUM
+Boundary: routing vs agent definition
+Concern: Request would move reusable routing logic into an agent artifact
+Why: Violates compilation metaphor and R006 separation of concerns
+Safer shape: Keep logic in a skill or routing layer; keep agent file declarative
+```
+
+## Heuristics
+
+- warn when a request mixes skill logic with agent artifacts
+- warn when orchestrator responsibilities expand into direct file-writing logic
+- warn when a request introduces a new abstraction without a clear reuse or boundary win
+- warn when a change smells like the wrong layer owns the behavior
+- prefer concise warnings with one safer alternative
+
+## Integration
+
+Use before:
+
+- major refactors
+- new workflow or routing features
+- multi-file cross-layer changes
+
+Good pairings:
+
+- `pre-generation-arch-check` -> `deep-plan`
+- `pre-generation-arch-check` -> `structured-dev-cycle`
+- `pre-generation-arch-check` -> implementation

--- a/.codex/rules/SHOULD-ecomode.md
+++ b/.codex/rules/SHOULD-ecomode.md
@@ -18,6 +18,8 @@ Auto-activates when: 4+ parallel tasks, batch operations, 80%+ context usage, or
 
 **Compression**: File lists -> count only (unless < 5), error traces -> first/last 3 lines, code -> path:line ref only.
 
+**Pruning Transparency**: When input pruning occurs, include a compact report line such as `[Pruned] {n} files, ~{tokens} tokens saved` so the user can see what was compressed away.
+
 ## Config
 
 ```yaml

--- a/.codex/skills/pre-generation-arch-check/SKILL.md
+++ b/.codex/skills/pre-generation-arch-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pre-generation-arch-check
+description: Check planned code changes for architecture and responsibility violations before implementation
+scope: package
+argument-hint: "<change-request-summary>"
+user-invocable: true
+---
+
+# Pre-Generation Architecture Check
+
+Review a requested change before code generation begins and warn about likely architecture violations.
+
+This skill fills a gap between planning and implementation:
+
+- `adversarial-review` focuses on attacker-minded risk after code exists
+- `deep-verify` focuses on release-quality verification after code exists
+- `pre-generation-arch-check` focuses on architecture hygiene before code is written
+
+## What It Checks
+
+The skill looks for likely violations of:
+
+- R006 separation of concerns
+- compilation metaphor integrity
+- wrong-layer ownership
+- accidental orchestrator responsibility expansion
+- speculative wrappers or abstractions that do not earn their cost
+
+## Inputs
+
+Provide a short request summary, optionally including likely files or modules.
+
+Examples:
+
+```text
+/pre-generation-arch-check add a background sync service to updater.ts
+/pre-generation-arch-check move routing logic into the agent file instead of the routing skill
+```
+
+## Output Contract
+
+### No concern
+
+```text
+[ARCH-CHECK] CLEAR
+
+Request appears consistent with current architecture.
+```
+
+### Warning
+
+```text
+[ARCH-WARNING] Severity: MEDIUM
+Boundary: routing vs agent definition
+Concern: Request would move reusable routing logic into an agent artifact
+Why: Violates compilation metaphor and R006 separation of concerns
+Safer shape: Keep logic in a skill or routing layer; keep agent file declarative
+```
+
+## Heuristics
+
+- warn when a request mixes skill logic with agent artifacts
+- warn when orchestrator responsibilities expand into direct file-writing logic
+- warn when a request introduces a new abstraction without a clear reuse or boundary win
+- warn when a change smells like the wrong layer owns the behavior
+- prefer concise warnings with one safer alternative
+
+## Integration
+
+Use before:
+
+- major refactors
+- new workflow or routing features
+- multi-file cross-layer changes
+
+Good pairings:
+
+- `pre-generation-arch-check` -> `deep-plan`
+- `pre-generation-arch-check` -> `structured-dev-cycle`
+- `pre-generation-arch-check` -> implementation

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.1.8",
-  "generatedAt": "2026-04-19T08:33:59.254Z",
-  "templateVersion": "0.1.8",
+  "generatorVersion": "0.1.9",
+  "generatedAt": "2026-04-19T08:53:03.217Z",
+  "templateVersion": "0.1.9",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -40,8 +40,8 @@
       "component": "rules"
     },
     ".codex/rules/SHOULD-ecomode.md": {
-      "templateHash": "eea1abea618f0081f310bd0fc57044e6462c3925ede35552f57d8cece2d95b61",
-      "size": 4656,
+      "templateHash": "718e983cc10af274ca83272620347e894d466c638809965712cf7d788a1afe15",
+      "size": 4839,
       "component": "rules"
     },
     ".codex/rules/MUST-language-policy.md": {
@@ -802,6 +802,11 @@
     ".codex/skills/skills-sh-search/SKILL.md": {
       "templateHash": "ff0c168d5962c0d51bc40ec8fb98e2db7e05c8e6bfa8d5651bb6615945ade8c7",
       "size": 6129,
+      "component": "skills"
+    },
+    ".codex/skills/pre-generation-arch-check/SKILL.md": {
+      "templateHash": "73f0302c824c1d241eefe65d5d56afe34fdaddcbb354c4222936a16d9effeb73",
+      "size": 2300,
       "component": "skills"
     },
     ".codex/skills/omcodex-takeover/SKILL.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-04-19
+
+### Added
+- Add `/pre-generation-arch-check` to catch architecture and responsibility violations before implementation begins.
+- Add wiki and packaged template coverage for the new skill.
+
+### Changed
+- Add pruning transparency guidance to R013 ecomode so compact output can report what was removed.
+
 ## [0.1.8] - 2026-04-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ NO EXCEPTIONS. NO EXCUSES.
 | `/optimize-report` | Generate optimization report |
 | `/research` | 10-team parallel deep analysis and cross-verification |
 | `/deep-plan` | Research-validated planning (research → plan → verify) |
+| `/pre-generation-arch-check` | Check architecture risks before implementation |
 | `/omcodex:sauron-watch` | Full R017 verification |
 | `/structured-dev-cycle` | 6-stage structured development cycle (Plan → Verify → Implement → Verify → Compound → Done) |
 | `/omcodex:lists` | Show all available commands |
@@ -131,7 +132,7 @@ project/
 +-- AGENTS.md                    # Entry point
 +-- .codex/
 |   +-- agents/                  # Subagent definitions (48 files)
-|   +-- skills/                  # Skills (108 directories)
+|   +-- skills/                  # Skills (109 directories)
 |   +-- rules/                   # Global rules (22 files)
 |   +-- hooks/                   # Hook scripts (security, validation, HUD)
 |   +-- contexts/                # Context files (4 files)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-48 agents. 108 skills. 22 rules. One command.
+48 agents. 109 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcodex init
@@ -132,14 +132,14 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (108)
+### Skills (109)
 
 | Category | Count | Includes |
 |----------|-------|----------|
 | Best Practices | 24 | Go, Python, TypeScript, Kotlin, Rust, React, FastAPI, Spring Boot, Django, Flutter, Docker, AWS, Postgres, Redis, Kafka, dbt, Spark, Snowflake, Airflow, pipeline-architecture-patterns, alembic, and more |
 | Routing | 4 | secretary, dev-lead, de-lead, qa-lead |
 | Workflow | 13 | structured-dev-cycle, deep-plan, research, evaluator-optimizer, dag-orchestration, worker-reviewer-pipeline, reasoning-sandwich, pipeline, and more |
-| Development | 9 | dev-review, dev-refactor, analysis, create-agent, intent-detection, web-design-guidelines, omcodex:takeover, skill-extractor, idea |
+| Development | 10 | dev-review, dev-refactor, analysis, create-agent, intent-detection, web-design-guidelines, omcodex:takeover, skill-extractor, pre-generation-arch-check, idea |
 | Operations | 10 | update-docs, audit-agents, sauron-watch, monitoring-setup, token-efficiency-audit, fix-refs, release-notes, and more |
 | Memory | 3 | memory-save, memory-recall, memory-management |
 | Package | 3 | npm-publish, npm-version, npm-audit |
@@ -166,6 +166,7 @@ All commands are invoked inside the oh-my-customcodex GPT Codex + OMX session.
 | `/research` | 10-team parallel analysis with cross-verification |
 | `/sdd-dev` | Spec-Driven Development workflow |
 | `/ambiguity-gate` | Pre-routing ambiguity analysis |
+| `/pre-generation-arch-check` | Check architecture risks before implementation |
 | `/adversarial-review` | Attacker-mindset security code review |
 | `/pipeline` | Execute YAML-defined pipelines |
 | `/pipeline resume` | Resume a halted pipeline from last failure point |

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-48개 에이전트. 108개 스킬. 22개 규칙. 명령어 하나.
+48개 에이전트. 109개 스킬. 22개 규칙. 명령어 하나.
 
 > **v0.1.7** — token-efficiency-audit 스킬, 토큰 효율 3계층 가이드, cc-token-saver/CLI flags cross-reference 추가
 
@@ -147,14 +147,14 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (108개)
+## 스킬 (109개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
 | 베스트 프랙티스 | 24 | Go, Python, TypeScript, Kotlin, Rust, React, FastAPI, Spring Boot, Django, Flutter, Docker, AWS, Postgres, Redis, Kafka, dbt, Spark, Snowflake, Airflow, pipeline-architecture-patterns, alembic 외 |
 | 라우팅 | 4 | secretary, dev-lead, de-lead, qa-lead |
 | 워크플로우 | 13 | structured-dev-cycle, deep-plan, research, evaluator-optimizer, dag-orchestration, worker-reviewer-pipeline, reasoning-sandwich, pipeline 외 |
-| 개발 | 9 | dev-review, dev-refactor, analysis, create-agent, intent-detection, web-design-guidelines, omcodex:takeover, skill-extractor, idea |
+| 개발 | 10 | dev-review, dev-refactor, analysis, create-agent, intent-detection, web-design-guidelines, omcodex:takeover, skill-extractor, pre-generation-arch-check, idea |
 | 운영 | 10 | update-docs, audit-agents, sauron-watch, monitoring-setup, token-efficiency-audit, fix-refs, release-notes 외 |
 | 메모리 | 3 | memory-save, memory-recall, memory-management |
 | 패키지 | 3 | npm-publish, npm-version, npm-audit |
@@ -183,6 +183,7 @@ Agent(arch-documenter):haiku      ┘
 | `/research` | 10-team 병렬 분석 및 교차 검증 |
 | `/sdd-dev` | Spec-Driven Development 워크플로우 |
 | `/ambiguity-gate` | 사전 라우팅 모호성 분석 |
+| `/pre-generation-arch-check` | 구현 전 아키텍처 위험 점검 |
 | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
 | `/pipeline` | YAML 파이프라인 실행 |
 | `/pipeline resume` | 중단된 파이프라인 재개 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/SHOULD-ecomode.md
+++ b/templates/.claude/rules/SHOULD-ecomode.md
@@ -18,6 +18,8 @@ Auto-activates when: 4+ parallel tasks, batch operations, 80%+ context usage, or
 
 **Compression**: File lists -> count only (unless < 5), error traces -> first/last 3 lines, code -> path:line ref only.
 
+**Pruning Transparency**: When input pruning occurs, include a compact report line such as `[Pruned] {n} files, ~{tokens} tokens saved` so the user can see what was compressed away.
+
 ## Config
 
 ```yaml

--- a/templates/.claude/skills/pre-generation-arch-check/SKILL.md
+++ b/templates/.claude/skills/pre-generation-arch-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pre-generation-arch-check
+description: Check planned code changes for architecture and responsibility violations before implementation
+scope: package
+argument-hint: "<change-request-summary>"
+user-invocable: true
+---
+
+# Pre-Generation Architecture Check
+
+Review a requested change before code generation begins and warn about likely architecture violations.
+
+This skill fills a gap between planning and implementation:
+
+- `adversarial-review` focuses on attacker-minded risk after code exists
+- `deep-verify` focuses on release-quality verification after code exists
+- `pre-generation-arch-check` focuses on architecture hygiene before code is written
+
+## What It Checks
+
+The skill looks for likely violations of:
+
+- R006 separation of concerns
+- compilation metaphor integrity
+- wrong-layer ownership
+- accidental orchestrator responsibility expansion
+- speculative wrappers or abstractions that do not earn their cost
+
+## Inputs
+
+Provide a short request summary, optionally including likely files or modules.
+
+Examples:
+
+```text
+/pre-generation-arch-check add a background sync service to updater.ts
+/pre-generation-arch-check move routing logic into the agent file instead of the routing skill
+```
+
+## Output Contract
+
+### No concern
+
+```text
+[ARCH-CHECK] CLEAR
+
+Request appears consistent with current architecture.
+```
+
+### Warning
+
+```text
+[ARCH-WARNING] Severity: MEDIUM
+Boundary: routing vs agent definition
+Concern: Request would move reusable routing logic into an agent artifact
+Why: Violates compilation metaphor and R006 separation of concerns
+Safer shape: Keep logic in a skill or routing layer; keep agent file declarative
+```
+
+## Heuristics
+
+- warn when a request mixes skill logic with agent artifacts
+- warn when orchestrator responsibilities expand into direct file-writing logic
+- warn when a request introduces a new abstraction without a clear reuse or boundary win
+- warn when a change smells like the wrong layer owns the behavior
+- prefer concise warnings with one safer alternative
+
+## Integration
+
+Use before:
+
+- major refactors
+- new workflow or routing features
+- multi-file cross-layer changes
+
+Good pairings:
+
+- `pre-generation-arch-check` -> `deep-plan`
+- `pre-generation-arch-check` -> `structured-dev-cycle`
+- `pre-generation-arch-check` -> implementation

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -104,7 +104,7 @@ oh-my-customcodex로 구동됩니다.
 | 릴리즈 | `/pipeline auto-dev`, `/omcodex-release-notes`, `/release-plan` | 자동 개발, 릴리즈 노트 |
 | 리서치 | `/research`, `/scout`, `/deep-plan`, `/omcodex:agora` | 병렬 분석, URL 평가, 연구 계획 |
 | 메모리 | `/memory-save`, `/memory-recall` | 세션 메모리 관리 |
-| 시스템 | `/token-efficiency-audit`, `/omcodex:lists`, `/omcodex:status`, `/omcodex:help` | 토큰 효율 감사, 전체 목록, 상태, 도움말 |
+| 시스템 | `/token-efficiency-audit`, `/pre-generation-arch-check`, `/omcodex:lists`, `/omcodex:status`, `/omcodex:help` | 토큰 효율/아키텍처 감사, 전체 목록, 상태, 도움말 |
 
 > 전체 커맨드 목록 (60+ 커맨드): `/omcodex:lists` 실행
 
@@ -115,7 +115,7 @@ project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (108 디렉토리)
+|   +-- skills/                  # 스킬 (109 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -118,6 +118,7 @@ NO EXCEPTIONS. NO EXCUSES.
 | `/optimize-report` | Generate optimization report |
 | `/research` | 10-team parallel deep analysis and cross-verification |
 | `/deep-plan` | Research-validated planning (research → plan → verify) |
+| `/pre-generation-arch-check` | Check architecture risks before implementation |
 | `/omcodex:sauron-watch` | Full R017 verification |
 | `/structured-dev-cycle` | 6-stage structured development cycle (Plan → Verify → Implement → Verify → Compound → Done) |
 | `/omcodex:lists` | Show all available commands |
@@ -131,7 +132,7 @@ project/
 +-- AGENTS.md                    # Entry point
 +-- .codex/
 |   +-- agents/                  # Subagent definitions (48 files)
-|   +-- skills/                  # Skills (108 directories)
+|   +-- skills/                  # Skills (109 directories)
 |   +-- rules/                   # Global rules (22 files)
 |   +-- hooks/                   # Hook scripts (security, validation, HUD)
 |   +-- contexts/                # Context files (4 files)

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -118,6 +118,7 @@ oh-my-customcodex로 구동됩니다.
 | `/optimize-report` | 최적화 리포트 생성 |
 | `/research` | 10-team 병렬 딥 분석 및 교차 검증 |
 | `/deep-plan` | 연구 검증 기반 계획 수립 (research → plan → verify) |
+| `/pre-generation-arch-check` | 구현 전 아키텍처 위험 점검 |
 | `/omcodex:sauron-watch` | 전체 R017 검증 |
 | `/structured-dev-cycle` | 6단계 구조적 개발 사이클 (Plan → Verify → Implement → Verify → Compound → Done) |
 | `/omcodex:lists` | 모든 사용 가능한 커맨드 표시 |
@@ -131,7 +132,7 @@ project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (108 디렉토리)
+|   +-- skills/                  # 스킬 (109 디렉토리)
 |   +-- rules/                   # 전역 규칙 (22 파일)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (4 파일)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.8",
-  "lastUpdated": "2026-04-19T08:34:00.000Z",
+  "version": "0.1.9",
+  "lastUpdated": "2026-04-19T08:50:00.000Z",
   "components": [
     {
       "name": "rules",
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".codex/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 108
+      "files": 109
     },
     {
       "name": "guides",

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-04-19"
-  total_pages: 242
+  total_pages: 243
   total_sources: 212
 
 pages:
@@ -315,6 +315,9 @@ pages:
     - file: skills/monitoring-setup.md
       title: "Monitoring Setup"
       summary: "Enable/disable OpenTelemetry console monitoring for Claude Code usage tracking."
+    - file: skills/pre-generation-arch-check.md
+      title: "Pre-Generation Architecture Check"
+      summary: "Check planned code changes for architecture and responsibility violations before implementation."
     - file: skills/token-efficiency-audit.md
       title: "Token Efficiency Audit"
       summary: "Audit and tune Claude/Codex settings for lower token usage without changing code."

--- a/wiki/skills/pre-generation-arch-check.md
+++ b/wiki/skills/pre-generation-arch-check.md
@@ -1,0 +1,37 @@
+---
+title: Pre-Generation Architecture Check
+type: skill
+updated: 2026-04-19
+sources:
+  - .codex/skills/pre-generation-arch-check/SKILL.md
+related:
+  - [[adversarial-review]]
+  - [[deep-verify]]
+  - [[structured-dev-cycle]]
+---
+
+# Pre-Generation Architecture Check
+
+Check a planned code change for architecture and responsibility violations before implementation starts.
+
+## Overview
+
+This skill acts like a pre-generation architecture lint pass. It examines a requested change and flags likely violations of R006 separation of concerns, compilation-metaphor boundaries, wrong-layer ownership, or speculative abstractions before code is written. It complements post-generation checks such as `adversarial-review` and `deep-verify`.
+
+## Key Details
+
+- **Scope**: package
+- **User-invocable**: yes
+- **Command**: `/pre-generation-arch-check`
+- **Effort**: not specified
+- **Argument hint**: `<change-request-summary>`
+
+## Relationships
+
+- **Used by agents**: orchestrator
+- **Related skills**: [[adversarial-review]], [[deep-verify]], [[structured-dev-cycle]]
+- **See also**: `R006`
+
+## Sources
+
+- `.codex/skills/pre-generation-arch-check/SKILL.md` — skill definition


### PR DESCRIPTION
## Summary
- add `/pre-generation-arch-check` as a reusable pre-generation architecture lint skill
- add DCP-inspired pruning transparency guidance to R013 ecomode
- add matching wiki/template artifacts and sync release metadata to 0.1.9

## Verification
- bun run build
- bun run lint
- bun run typecheck
- bun run .github/scripts/validate-docs.ts --programmatic-only
- bun test tests/unit/core/template-validation.test.ts tests/unit/core/auto-tag-workflow.test.ts tests/unit/core/release-workflow.test.ts tests/unit/core/layout.test.ts
- release CI batch suite

Closes #287