### PR TITLE
Release v0.3.10

### DIFF
--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.3.9",
-  "generatedAt": "2026-04-24T09:08:11.082Z",
-  "templateVersion": "0.3.9",
+  "generatorVersion": "0.3.10",
+  "generatedAt": "2026-04-24T09:10:58.909Z",
+  "templateVersion": "0.3.10",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-04-24
+
+### Fixed
+- Extend R006 sensitive-path guidance and hook guarding to cover Write/Edit targeting `.claude/**` and `templates/.claude/**`, with source/template/wiki regression coverage for #902.
+
 ## [0.3.9] - 2026-04-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.3.9",
-  "lastUpdated": "2026-04-24T08:45:48.000Z",
+  "version": "0.3.10",
+  "lastUpdated": "2026-04-24T09:10:47.000Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary
- Release oh-my-customcodex v0.3.10.
- Ships #902: R006 and hook guard coverage for Write/Edit targeting .claude/** and templates/.claude/**.
- Publishes updated package/template manifest metadata and changelog.

## Verification
- bun run build
- bun run test (1745 pass, 0 fail)
- bun run lint
- bun run typecheck
- bun run .github/scripts/validate-docs.ts --programmatic-only
- npm pack --dry-run
- architect verification PASS

Closes #902