### PR TITLE
release: v0.2.1 version sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lastUpdated": "2026-04-19T08:50:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- bump `package.json` to `0.2.1`
- bump `templates/manifest.json` to `0.2.1`
- unblock the post-merge auto-tag flow so `v0.2.1` can be created from truthful version metadata

## Verification
- `bun run build`

## Context
- The main `v0.2.1` release batch already merged in PR #859.
- `Auto Tag on Release Merge` skipped tag creation because the repo version metadata still said `0.2.0`.

Related: #859