### PR TITLE
Release v0.3.9

### DIFF
--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.3.8",
-  "generatedAt": "2026-04-24T07:21:24.573Z",
-  "templateVersion": "0.3.8",
+  "generatorVersion": "0.3.9",
+  "generatedAt": "2026-04-24T08:46:02.206Z",
+  "templateVersion": "0.3.9",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-04-24
+
+### Fixed
+- Update the macOS Codex installer path to use the current Homebrew cask.
+- Remove stale Bash output-directory pre-creation guidance from Codex skills/rules, templates, and docs, with regression coverage to keep it from returning.
+- Stabilize serve and doctor tests so release verification can complete reliably.
+
 ## [0.3.8] - 2026-04-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.3.8",
-  "lastUpdated": "2026-04-22T05:10:00.000Z",
+  "version": "0.3.9",
+  "lastUpdated": "2026-04-24T08:45:48.000Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary
- Bump oh-my-customcodex to 0.3.9
- Add changelog notes for the auto-dev issue cleanup
- Refresh template manifest and source lockfile versions

## Verification
- bun run build
- bun run test: 1738 pass / 0 fail
- bun run lint
- bun run typecheck
- npm pack --dry-run
- bun run .github/scripts/validate-docs.ts --programmatic-only

## Release Notes
This release publishes the fixes for the Codex installer cask command, stale output-directory mkdir guidance, and release verification test stability.