### PR TITLE
docs: keep README skill counts releasable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-49 agents. 112 skills. 22 rules. One command.
+49 agents. 114 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcustomcodex init
@@ -286,7 +286,7 @@ your-project/
 │   ├── contexts/               # 4 shared context files
 │   └── ontology/               # Knowledge graph for RAG
 ├── .agents/
-│   └── skills/                 # 112 installed skill modules
+│   └── skills/                 # 114 installed skill modules
 └── guides/                     # 40 reference documents
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-49개 에이전트. 112개 스킬. 22개 규칙. 명령어 하나.
+49개 에이전트. 114개 스킬. 22개 규칙. 명령어 하나.
 
 > **v0.1.7** — token-efficiency-audit 스킬, 토큰 효율 3계층 가이드, cc-token-saver/CLI flags cross-reference 추가
 
@@ -149,7 +149,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (112개)
+## 스킬 (114개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -298,7 +298,7 @@ your-project/
 │   ├── contexts/               # 4개 공유 컨텍스트 파일
 │   └── ontology/               # RAG용 지식 그래프
 ├── .agents/
-│   └── skills/                 # 112개 설치 스킬 모듈
+│   └── skills/                 # 114개 설치 스킬 모듈
 └── guides/                     # 40개 레퍼런스 문서
 ```
 


### PR DESCRIPTION
## Summary
- update remaining README/README_ko skill-count references from 112 to 114
- fixes the release documentation gate for v0.4.1

## Verification
- bun run .github/scripts/validate-docs.ts --programmatic-only