### PR TITLE
feat: internalize upstream eval and onboarding guidance

### DIFF
--- a/.codex/agents/mgr-creator.md
+++ b/.codex/agents/mgr-creator.md
@@ -7,6 +7,7 @@ memory: project
 effort: high
 skills:
   - create-agent
+  - agent-eval-framework
 tools:
   - Read
   - Write
@@ -35,6 +36,16 @@ Frontmatter (name, description, model, tools, skills, memory) + body (purpose, c
 ### Phase 3: Auto-discovery
 
 No registry update needed - agents auto-discovered from `.claude/agents/*.md`.
+
+### Phase 4: Optional Quantitative Gate
+
+For high-risk or reusable agents, use `agent-eval-framework` after creation:
+
+1. Define an ideal trajectory for the agent's first representative task.
+2. Run correctness checks before measuring efficiency.
+3. Record `step_ratio`, `tool_call_ratio`, and `latency_ratio` as advisory evidence.
+
+Do not force this gate for every small helper agent. It is opt-in when the extra cost is justified by reuse, safety, or routing criticality.
 
 ## Rules Applied
 

--- a/.codex/rules/MUST-agent-design.md
+++ b/.codex/rules/MUST-agent-design.md
@@ -254,6 +254,7 @@ Recommended practice:
 2. Keep allow rules only as defensive documentation; do not rely on them to suppress sensitive-path prompts.
 3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
 4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
+5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
 
 ## Separation of Concerns
 

--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -21,6 +21,19 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.
 
+## Optional: Quantitative Evidence
+
+For agent, skill, or workflow changes, completion evidence MAY include `agent-eval-framework` metrics:
+
+| Metric | Meaning | Gate |
+|--------|---------|------|
+| `correctness` | Acceptance criteria satisfied | Required if included |
+| `step_ratio` | Observed steps vs. ideal steps | Advisory |
+| `tool_call_ratio` | Observed tool calls vs. ideal tool calls | Advisory |
+| `latency_ratio` | Observed duration vs. ideal duration | Advisory |
+
+These metrics strengthen a `[Done]` claim but do not replace task-specific verification. A failed correctness score blocks completion even if efficiency ratios are good.
+
 <!-- DETAIL: Self-Check box
 1. Did I verify ACTUAL outcome? "I ran the command" ≠ "the command succeeded" → YES: Continue / NO: Verify first
 2. Does task type have specific criteria? YES: Check each / NO: Apply general verification

--- a/.codex/rules/SHOULD-interaction.md
+++ b/.codex/rules/SHOULD-interaction.md
@@ -35,6 +35,8 @@
 
 ## Output Styles
 
+Session-level style enforcement belongs in runtime output-style mechanisms when the host supports them. In this Codex port, R003 remains the portable source of style-selection rules; packaged Claude compatibility may additionally provide `.claude/output-styles/` presets that reinforce the same constraints.
+
 | Style | Trigger | Behavior |
 |-------|---------|----------|
 | `concise` | effort: low, batch operations | Key result only, no preamble, no elaboration |

--- a/.codex/skills/agent-eval-framework/SKILL.md
+++ b/.codex/skills/agent-eval-framework/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agent-eval-framework
+description: Quantitative agent evaluation using correctness, step ratio, tool-call ratio, and latency ratio
+scope: harness
+user-invocable: true
+argument-hint: "<trace-or-task> [--ideal <path>] [--format markdown|json]"
+effort: high
+version: 1.0.0
+---
+
+# Agent Eval Framework
+
+## Purpose
+
+Evaluate agent runs with a two-phase quantitative gate:
+
+1. **Correctness first**: the task must meet its stated acceptance criteria.
+2. **Efficiency second**: only correctness-passing runs are compared by step, tool-call, and latency ratios.
+
+This keeps eval pressure useful. A faster run that fails the task is not a better run.
+
+## Metric Framework
+
+| Metric | Formula | Pass Signal |
+|--------|---------|-------------|
+| `correctness` | `passed_criteria / total_criteria` | `1.0` for release-quality evidence |
+| `step_ratio` | `observed_steps / ideal_steps` | `<= 1.25` preferred |
+| `tool_call_ratio` | `observed_tool_calls / ideal_tool_calls` | `<= 1.25` preferred |
+| `latency_ratio` | `observed_ms / ideal_ms` | `<= 1.50` preferred |
+
+Use ratios as advisory evidence unless a task explicitly opts into a stricter gate.
+
+## Ideal Trajectory Schema
+
+```yaml
+task: "short task name"
+capability: "file_operations | retrieval | tool_use | memory | conversation | summarization"
+ideal:
+  steps: 4
+  tool_calls: 5
+  latency_ms: 120000
+acceptance_criteria:
+  - "Criterion one"
+  - "Criterion two"
+notes: "Why this ideal path is reasonable"
+```
+
+## Capability Taxonomy
+
+| Capability | Typical Evidence |
+|------------|------------------|
+| `file_operations` | precise diffs, no unrelated churn, verification after writes |
+| `retrieval` | targeted `rg`/file reads, source references, low duplicate search |
+| `tool_use` | appropriate tool choice, no unnecessary escalation |
+| `memory` | relevant memory used and cited, stale facts re-verified when needed |
+| `conversation` | clear routing, no repeated clarification for known constraints |
+| `summarization` | faithful compression, preserved blockers and evidence |
+
+## Workflow
+
+1. Define or load an ideal trajectory for the task.
+2. Collect observed run data from trace, transcript, hook output, or manual evidence.
+3. Score correctness against acceptance criteria.
+4. If correctness fails, stop and report failed criteria.
+5. If correctness passes, compute efficiency ratios.
+6. Attach the metric table to the completion evidence or improvement report.
+
+## Output Format
+
+```markdown
+## Agent Eval Result
+
+| Metric | Observed | Ideal | Ratio | Verdict |
+|--------|----------|-------|-------|---------|
+| correctness | 4/4 | 4/4 | 1.00 | pass |
+| steps | 5 | 4 | 1.25 | pass |
+| tool calls | 7 | 5 | 1.40 | advisory |
+| latency | 150s | 120s | 1.25 | pass |
+
+Decision: correctness-pass, efficiency-advisory
+```
+
+## Integration Points
+
+- `harness-eval`: use this framework to add trajectory efficiency evidence to benchmark runs.
+- `evaluator-optimizer`: run correctness before efficiency comparisons.
+- `mgr-creator`: opt in for high-risk new agents where quantitative validation is worth the extra cost.
+- `omcustomcodex:improve-report`: include repeated ratio regressions as improvement suggestions.
+
+## Attribution
+
+Adapted from LangChain Deep Agents eval methodology: correctness-first scoring, ideal trajectory annotation, and efficiency ratios for step, tool-call, and latency comparison.

--- a/.codex/skills/agora/SKILL.md
+++ b/.codex/skills/agora/SKILL.md
@@ -43,6 +43,17 @@ source:
 Spawn 3 reviewers as Agent Team members:
 
 ```
+
+### Anti-Groupthink Mode
+
+Use `--anti-groupthink` when consensus itself is a risk:
+
+1. Reviewers submit independent findings before seeing peer output.
+2. One reviewer is assigned as devil's advocate.
+3. Minority findings are preserved unless the synthesis explicitly rejects them with evidence.
+4. Debate is capped at two challenge rounds before the lead either decides or requests more facts.
+
+For decisions where dissent preservation is the main goal, use `roundtable-debate` directly instead of `agora`.
 Agent(name: "claude-critic", model: opus, effort: max)
   → 20-point deep adversarial review
   

--- a/.codex/skills/codex-exec/SKILL.md
+++ b/.codex/skills/codex-exec/SKILL.md
@@ -204,3 +204,15 @@ When routing skills detect a code generation task and codex is available:
 ```
 /codex-exec "Generate {description} following {framework} best practices" --effort high --full-auto
 ```
+
+## Browser Verify Workflow
+
+For frontend or browser-visible changes, use a Build + Vision + Verify loop instead of stopping at a successful build:
+
+1. Build or start the local dev server.
+2. Open the target in the available browser automation surface.
+3. Capture screenshot evidence and console/network errors.
+4. If the visual state or console is wrong, run `codex-exec` with the concrete evidence and repeat.
+5. Stop only when build, browser render, and error checks all pass.
+
+This pattern composes with the Codex App Browser Use plugin or any local browser MCP. Keep the loop evidence-driven: screenshot, console output, network status, and the exact command that produced the build.

--- a/.codex/skills/evaluator-optimizer/SKILL.md
+++ b/.codex/skills/evaluator-optimizer/SKILL.md
@@ -104,6 +104,26 @@ When `conditional.enabled: true` and ANY `skip_when` condition is met, the evalu
 | Complex architecture, security-critical | High | Run with pre-negotiation |
 | Previously failed task retry | Any | Always run |
 
+### Quantitative Efficiency Metrics
+
+When a task provides an ideal trajectory, the evaluator MAY attach `agent-eval-framework` metrics after the normal quality gate:
+
+```yaml
+evaluator-optimizer:
+  quantitative_metrics:
+    enabled: true
+    ideal:
+      steps: 4
+      tool_calls: 5
+      latency_ms: 120000
+    advisory_thresholds:
+      step_ratio: 1.25
+      tool_call_ratio: 1.25
+      latency_ratio: 1.50
+```
+
+Correctness remains the primary gate. Efficiency ratios are used to compare correctness-passing candidates or to create follow-up improvement suggestions.
+
 ### Parameter Details
 
 | Parameter | Required | Default | Description |

--- a/.codex/skills/harness-eval/SKILL.md
+++ b/.codex/skills/harness-eval/SKILL.md
@@ -86,6 +86,19 @@ This skill provides preset rubrics for the evaluator-optimizer pipeline:
 
 The evaluator-optimizer skill's `pre_negotiation` phase accepts harness-eval rubric dimensions as sprint contract criteria.
 
+## Optional 4-Metric Trajectory Evidence
+
+For agent or skill benchmarks, enrich the 0-100 quality score with the `agent-eval-framework` metrics:
+
+| Metric | Source | Use |
+|--------|--------|-----|
+| `correctness` | benchmark assertions and acceptance criteria | Required before efficiency is considered |
+| `step_ratio` | observed steps vs. ideal trajectory | Advisory signal for unnecessary loops |
+| `tool_call_ratio` | observed tool calls vs. ideal trajectory | Advisory signal for noisy tool use |
+| `latency_ratio` | observed duration vs. ideal trajectory | Advisory signal for runtime regression |
+
+Evaluation order is fixed: correctness first, efficiency second. A benchmark run with failed correctness cannot be rescued by strong efficiency ratios.
+
 ## Output
 
 Results saved to `.codex/outputs/sessions/{YYYY-MM-DD}/harness-eval-{HHmmss}.md` with per-task scores and aggregate grade.

--- a/.codex/skills/roundtable-debate/SKILL.md
+++ b/.codex/skills/roundtable-debate/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: roundtable-debate
+description: Structured multi-agent debate that preserves dissent with a mandatory devil's advocate and two-round cap
+scope: core
+user-invocable: true
+argument-hint: "<topic-or-document> [--rounds 1|2] [--decision required|advisory]"
+effort: high
+version: 1.0.0
+---
+
+# Roundtable Debate
+
+## Purpose
+
+Run a bounded debate when convergence would hide useful disagreement. Unlike `agora`, which drives toward consensus, this workflow preserves minority positions and requires explicit justification before dismissing them.
+
+## When To Use
+
+- Architecture or product choices with multiple defensible paths.
+- Review work where anchoring or groupthink is likely.
+- Decisions where a minority risk could be more important than the majority preference.
+
+## Workflow
+
+1. **Independent-first analysis**: spawn 3-5 reviewers in parallel. Do not share intermediate opinions before each reviewer submits an initial view.
+2. **Mandatory devil's advocate**: one reviewer argues against the emerging default, even if they personally agree with it.
+3. **Round 1 synthesis**: group findings into majority positions, minority positions, and unresolved facts.
+4. **Round 2 challenge**: reviewers respond only to disputed claims and missing evidence.
+5. **Decision record**: keep the final recommendation and any protected dissent.
+
+Hard cap: two debate rounds. If the decision still depends on missing facts, stop and gather evidence instead of debating longer.
+
+## Output
+
+```markdown
+# Roundtable Debate Result
+
+## Topic
+{topic}
+
+## Majority Recommendation
+{recommendation}
+
+## Protected Dissent
+| Position | Advocate | Why It Was Not Dismissed |
+|----------|----------|--------------------------|
+| {position} | devil's advocate | {evidence or risk} |
+
+## Decision
+{adopt | defer | reject | gather-more-evidence}
+```
+
+## Relationship To Agora
+
+| Workflow | Goal | Best For |
+|----------|------|----------|
+| `agora` | adversarial consensus | release gates, spec approval |
+| `roundtable-debate` | dissent preservation | ambiguous strategy, architectural tradeoffs |
+
+Use `agora --anti-groupthink` when you need consensus plus explicit dissent handling.

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,12 +1,12 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.0",
-  "generatedAt": "2026-04-24T14:39:46.453Z",
-  "templateVersion": "0.4.0",
+  "generatorVersion": "0.4.1",
+  "generatedAt": "2026-04-27T01:04:57.205Z",
+  "templateVersion": "0.4.1",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
-      "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
-      "size": 2487,
+      "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
+      "size": 2796,
       "component": "rules"
     },
     ".codex/rules/SHOULD-hud-statusline.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-design.md": {
-      "templateHash": "1b716673f6fc603c71aff5a1bb9d55cec44b9bd032812b8f3bb8978fb369c7e3",
-      "size": 21766,
+      "templateHash": "6bcadf1f1a2dd2132fe6d235910e6b1203d11735af86c49289f3eb3b72c15b99",
+      "size": 21995,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "71711d39a564088c713103019f1e2b4e1e3bd373b2ab922290666a5c5436a201",
-      "size": 5547,
+      "templateHash": "9aae499cf32ad1f2e2e532702e93949eb0048f7fc4de521a3225abf91ab1f65f",
+      "size": 6195,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {
@@ -295,8 +295,8 @@
       "component": "agents"
     },
     ".codex/agents/mgr-creator.md": {
-      "templateHash": "83a8f31defc229bd86ed4ec4f0e7c7a92abefdb789cadf3f779f2fe06335a346",
-      "size": 1800,
+      "templateHash": "00dcee0e4e8b4bf64d43140909164f3369caa030e4b295cef22f09d4beaf893a",
+      "size": 2300,
       "component": "agents"
     },
     ".codex/agents/qa-writer.md": {
@@ -709,6 +709,16 @@
       "size": 651,
       "component": "guides"
     },
+    "guides/agent-eval/README.md": {
+      "templateHash": "601aad7506dd76bc207482f89a54ad1fb119fd8702f6959dc10f416460740086",
+      "size": 1585,
+      "component": "guides"
+    },
+    "guides/agent-eval/index.yaml": {
+      "templateHash": "6dfad9a2ca7f5ed8a8b62b9a8077a2d7006c0a32534fdaded6797adc08faf6e1",
+      "size": 147,
+      "component": "guides"
+    },
     "guides/web-design/accessibility.md": {
       "templateHash": "92cc51f7d89cef28ce632c4fe07ff8335b14f6007fa4bead31e5cb7a59dfd001",
       "size": 1181,
@@ -1030,8 +1040,8 @@
       "component": "guides"
     },
     "guides/browser-automation/README.md": {
-      "templateHash": "c51465e8fdf79a2fedf2803138e13bb6531edefafe280ae6612a639e31cbdfc0",
-      "size": 3779,
+      "templateHash": "665d7b72e1f6469fa46d70edf1f6d6baccae06367c6c7d4b592d44652d7c2195",
+      "size": 4343,
       "component": "guides"
     },
     "guides/browser-automation/index.yaml": {
@@ -1039,9 +1049,19 @@
       "size": 392,
       "component": "guides"
     },
+    "guides/multi-agent-debate-patterns/README.md": {
+      "templateHash": "08b86f425d7417d9f5e1a90f0198078b243033122940623d0a56a8eb124edf23",
+      "size": 1015,
+      "component": "guides"
+    },
+    "guides/multi-agent-debate-patterns/index.yaml": {
+      "templateHash": "f71bd7dc36a3ad03fe44db13ac293c4713626d733676f76c0d34a7757ab9cdaa",
+      "size": 167,
+      "component": "guides"
+    },
     "guides/index.yaml": {
-      "templateHash": "902f0a11505ce991cc2f5f420b76cd8c7078809f76dd8586a44f605a72090e4e",
-      "size": 7631,
+      "templateHash": "fd59433e66632a832bdf4ceaa387e561b0f9b91802b21a1683a7b39ecb997b36",
+      "size": 8002,
       "component": "guides"
     },
     "guides/spark/README.md": {

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (112)
+### Skills (114)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -227,7 +227,7 @@ Key rules: R010 (orchestrator never writes files), R009 (parallel execution mand
 
 ---
 
-### Guides (40)
+### Guides (42)
 
 Reference documentation covering best practices, architecture decisions, and integration patterns. Located in `guides/` at project root, covering topics from agent design to CI/CD to observability.
 

--- a/guides/agent-eval/README.md
+++ b/guides/agent-eval/README.md
@@ -1,0 +1,48 @@
+# Agent Eval Guide
+
+## Evaluation Order
+
+Agent evaluation uses two phases:
+
+1. **Correctness gate**: verify the task outcome against explicit acceptance criteria.
+2. **Efficiency review**: compare only correctness-passing runs against an ideal trajectory.
+
+Do not optimize step count or latency before correctness is proven.
+
+## Four Metrics
+
+| Metric | Definition | Typical Use |
+|--------|------------|-------------|
+| `correctness` | Passed criteria divided by total criteria | Release or completion gate |
+| `step_ratio` | Observed steps divided by ideal steps | Detect avoidable loops |
+| `tool_call_ratio` | Observed tool calls divided by ideal tool calls | Detect noisy retrieval or tool misuse |
+| `latency_ratio` | Observed duration divided by ideal duration | Detect runtime regressions |
+
+## Ideal Trajectory
+
+```yaml
+task: "create a small routing skill"
+capability: "tool_use"
+ideal:
+  steps: 5
+  tool_calls: 8
+  latency_ms: 180000
+acceptance_criteria:
+  - "Skill frontmatter is valid"
+  - "Routing docs reference the skill"
+  - "Tests or static checks pass"
+```
+
+## Interpreting Ratios
+
+- `1.00`: observed matched the ideal.
+- `< 1.00`: faster or shorter than ideal; verify no evidence was skipped.
+- `1.00-1.25`: usually acceptable.
+- `> 1.25`: advisory improvement candidate.
+- correctness below `1.00`: fail regardless of efficiency.
+
+## Integration
+
+- Use `agent-eval-framework` for task-level scoring.
+- Use `harness-eval` when running repeatable benchmark suites.
+- Use `omcustomcodex:improve-report` to turn repeated ratio regressions into improvement suggestions.

--- a/guides/agent-eval/index.yaml
+++ b/guides/agent-eval/index.yaml
@@ -1,0 +1,6 @@
+name: agent-eval
+description: Quantitative agent evaluation with correctness-first 4-metric evidence
+source:
+  type: internal
+files:
+  - README.md

--- a/guides/browser-automation/README.md
+++ b/guides/browser-automation/README.md
@@ -75,6 +75,18 @@ Capture at least one of:
 
 When summarizing evidence for the model, preserve reference tokens and URLs so follow-up steps can still target the right page elements.
 
+## Build + Vision + Verify Loop
+
+For browser-visible changes, treat a successful build as the start of verification, not the end:
+
+1. Build or start the local app.
+2. Open the page in the available browser surface.
+3. Capture screenshot, console, and network evidence.
+4. Feed concrete failures back to the implementation agent.
+5. Repeat until build, render, and runtime evidence all pass.
+
+This is the Codex Browser Use pattern in portable form. Prefer the in-app Browser Use plugin when available; otherwise use Playwright or the existing browser MCP surface.
+
 ## Design And Strategy Workflows
 
 ### Product strategy sessions

--- a/guides/index.yaml
+++ b/guides/index.yaml
@@ -46,6 +46,18 @@ guides:
     source:
       type: internal
 
+  - name: agent-eval
+    description: Quantitative agent evaluation with correctness-first 4-metric evidence
+    path: ./agent-eval/
+    source:
+      type: internal
+
+  - name: multi-agent-debate-patterns
+    description: Anti-groupthink debate patterns for Agora and roundtable-debate workflows
+    path: ./multi-agent-debate-patterns/
+    source:
+      type: internal
+
   # Languages
   - name: golang
     description: Go language reference from Effective Go

--- a/guides/multi-agent-debate-patterns/README.md
+++ b/guides/multi-agent-debate-patterns/README.md
@@ -1,0 +1,26 @@
+# Multi-Agent Debate Patterns
+
+## Pattern Choice
+
+| Pattern | Goal | Use When |
+|---------|------|----------|
+| `agora` | Reach adversarial consensus | Release gates, design approval, high-risk specs |
+| `roundtable-debate` | Preserve dissent | Strategy choices, tradeoffs, ambiguous product or architecture decisions |
+
+## Failure Modes
+
+- **Anchoring**: later reviewers inherit the first opinion.
+- **Groupthink**: reviewers converge because convergence looks productive.
+- **Degeneration of thought**: debate continues without adding new evidence.
+
+## Controls
+
+1. Start with independent parallel analysis.
+2. Assign a devil's advocate.
+3. Protect minority findings unless explicitly rejected with evidence.
+4. Cap debate at two rounds.
+5. Switch from debate to evidence gathering when facts are missing.
+
+## Decision Record
+
+Keep the final recommendation, rejected alternatives, and protected dissent together. Future agents should be able to see not only what was chosen, but which minority risk remains live.

--- a/guides/multi-agent-debate-patterns/index.yaml
+++ b/guides/multi-agent-debate-patterns/index.yaml
@@ -1,0 +1,6 @@
+name: multi-agent-debate-patterns
+description: Anti-groupthink debate patterns for Agora and roundtable-debate workflows
+source:
+  type: internal
+files:
+  - README.md

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -228,14 +228,7 @@ export async function initCommand(options: InitOptions): Promise<InitResult> {
     }
 
     console.log('');
-    console.log('Required plugins (install manually):');
-    console.log('  /plugin marketplace add obra/superpowers-marketplace');
-    console.log('  /plugin install superpowers');
-    console.log('  /plugin install openai-docs');
-    console.log('  /plugin install elements-of-style');
-    console.log('  /plugin install context7');
-    console.log('');
-    console.log('See AGENTS.md "외부 의존성" section for details.');
+    console.log('Codex setup complete. See AGENTS.md for Codex-native MCP and runtime guidance.');
 
     return {
       success: true,

--- a/templates/.claude/agents/mgr-creator.md
+++ b/templates/.claude/agents/mgr-creator.md
@@ -7,6 +7,7 @@ memory: project
 effort: high
 skills:
   - create-agent
+  - agent-eval-framework
 tools:
   - Read
   - Write
@@ -35,6 +36,16 @@ Frontmatter (name, description, model, tools, skills, memory) + body (purpose, c
 ### Phase 3: Auto-discovery
 
 No registry update needed - agents auto-discovered from `.claude/agents/*.md`.
+
+### Phase 4: Optional Quantitative Gate
+
+For high-risk or reusable agents, use `agent-eval-framework` after creation:
+
+1. Define an ideal trajectory for the agent's first representative task.
+2. Run correctness checks before measuring efficiency.
+3. Record `step_ratio`, `tool_call_ratio`, and `latency_ratio` as advisory evidence.
+
+Do not force this gate for every small helper agent. It is opt-in when the extra cost is justified by reuse, safety, or routing criticality.
 
 ## Rules Applied
 

--- a/templates/.claude/output-styles/korean-engineer.md
+++ b/templates/.claude/output-styles/korean-engineer.md
@@ -1,0 +1,24 @@
+---
+name: korean-engineer
+description: Korean-first engineering responses with agent identity and evidence-focused completion
+keep-coding-instructions: true
+---
+
+# Korean Engineer Output Style
+
+Use Korean for user-facing communication unless the user explicitly asks otherwise. Keep code, file contents, identifiers, and commit trailers in English when that is the repository convention.
+
+Every response starts with the agent identity block required by the project guidance:
+
+```text
+┌─ Agent: {agent-name} / {model}
+│ Skill: {active-skill-or-none}
+└─ Status: {current action or result}
+```
+
+Prefer concise, evidence-focused engineering reports:
+
+- State the current action or outcome first.
+- Cite concrete verification evidence before declaring completion.
+- Do not claim release, deploy, or publish completion until the external surface has been checked.
+- Keep uncertainty explicit and tied to the missing evidence.

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -254,6 +254,7 @@ Recommended practice:
 2. Keep allow rules only as defensive documentation; do not rely on them to suppress sensitive-path prompts.
 3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
 4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
+5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
 
 ## Separation of Concerns
 

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -21,6 +21,19 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.
 
+## Optional: Quantitative Evidence
+
+For agent, skill, or workflow changes, completion evidence MAY include `agent-eval-framework` metrics:
+
+| Metric | Meaning | Gate |
+|--------|---------|------|
+| `correctness` | Acceptance criteria satisfied | Required if included |
+| `step_ratio` | Observed steps vs. ideal steps | Advisory |
+| `tool_call_ratio` | Observed tool calls vs. ideal tool calls | Advisory |
+| `latency_ratio` | Observed duration vs. ideal duration | Advisory |
+
+These metrics strengthen a `[Done]` claim but do not replace task-specific verification. A failed correctness score blocks completion even if efficiency ratios are good.
+
 <!-- DETAIL: Self-Check box
 1. Did I verify ACTUAL outcome? "I ran the command" ≠ "the command succeeded" → YES: Continue / NO: Verify first
 2. Does task type have specific criteria? YES: Check each / NO: Apply general verification

--- a/templates/.claude/rules/SHOULD-interaction.md
+++ b/templates/.claude/rules/SHOULD-interaction.md
@@ -35,6 +35,8 @@
 
 ## Output Styles
 
+Session-level style enforcement belongs in runtime output-style mechanisms when the host supports them. In this Codex port, R003 remains the portable source of style-selection rules; packaged Claude compatibility may additionally provide `.claude/output-styles/` presets that reinforce the same constraints.
+
 | Style | Trigger | Behavior |
 |-------|---------|----------|
 | `concise` | effort: low, batch operations | Key result only, no preamble, no elaboration |

--- a/templates/.claude/skills/agent-eval-framework/SKILL.md
+++ b/templates/.claude/skills/agent-eval-framework/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agent-eval-framework
+description: Quantitative agent evaluation using correctness, step ratio, tool-call ratio, and latency ratio
+scope: harness
+user-invocable: true
+argument-hint: "<trace-or-task> [--ideal <path>] [--format markdown|json]"
+effort: high
+version: 1.0.0
+---
+
+# Agent Eval Framework
+
+## Purpose
+
+Evaluate agent runs with a two-phase quantitative gate:
+
+1. **Correctness first**: the task must meet its stated acceptance criteria.
+2. **Efficiency second**: only correctness-passing runs are compared by step, tool-call, and latency ratios.
+
+This keeps eval pressure useful. A faster run that fails the task is not a better run.
+
+## Metric Framework
+
+| Metric | Formula | Pass Signal |
+|--------|---------|-------------|
+| `correctness` | `passed_criteria / total_criteria` | `1.0` for release-quality evidence |
+| `step_ratio` | `observed_steps / ideal_steps` | `<= 1.25` preferred |
+| `tool_call_ratio` | `observed_tool_calls / ideal_tool_calls` | `<= 1.25` preferred |
+| `latency_ratio` | `observed_ms / ideal_ms` | `<= 1.50` preferred |
+
+Use ratios as advisory evidence unless a task explicitly opts into a stricter gate.
+
+## Ideal Trajectory Schema
+
+```yaml
+task: "short task name"
+capability: "file_operations | retrieval | tool_use | memory | conversation | summarization"
+ideal:
+  steps: 4
+  tool_calls: 5
+  latency_ms: 120000
+acceptance_criteria:
+  - "Criterion one"
+  - "Criterion two"
+notes: "Why this ideal path is reasonable"
+```
+
+## Capability Taxonomy
+
+| Capability | Typical Evidence |
+|------------|------------------|
+| `file_operations` | precise diffs, no unrelated churn, verification after writes |
+| `retrieval` | targeted `rg`/file reads, source references, low duplicate search |
+| `tool_use` | appropriate tool choice, no unnecessary escalation |
+| `memory` | relevant memory used and cited, stale facts re-verified when needed |
+| `conversation` | clear routing, no repeated clarification for known constraints |
+| `summarization` | faithful compression, preserved blockers and evidence |
+
+## Workflow
+
+1. Define or load an ideal trajectory for the task.
+2. Collect observed run data from trace, transcript, hook output, or manual evidence.
+3. Score correctness against acceptance criteria.
+4. If correctness fails, stop and report failed criteria.
+5. If correctness passes, compute efficiency ratios.
+6. Attach the metric table to the completion evidence or improvement report.
+
+## Output Format
+
+```markdown
+## Agent Eval Result
+
+| Metric | Observed | Ideal | Ratio | Verdict |
+|--------|----------|-------|-------|---------|
+| correctness | 4/4 | 4/4 | 1.00 | pass |
+| steps | 5 | 4 | 1.25 | pass |
+| tool calls | 7 | 5 | 1.40 | advisory |
+| latency | 150s | 120s | 1.25 | pass |
+
+Decision: correctness-pass, efficiency-advisory
+```
+
+## Integration Points
+
+- `harness-eval`: use this framework to add trajectory efficiency evidence to benchmark runs.
+- `evaluator-optimizer`: run correctness before efficiency comparisons.
+- `mgr-creator`: opt in for high-risk new agents where quantitative validation is worth the extra cost.
+- `omcustomcodex:improve-report`: include repeated ratio regressions as improvement suggestions.
+
+## Attribution
+
+Adapted from LangChain Deep Agents eval methodology: correctness-first scoring, ideal trajectory annotation, and efficiency ratios for step, tool-call, and latency comparison.

--- a/templates/.claude/skills/agora/SKILL.md
+++ b/templates/.claude/skills/agora/SKILL.md
@@ -43,6 +43,17 @@ source:
 Spawn 3 reviewers as Agent Team members:
 
 ```
+
+### Anti-Groupthink Mode
+
+Use `--anti-groupthink` when consensus itself is a risk:
+
+1. Reviewers submit independent findings before seeing peer output.
+2. One reviewer is assigned as devil's advocate.
+3. Minority findings are preserved unless the synthesis explicitly rejects them with evidence.
+4. Debate is capped at two challenge rounds before the lead either decides or requests more facts.
+
+For decisions where dissent preservation is the main goal, use `roundtable-debate` directly instead of `agora`.
 Agent(name: "claude-critic", model: opus, effort: max)
   → 20-point deep adversarial review
   

--- a/templates/.claude/skills/codex-exec/SKILL.md
+++ b/templates/.claude/skills/codex-exec/SKILL.md
@@ -204,3 +204,15 @@ When routing skills detect a code generation task and codex is available:
 ```
 /codex-exec "Generate {description} following {framework} best practices" --effort high --full-auto
 ```
+
+## Browser Verify Workflow
+
+For frontend or browser-visible changes, use a Build + Vision + Verify loop instead of stopping at a successful build:
+
+1. Build or start the local dev server.
+2. Open the target in the available browser automation surface.
+3. Capture screenshot evidence and console/network errors.
+4. If the visual state or console is wrong, run `codex-exec` with the concrete evidence and repeat.
+5. Stop only when build, browser render, and error checks all pass.
+
+This pattern composes with the Codex App Browser Use plugin or any local browser MCP. Keep the loop evidence-driven: screenshot, console output, network status, and the exact command that produced the build.

--- a/templates/.claude/skills/evaluator-optimizer/SKILL.md
+++ b/templates/.claude/skills/evaluator-optimizer/SKILL.md
@@ -104,6 +104,26 @@ When `conditional.enabled: true` and ANY `skip_when` condition is met, the evalu
 | Complex architecture, security-critical | High | Run with pre-negotiation |
 | Previously failed task retry | Any | Always run |
 
+### Quantitative Efficiency Metrics
+
+When a task provides an ideal trajectory, the evaluator MAY attach `agent-eval-framework` metrics after the normal quality gate:
+
+```yaml
+evaluator-optimizer:
+  quantitative_metrics:
+    enabled: true
+    ideal:
+      steps: 4
+      tool_calls: 5
+      latency_ms: 120000
+    advisory_thresholds:
+      step_ratio: 1.25
+      tool_call_ratio: 1.25
+      latency_ratio: 1.50
+```
+
+Correctness remains the primary gate. Efficiency ratios are used to compare correctness-passing candidates or to create follow-up improvement suggestions.
+
 ### Parameter Details
 
 | Parameter | Required | Default | Description |

--- a/templates/.claude/skills/harness-eval/SKILL.md
+++ b/templates/.claude/skills/harness-eval/SKILL.md
@@ -86,6 +86,19 @@ This skill provides preset rubrics for the evaluator-optimizer pipeline:
 
 The evaluator-optimizer skill's `pre_negotiation` phase accepts harness-eval rubric dimensions as sprint contract criteria.
 
+## Optional 4-Metric Trajectory Evidence
+
+For agent or skill benchmarks, enrich the 0-100 quality score with the `agent-eval-framework` metrics:
+
+| Metric | Source | Use |
+|--------|--------|-----|
+| `correctness` | benchmark assertions and acceptance criteria | Required before efficiency is considered |
+| `step_ratio` | observed steps vs. ideal trajectory | Advisory signal for unnecessary loops |
+| `tool_call_ratio` | observed tool calls vs. ideal trajectory | Advisory signal for noisy tool use |
+| `latency_ratio` | observed duration vs. ideal trajectory | Advisory signal for runtime regression |
+
+Evaluation order is fixed: correctness first, efficiency second. A benchmark run with failed correctness cannot be rescued by strong efficiency ratios.
+
 ## Output
 
 Results saved to `.codex/outputs/sessions/{YYYY-MM-DD}/harness-eval-{HHmmss}.md` with per-task scores and aggregate grade.

--- a/templates/.claude/skills/roundtable-debate/SKILL.md
+++ b/templates/.claude/skills/roundtable-debate/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: roundtable-debate
+description: Structured multi-agent debate that preserves dissent with a mandatory devil's advocate and two-round cap
+scope: core
+user-invocable: true
+argument-hint: "<topic-or-document> [--rounds 1|2] [--decision required|advisory]"
+effort: high
+version: 1.0.0
+---
+
+# Roundtable Debate
+
+## Purpose
+
+Run a bounded debate when convergence would hide useful disagreement. Unlike `agora`, which drives toward consensus, this workflow preserves minority positions and requires explicit justification before dismissing them.
+
+## When To Use
+
+- Architecture or product choices with multiple defensible paths.
+- Review work where anchoring or groupthink is likely.
+- Decisions where a minority risk could be more important than the majority preference.
+
+## Workflow
+
+1. **Independent-first analysis**: spawn 3-5 reviewers in parallel. Do not share intermediate opinions before each reviewer submits an initial view.
+2. **Mandatory devil's advocate**: one reviewer argues against the emerging default, even if they personally agree with it.
+3. **Round 1 synthesis**: group findings into majority positions, minority positions, and unresolved facts.
+4. **Round 2 challenge**: reviewers respond only to disputed claims and missing evidence.
+5. **Decision record**: keep the final recommendation and any protected dissent.
+
+Hard cap: two debate rounds. If the decision still depends on missing facts, stop and gather evidence instead of debating longer.
+
+## Output
+
+```markdown
+# Roundtable Debate Result
+
+## Topic
+{topic}
+
+## Majority Recommendation
+{recommendation}
+
+## Protected Dissent
+| Position | Advocate | Why It Was Not Dismissed |
+|----------|----------|--------------------------|
+| {position} | devil's advocate | {evidence or risk} |
+
+## Decision
+{adopt | defer | reject | gather-more-evidence}
+```
+
+## Relationship To Agora
+
+| Workflow | Goal | Best For |
+|----------|------|----------|
+| `agora` | adversarial consensus | release gates, spec approval |
+| `roundtable-debate` | dissent preservation | ambiguous strategy, architectural tradeoffs |
+
+Use `agora --anti-groupthink` when you need consensus plus explicit dissent handling.

--- a/templates/AGENTS.md.en
+++ b/templates/AGENTS.md.en
@@ -220,38 +220,23 @@ Task tool + routing skills remain the fallback for simple/cost-sensitive tasks.
 
 ## External Dependencies
 
-### Required Plugins
-
-Install via `/plugin install <name>`:
-
-| Plugin | Source | Purpose |
-|--------|--------|---------|
-| superpowers | claude-plugins-official | TDD, debugging, collaboration patterns |
-| openai-docs | superpowers-marketplace | OpenAI and Codex development documentation |
-| elements-of-style | superpowers-marketplace | Writing clarity guidelines |
-| obsidian-skills | - | Obsidian markdown support |
-| context7 | claude-plugins-official | Library documentation lookup |
-
-### Recommended MCP Servers
+### Recommended Codex MCP Servers
 
 | Server | Purpose |
 |--------|---------|
 | omx-memory | Session memory persistence (Chroma-based) |
+| context7 | Library documentation lookup MCP server when a project needs it |
 
 ### Setup Commands
 
 ```bash
-# Add marketplace
-/plugin marketplace add obra/superpowers-marketplace
-
-# Install plugins
-/plugin install superpowers
-/plugin install openai-docs
-/plugin install elements-of-style
-
 # MCP setup (omx-memory)
 npm install -g omx-memory
 omx-memory setup
 ```
+
+### Claude Code Compatibility Note
+
+Projects that run in the Claude Code plugin ecosystem may separately install plugins such as `superpowers`, `openai-docs`, `elements-of-style`, and `context7`. They are not required Codex init steps.
 
 <!-- omcodex:git-workflow -->

--- a/templates/AGENTS.md.ko
+++ b/templates/AGENTS.md.ko
@@ -220,38 +220,23 @@ Codex CLI의 Agent Teams 기능이 활성화되어 있으면 (`OMCODEX_AGENT_TEA
 
 ## 외부 의존성
 
-### 필수 플러그인
-
-`/plugin install <이름>`으로 설치:
-
-| 플러그인 | 소스 | 용도 |
-|----------|------|------|
-| superpowers | claude-plugins-official | TDD, 디버깅, 협업 패턴 |
-| openai-docs | superpowers-marketplace | Codex CLI 개발 문서 |
-| elements-of-style | superpowers-marketplace | 글쓰기 명확성 가이드라인 |
-| obsidian-skills | - | 옵시디언 마크다운 지원 |
-| context7 | claude-plugins-official | 라이브러리 문서 조회 |
-
-### 권장 MCP 서버
+### Codex 권장 MCP 서버
 
 | 서버 | 용도 |
 |------|------|
 | omx-memory | 세션 메모리 영속성 (Chroma 기반) |
+| context7 | 라이브러리 문서 조회용 MCP 서버 (프로젝트 필요 시 설정) |
 
 ### 설치 명령어
 
 ```bash
-# 마켓플레이스 추가
-/plugin marketplace add obra/superpowers-marketplace
-
-# 플러그인 설치
-/plugin install superpowers
-/plugin install openai-docs
-/plugin install elements-of-style
-
 # MCP 설정 (omx-memory)
 npm install -g omx-memory
 omx-memory setup
 ```
+
+### Claude Code 호환 참고
+
+Claude Code 플러그인 생태계를 쓰는 프로젝트에서는 `superpowers`, `openai-docs`, `elements-of-style`, `context7` 같은 플러그인을 별도로 설치할 수 있습니다. Codex 초기화의 필수 단계는 아닙니다.
 
 <!-- omcodex:git-workflow -->

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -222,9 +222,9 @@ Task tool + routing skills remain the fallback for simple/cost-sensitive tasks.
 
 ## External Dependencies
 
-### Required Plugins
+### Claude Code Plugins
 
-Install via `/plugin install <name>`:
+Install in Claude Code via `/plugin install <name>`:
 
 | Plugin | Source | Purpose |
 |--------|--------|---------|
@@ -240,7 +240,7 @@ Install via `/plugin install <name>`:
 |--------|---------|
 | omx-memory | Session memory persistence |
 
-### Setup Commands
+### Claude Code Setup Commands
 
 ```bash
 # Add marketplace

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -222,9 +222,9 @@ Codex CLI의 Agent Teams 기능이 활성화되어 있으면 (`OMCODEX_AGENT_TEA
 
 ## 외부 의존성
 
-### 필수 플러그인
+### Claude Code 플러그인
 
-`/plugin install <이름>`으로 설치:
+Claude Code 환경에서 `/plugin install <이름>`으로 설치:
 
 | 플러그인 | 소스 | 용도 |
 |----------|------|------|
@@ -240,7 +240,7 @@ Codex CLI의 Agent Teams 기능이 활성화되어 있으면 (`OMCODEX_AGENT_TEA
 |------|------|
 | omx-memory | 세션 메모리 영속성 |
 
-### 설치 명령어
+### Claude Code 설치 명령어
 
 ```bash
 # 마켓플레이스 추가

--- a/templates/guides/agent-eval/README.md
+++ b/templates/guides/agent-eval/README.md
@@ -1,0 +1,48 @@
+# Agent Eval Guide
+
+## Evaluation Order
+
+Agent evaluation uses two phases:
+
+1. **Correctness gate**: verify the task outcome against explicit acceptance criteria.
+2. **Efficiency review**: compare only correctness-passing runs against an ideal trajectory.
+
+Do not optimize step count or latency before correctness is proven.
+
+## Four Metrics
+
+| Metric | Definition | Typical Use |
+|--------|------------|-------------|
+| `correctness` | Passed criteria divided by total criteria | Release or completion gate |
+| `step_ratio` | Observed steps divided by ideal steps | Detect avoidable loops |
+| `tool_call_ratio` | Observed tool calls divided by ideal tool calls | Detect noisy retrieval or tool misuse |
+| `latency_ratio` | Observed duration divided by ideal duration | Detect runtime regressions |
+
+## Ideal Trajectory
+
+```yaml
+task: "create a small routing skill"
+capability: "tool_use"
+ideal:
+  steps: 5
+  tool_calls: 8
+  latency_ms: 180000
+acceptance_criteria:
+  - "Skill frontmatter is valid"
+  - "Routing docs reference the skill"
+  - "Tests or static checks pass"
+```
+
+## Interpreting Ratios
+
+- `1.00`: observed matched the ideal.
+- `< 1.00`: faster or shorter than ideal; verify no evidence was skipped.
+- `1.00-1.25`: usually acceptable.
+- `> 1.25`: advisory improvement candidate.
+- correctness below `1.00`: fail regardless of efficiency.
+
+## Integration
+
+- Use `agent-eval-framework` for task-level scoring.
+- Use `harness-eval` when running repeatable benchmark suites.
+- Use `omcustomcodex:improve-report` to turn repeated ratio regressions into improvement suggestions.

--- a/templates/guides/agent-eval/index.yaml
+++ b/templates/guides/agent-eval/index.yaml
@@ -1,0 +1,6 @@
+name: agent-eval
+description: Quantitative agent evaluation with correctness-first 4-metric evidence
+source:
+  type: internal
+files:
+  - README.md

--- a/templates/guides/browser-automation/README.md
+++ b/templates/guides/browser-automation/README.md
@@ -75,6 +75,18 @@ Capture at least one of:
 
 When summarizing evidence for the model, preserve reference tokens and URLs so follow-up steps can still target the right page elements.
 
+## Build + Vision + Verify Loop
+
+For browser-visible changes, treat a successful build as the start of verification, not the end:
+
+1. Build or start the local app.
+2. Open the page in the available browser surface.
+3. Capture screenshot, console, and network evidence.
+4. Feed concrete failures back to the implementation agent.
+5. Repeat until build, render, and runtime evidence all pass.
+
+This is the Codex Browser Use pattern in portable form. Prefer the in-app Browser Use plugin when available; otherwise use Playwright or the existing browser MCP surface.
+
 ## Design And Strategy Workflows
 
 ### Product strategy sessions

--- a/templates/guides/index.yaml
+++ b/templates/guides/index.yaml
@@ -40,6 +40,18 @@ guides:
     source:
       type: internal
 
+  - name: agent-eval
+    description: Quantitative agent evaluation with correctness-first 4-metric evidence
+    path: ./agent-eval/
+    source:
+      type: internal
+
+  - name: multi-agent-debate-patterns
+    description: Anti-groupthink debate patterns for Agora and roundtable-debate workflows
+    path: ./multi-agent-debate-patterns/
+    source:
+      type: internal
+
   # Languages
   - name: golang
     description: Go language reference from Effective Go

--- a/templates/guides/multi-agent-debate-patterns/README.md
+++ b/templates/guides/multi-agent-debate-patterns/README.md
@@ -1,0 +1,26 @@
+# Multi-Agent Debate Patterns
+
+## Pattern Choice
+
+| Pattern | Goal | Use When |
+|---------|------|----------|
+| `agora` | Reach adversarial consensus | Release gates, design approval, high-risk specs |
+| `roundtable-debate` | Preserve dissent | Strategy choices, tradeoffs, ambiguous product or architecture decisions |
+
+## Failure Modes
+
+- **Anchoring**: later reviewers inherit the first opinion.
+- **Groupthink**: reviewers converge because convergence looks productive.
+- **Degeneration of thought**: debate continues without adding new evidence.
+
+## Controls
+
+1. Start with independent parallel analysis.
+2. Assign a devil's advocate.
+3. Protect minority findings unless explicitly rejected with evidence.
+4. Cap debate at two rounds.
+5. Switch from debate to evidence gathering when facts are missing.
+
+## Decision Record
+
+Keep the final recommendation, rejected alternatives, and protected dissent together. Future agents should be able to see not only what was chosen, but which minority risk remains live.

--- a/templates/guides/multi-agent-debate-patterns/index.yaml
+++ b/templates/guides/multi-agent-debate-patterns/index.yaml
@@ -1,0 +1,6 @@
+name: multi-agent-debate-patterns
+description: Anti-groupthink debate patterns for Agora and roundtable-debate workflows
+source:
+  type: internal
+files:
+  - README.md

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.0",
-  "lastUpdated": "2026-04-24T14:35:00.000Z",
+  "version": "0.4.1",
+  "lastUpdated": "2026-04-27T01:00:00.000Z",
   "components": [
     {
       "name": "rules",
@@ -18,13 +18,13 @@
       "name": "skills",
       "path": ".agents/skills",
       "description": "Reusable skill modules (project-scoped repo skills)",
-      "files": 112
+      "files": 114
     },
     {
       "name": "guides",
       "path": "guides",
       "description": "Reference documentation",
-      "files": 40
+      "files": 42
     },
     {
       "name": "hooks",

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -527,6 +527,27 @@ describe('Template Validation', () => {
     });
   });
 
+  describe('Codex init guidance', () => {
+    it('does not present Claude Code plugins as required Codex init steps', async () => {
+      const initSource = await readFile(
+        resolve(import.meta.dir, '../../../src/cli/init.ts'),
+        'utf-8'
+      );
+      const agentsKo = await readFile(join(TEMPLATES_DIR, 'AGENTS.md.ko'), 'utf-8');
+      const agentsEn = await readFile(join(TEMPLATES_DIR, 'AGENTS.md.en'), 'utf-8');
+
+      expect(initSource).not.toContain('Required plugins (install manually)');
+      expect(initSource).not.toContain('/plugin install superpowers');
+
+      for (const content of [agentsKo, agentsEn]) {
+        expect(content).not.toContain('### Required Plugins');
+        expect(content).not.toContain('### 필수 플러그인');
+        expect(content).not.toContain('/plugin marketplace add obra/superpowers-marketplace');
+        expect(content).not.toContain('/plugin install superpowers');
+      }
+    });
+  });
+
   describe('repo root provider layout validation', () => {
     const PROJECT_ROOT = resolve(import.meta.dir, '../../..');
 

--- a/wiki/guides/agent-eval.md
+++ b/wiki/guides/agent-eval.md
@@ -1,0 +1,18 @@
+---
+title: Agent Eval
+type: guide
+updated: 2026-04-27
+sources:
+  - guides/agent-eval/README.md
+related:
+  - [[agent-eval-framework]]
+  - [[harness-eval]]
+---
+
+# Agent Eval
+
+Guide for correctness-first 4-metric evaluation of agent runs.
+
+## Sources
+
+- `guides/agent-eval/README.md`

--- a/wiki/guides/multi-agent-debate-patterns.md
+++ b/wiki/guides/multi-agent-debate-patterns.md
@@ -1,0 +1,18 @@
+---
+title: Multi-Agent Debate Patterns
+type: guide
+updated: 2026-04-27
+sources:
+  - guides/multi-agent-debate-patterns/README.md
+related:
+  - [[agora]]
+  - [[roundtable-debate]]
+---
+
+# Multi-Agent Debate Patterns
+
+Guide for choosing between consensus-seeking review and dissent-preserving debate.
+
+## Sources
+
+- `guides/multi-agent-debate-patterns/README.md`

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -78,6 +78,7 @@ Recommended practice:
 2. Keep allow rules only as defensive documentation; do not rely on them to suppress sensitive-path prompts.
 3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
 4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
+5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
 
 ## Enforcement
 

--- a/wiki/skills/agent-eval-framework.md
+++ b/wiki/skills/agent-eval-framework.md
@@ -1,0 +1,25 @@
+---
+title: Agent Eval Framework
+type: skill
+updated: 2026-04-27
+sources:
+  - .codex/skills/agent-eval-framework/SKILL.md
+related:
+  - [[harness-eval]]
+  - [[evaluator-optimizer]]
+  - [[r020]]
+---
+
+# Agent Eval Framework
+
+Quantitative agent evaluation using correctness, step ratio, tool-call ratio, and latency ratio.
+
+## Key Details
+
+- Correctness is evaluated before efficiency.
+- Ideal trajectories define expected steps, tool calls, latency, and acceptance criteria.
+- Efficiency ratios are advisory unless a task explicitly opts into a stricter gate.
+
+## Sources
+
+- `.codex/skills/agent-eval-framework/SKILL.md`

--- a/wiki/skills/roundtable-debate.md
+++ b/wiki/skills/roundtable-debate.md
@@ -1,0 +1,24 @@
+---
+title: Roundtable Debate
+type: skill
+updated: 2026-04-27
+sources:
+  - .codex/skills/roundtable-debate/SKILL.md
+related:
+  - [[agora]]
+---
+
+# Roundtable Debate
+
+Structured multi-agent debate for decisions where dissent preservation matters more than fast consensus.
+
+## Key Details
+
+- Starts with independent parallel analysis.
+- Requires a devil's advocate.
+- Protects minority findings unless rejected with evidence.
+- Caps debate at two rounds before deciding or gathering more facts.
+
+## Sources
+
+- `.codex/skills/roundtable-debate/SKILL.md`


### PR DESCRIPTION
## Summary
- add packaged agent evaluation and roundtable debate skills with guide/wiki/template coverage
- fold upstream evaluation, browser verification, anti-groupthink, output-style, and sensitive-path guidance into Codex-facing surfaces
- fix init/template wording so Codex setup no longer presents Claude Code plugins as required Codex steps
- bump package/template manifest to 0.4.1 and refresh packaged lockfile/counts

## Verification
- bun run build
- bun run typecheck
- bun run lint
- bun test tests/unit/core/sensitive-output-guidance.test.ts tests/unit/core/template-validation.test.ts
- bun test tests/unit/core/hooks-scripts.test.ts
- bun test tests/unit/core/template-validation.test.ts tests/unit/cli/init.test.ts
- bun test

Closes #912
Closes #913
Closes #914
Closes #915
Closes #916
Closes #918
Closes #919
Closes #920
Closes #921
Closes #922