### PR TITLE
feat: carry release-monitor issues into auto-dev

### DIFF
--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -19,13 +19,19 @@ steps:
       2. Scan open GitHub issues:
          gh issue list --state open --limit 100 --json number,title,labels,body,milestone
 
+         Also scan release-monitor queues even when `verify-done` is empty:
+         gh issue list --state open --label codex-release --limit 100 --json number,title,labels,body,milestone
+         gh issue list --state open --label oh-my-codex-release --limit 100 --json number,title,labels,body,milestone
+
       3. Group by label and compute for each issue:
          - dependencies: parse "see #N", "depends on #N", "#N 참조" from body
+         - release_monitor: true when labels include codex-release or oh-my-codex-release
          - blocked_by_decision: true if body references any decision-needed issue
          - effort: XS/S/M/L from scope
          - order: topological sort over dependencies
 
-      4. Output: dependency-sorted issue table with blocked_by_decision flag.
+      4. Output: dependency-sorted issue table with blocked_by_decision and release_monitor flags.
+         Never terminate auto-dev from an empty `verify-done` query alone while open release-monitor issues remain.
     description: "Ensure labels exist, scan issues, dependency-analyze"
 
   - name: scope-selection
@@ -39,9 +45,12 @@ steps:
       2. Exclude:
          - blocked_by_decision == true
          - Issues requiring manual/human action
-      3. Sort by dependency: prerequisites before dependents
-      4. Cap at 7 issues; if priority issues < 7, stop at that priority (don't mix tiers)
-      5. Minimum 1 issue; if 0 eligible, halt with "no eligible issues for auto-dev run"
+      3. Include release-monitor issues after explicit impact triage:
+         - If code/docs changes are needed, include the issue in the release manifest.
+         - If no change is needed, comment with evidence and close or mark as triaged.
+      4. Sort by dependency: prerequisites before dependents
+      5. Cap at 7 issues; if priority issues < 7, stop at that priority (don't mix tiers)
+      6. Minimum 1 issue or 1 release-monitor triage action; if 0 eligible and 0 release-monitor actions, halt with "no eligible issues for auto-dev run"
 
       Create release milestone and assign scoped issues.
       Output markdown release manifest:

--- a/.codex/skills/visual-ralph/SKILL.md
+++ b/.codex/skills/visual-ralph/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: visual-ralph
+description: Visual Ralph orchestration for frontend UI using approved references, Ralph implementation, Visual Verdict scoring, and reproducible design-system evidence
+---
+
+# Visual Ralph Skill
+
+Use this skill when the user wants a frontend UI implemented or restyled through
+a measured visual loop rather than subjective design feedback.
+
+## Purpose
+
+Create a frontend delivery loop:
+
+`user description or live URL -> approved visual reference -> $ralph implementation -> $visual-verdict + optional pixel diff -> reusable design system`.
+
+For live URL cloning or recreation requests, Visual Ralph owns the flow. Preserve
+the URL, viewport, content state, and interaction notes in the handoff instead of
+routing new work to a standalone web-clone path.
+
+## Use When
+
+- The user describes a web/app UI and wants implementation.
+- The user provides a live URL and wants a measured visual implementation.
+- A generated raster mockup or static reference image would clarify the target.
+- The task needs screenshot-based pass/fail iteration.
+- The final result should leave reusable tokens/components, not only a one-off visual match.
+
+## Do Not Use When
+
+- The user only wants design critique or frontend advice.
+- The task is non-visual backend/API work.
+- The user supplied a final static reference and only needs a comparison/fix loop; hand directly to `$ralph` with `$visual-verdict`.
+- The requested output is a deterministic SVG/vector/code-native asset.
+
+## Workflow
+
+### 1. Ground The Target Repo
+
+Inspect local evidence before choosing stack-specific tactics:
+- package manager and scripts,
+- frontend framework and routing,
+- styling system and design-token conventions,
+- screenshot/test tooling,
+- existing components that should be reused.
+
+Do not assume React, Vue, Tailwind, Playwright, or another stack without repo evidence.
+
+### 2. Establish The Visual Reference
+
+For live URL work, record:
+- source URL and scope note,
+- viewport(s), route/state, and seed/login assumptions,
+- baseline screenshot path or capture command,
+- interaction parity notes,
+- known exclusions such as backend/auth/personalized data/third-party widget parity.
+
+For generated UI concepts, use `$imagegen` to produce the reference. Prompt for a
+`ui-mockup` with viewport/aspect ratio, intended surface, hierarchy, typography,
+color direction, exact text, and a ban on unrequested logos/watermarks.
+
+For project-bound implementation, save the approved reference in the workspace,
+for example `.omx/artifacts/visual-ralph/<slug>/reference.png`.
+
+### 3. Require User Approval
+
+Stop after reference generation or URL-derived reference capture and ask the user
+to approve one reference image/state or request targeted changes. Do not start
+frontend implementation before approval.
+
+### 4. Hand Off To Ralph
+
+Invoke `$ralph` with:
+- approved reference image path or URL-derived artifact,
+- source URL and scope note when relevant,
+- viewport/content state,
+- detected repo/frontend context,
+- exact screenshot command and output path,
+- the completion checklist below.
+
+### 5. Use Visual Verdict Before Every Next Edit
+
+For each visual iteration:
+1. Capture the current screenshot with recorded viewport/state.
+2. Run `$visual-verdict` against the approved reference.
+3. Treat the JSON verdict as authoritative.
+4. If `score < 90`, convert `differences[]` and `suggestions[]` into the next edit plan.
+5. Rerun before the next edit.
+
+Pixel diff is secondary evidence only. It helps translate mismatch hotspots into
+concrete edits, but it does not replace `$visual-verdict`.
+
+### 6. Leave A Reproducible Design System
+
+Encode the match in repo-native reusable artifacts: CSS variables, theme tokens,
+Tailwind config, component variants, stories, docs, or the existing equivalent.
+Capture applicable colors, spacing, typography, radii, shadows, and key states.
+
+## Completion Checklist
+
+- Approved reference or URL-derived artifact is saved in the workspace.
+- Screenshot reproduction command, viewport, route/state, and output paths are documented.
+- Final `$visual-verdict` score is `>= 90`.
+- Pixel diff or overlay evidence is recorded when useful.
+- Design tokens/components are repo-native and reusable.
+- Build/lint/test or the repo equivalent passes.
+- Remaining visual differences are documented with rationale.
+
+## Handoff Template
+
+```text
+$ralph "Implement the approved frontend reference.
+Reference: <workspace-reference-image-or-url-derived-artifact>
+Source URL: <url and permission/scope note, if relevant>
+Viewport/content state: <viewport, route/state, seed/login assumptions>
+Interaction parity notes: <visible controls and known exclusions>
+Route/surface: <route or component>
+Screenshot command: <command and viewport>
+Use $visual-verdict before every next edit; pass threshold score >= 90.
+Use pixel diff only as secondary debug evidence.
+Extract reusable design tokens/components.
+Run build/lint/test before completion.
+Do not make major design pivots unless explicitly requested."
+```
+
+Task: {{ARGUMENTS}}

--- a/.codex/skills/visual-verdict/SKILL.md
+++ b/.codex/skills/visual-verdict/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: visual-verdict
+description: Structured visual QA verdict for screenshot-to-reference comparisons
+---
+
+# Visual Verdict Skill
+
+Use this skill when a UI task needs a strict visual comparison between one or
+more reference images and the current generated screenshot.
+
+## Inputs
+
+- `reference_images[]`: one or more reference image paths
+- `generated_screenshot`: current output screenshot path
+- `category_hint`: optional UI category, such as `dashboard`, `landing-page`, or `editor`
+
+## Output Contract
+
+Return JSON only:
+
+```json
+{
+  "score": 0,
+  "verdict": "revise",
+  "category_match": false,
+  "differences": ["..."],
+  "suggestions": ["..."],
+  "reasoning": "short explanation"
+}
+```
+
+Rules:
+- `score` is an integer from 0 to 100.
+- `verdict` is `pass`, `revise`, or `fail`.
+- `category_match` is true only when the screenshot matches the intended UI category.
+- `differences[]` lists concrete visual mismatches.
+- `suggestions[]` lists concrete next edits tied to the mismatches.
+- `reasoning` is one or two short sentences.
+
+## Threshold And Loop
+
+- Target pass threshold is `score >= 90`.
+- If `score < 90`, continue editing and rerun `$visual-verdict` before the next edit.
+- Persist useful verdict evidence in `.omx/state/{scope}/ralph-progress.json` when Ralph is active.
+
+## Debug Visualization
+
+Pixel diff or pixelmatch overlays are secondary debugging aids. They help locate
+hotspots, but `$visual-verdict` remains the authoritative pass/fail signal.

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.1",
-  "generatedAt": "2026-04-27T01:04:57.205Z",
-  "templateVersion": "0.4.1",
+  "generatorVersion": "0.4.2",
+  "generatedAt": "2026-04-27T01:32:03.062Z",
+  "templateVersion": "0.4.2",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-49 agents. 114 skills. 22 rules. One command.
+49 agents. 116 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcustomcodex init
@@ -134,7 +134,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (114)
+### Skills (116)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -147,7 +147,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 | Package | 3 | npm-publish, npm-version, npm-audit |
 | Optimization | 3 | optimize-analyze, optimize-bundle, optimize-report |
 | Security | 3 | adversarial-review, cve-triage, jinja2-prompts |
-| Other | 10 | codex-exec, claude-native, vercel-deploy, skills-sh-search, result-aggregation, writing-clearly-and-concisely, and more |
+| Other | 12 | codex-exec, claude-native, visual-ralph, visual-verdict, vercel-deploy, skills-sh-search, result-aggregation, writing-clearly-and-concisely, and more |
 
 Skills use a 3-tier scope system: `core` (universal), `harness` (agent/skill maintenance), `package` (project-specific).
 
@@ -286,7 +286,7 @@ your-project/
 │   ├── contexts/               # 4 shared context files
 │   └── ontology/               # Knowledge graph for RAG
 ├── .agents/
-│   └── skills/                 # 114 installed skill modules
+│   └── skills/                 # 116 installed skill modules
 └── guides/                     # 40 reference documents
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-49개 에이전트. 114개 스킬. 22개 규칙. 명령어 하나.
+49개 에이전트. 116개 스킬. 22개 규칙. 명령어 하나.
 
 > **v0.1.7** — token-efficiency-audit 스킬, 토큰 효율 3계층 가이드, cc-token-saver/CLI flags cross-reference 추가
 
@@ -149,7 +149,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (114개)
+## 스킬 (116개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -162,7 +162,7 @@ Agent(arch-documenter):haiku      ┘
 | 패키지 | 3 | npm-publish, npm-version, npm-audit |
 | 최적화 | 3 | optimize-analyze, optimize-bundle, optimize-report |
 | 보안 | 3 | adversarial-review, cve-triage, jinja2-prompts |
-| 기타 | 10 | codex-exec, claude-native, vercel-deploy, skills-sh-search, result-aggregation, writing-clearly-and-concisely 외 |
+| 기타 | 12 | codex-exec, claude-native, visual-ralph, visual-verdict, vercel-deploy, skills-sh-search, result-aggregation, writing-clearly-and-concisely 외 |
 
 스킬은 3-tier scope 시스템을 사용합니다: `core` (범용), `harness` (에이전트/스킬 관리), `package` (프로젝트 특화).
 
@@ -298,7 +298,7 @@ your-project/
 │   ├── contexts/               # 4개 공유 컨텍스트 파일
 │   └── ontology/               # RAG용 지식 그래프
 ├── .agents/
-│   └── skills/                 # 114개 설치 스킬 모듈
+│   └── skills/                 # 116개 설치 스킬 모듈
 └── guides/                     # 40개 레퍼런스 문서
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/visual-ralph/SKILL.md
+++ b/templates/.claude/skills/visual-ralph/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: visual-ralph
+description: Visual Ralph orchestration for frontend UI using approved references, Ralph implementation, Visual Verdict scoring, and reproducible design-system evidence
+---
+
+# Visual Ralph Skill
+
+Use this skill when the user wants a frontend UI implemented or restyled through
+a measured visual loop rather than subjective design feedback.
+
+## Purpose
+
+Create a frontend delivery loop:
+
+`user description or live URL -> approved visual reference -> $ralph implementation -> $visual-verdict + optional pixel diff -> reusable design system`.
+
+For live URL cloning or recreation requests, Visual Ralph owns the flow. Preserve
+the URL, viewport, content state, and interaction notes in the handoff instead of
+routing new work to a standalone web-clone path.
+
+## Use When
+
+- The user describes a web/app UI and wants implementation.
+- The user provides a live URL and wants a measured visual implementation.
+- A generated raster mockup or static reference image would clarify the target.
+- The task needs screenshot-based pass/fail iteration.
+- The final result should leave reusable tokens/components, not only a one-off visual match.
+
+## Do Not Use When
+
+- The user only wants design critique or frontend advice.
+- The task is non-visual backend/API work.
+- The user supplied a final static reference and only needs a comparison/fix loop; hand directly to `$ralph` with `$visual-verdict`.
+- The requested output is a deterministic SVG/vector/code-native asset.
+
+## Workflow
+
+### 1. Ground The Target Repo
+
+Inspect local evidence before choosing stack-specific tactics:
+- package manager and scripts,
+- frontend framework and routing,
+- styling system and design-token conventions,
+- screenshot/test tooling,
+- existing components that should be reused.
+
+Do not assume React, Vue, Tailwind, Playwright, or another stack without repo evidence.
+
+### 2. Establish The Visual Reference
+
+For live URL work, record:
+- source URL and scope note,
+- viewport(s), route/state, and seed/login assumptions,
+- baseline screenshot path or capture command,
+- interaction parity notes,
+- known exclusions such as backend/auth/personalized data/third-party widget parity.
+
+For generated UI concepts, use `$imagegen` to produce the reference. Prompt for a
+`ui-mockup` with viewport/aspect ratio, intended surface, hierarchy, typography,
+color direction, exact text, and a ban on unrequested logos/watermarks.
+
+For project-bound implementation, save the approved reference in the workspace,
+for example `.omx/artifacts/visual-ralph/<slug>/reference.png`.
+
+### 3. Require User Approval
+
+Stop after reference generation or URL-derived reference capture and ask the user
+to approve one reference image/state or request targeted changes. Do not start
+frontend implementation before approval.
+
+### 4. Hand Off To Ralph
+
+Invoke `$ralph` with:
+- approved reference image path or URL-derived artifact,
+- source URL and scope note when relevant,
+- viewport/content state,
+- detected repo/frontend context,
+- exact screenshot command and output path,
+- the completion checklist below.
+
+### 5. Use Visual Verdict Before Every Next Edit
+
+For each visual iteration:
+1. Capture the current screenshot with recorded viewport/state.
+2. Run `$visual-verdict` against the approved reference.
+3. Treat the JSON verdict as authoritative.
+4. If `score < 90`, convert `differences[]` and `suggestions[]` into the next edit plan.
+5. Rerun before the next edit.
+
+Pixel diff is secondary evidence only. It helps translate mismatch hotspots into
+concrete edits, but it does not replace `$visual-verdict`.
+
+### 6. Leave A Reproducible Design System
+
+Encode the match in repo-native reusable artifacts: CSS variables, theme tokens,
+Tailwind config, component variants, stories, docs, or the existing equivalent.
+Capture applicable colors, spacing, typography, radii, shadows, and key states.
+
+## Completion Checklist
+
+- Approved reference or URL-derived artifact is saved in the workspace.
+- Screenshot reproduction command, viewport, route/state, and output paths are documented.
+- Final `$visual-verdict` score is `>= 90`.
+- Pixel diff or overlay evidence is recorded when useful.
+- Design tokens/components are repo-native and reusable.
+- Build/lint/test or the repo equivalent passes.
+- Remaining visual differences are documented with rationale.
+
+## Handoff Template
+
+```text
+$ralph "Implement the approved frontend reference.
+Reference: <workspace-reference-image-or-url-derived-artifact>
+Source URL: <url and permission/scope note, if relevant>
+Viewport/content state: <viewport, route/state, seed/login assumptions>
+Interaction parity notes: <visible controls and known exclusions>
+Route/surface: <route or component>
+Screenshot command: <command and viewport>
+Use $visual-verdict before every next edit; pass threshold score >= 90.
+Use pixel diff only as secondary debug evidence.
+Extract reusable design tokens/components.
+Run build/lint/test before completion.
+Do not make major design pivots unless explicitly requested."
+```
+
+Task: {{ARGUMENTS}}

--- a/templates/.claude/skills/visual-verdict/SKILL.md
+++ b/templates/.claude/skills/visual-verdict/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: visual-verdict
+description: Structured visual QA verdict for screenshot-to-reference comparisons
+---
+
+# Visual Verdict Skill
+
+Use this skill when a UI task needs a strict visual comparison between one or
+more reference images and the current generated screenshot.
+
+## Inputs
+
+- `reference_images[]`: one or more reference image paths
+- `generated_screenshot`: current output screenshot path
+- `category_hint`: optional UI category, such as `dashboard`, `landing-page`, or `editor`
+
+## Output Contract
+
+Return JSON only:
+
+```json
+{
+  "score": 0,
+  "verdict": "revise",
+  "category_match": false,
+  "differences": ["..."],
+  "suggestions": ["..."],
+  "reasoning": "short explanation"
+}
+```
+
+Rules:
+- `score` is an integer from 0 to 100.
+- `verdict` is `pass`, `revise`, or `fail`.
+- `category_match` is true only when the screenshot matches the intended UI category.
+- `differences[]` lists concrete visual mismatches.
+- `suggestions[]` lists concrete next edits tied to the mismatches.
+- `reasoning` is one or two short sentences.
+
+## Threshold And Loop
+
+- Target pass threshold is `score >= 90`.
+- If `score < 90`, continue editing and rerun `$visual-verdict` before the next edit.
+- Persist useful verdict evidence in `.omx/state/{scope}/ralph-progress.json` when Ralph is active.
+
+## Debug Visualization
+
+Pixel diff or pixelmatch overlays are secondary debugging aids. They help locate
+hotspots, but `$visual-verdict` remains the authoritative pass/fail signal.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.1",
-  "lastUpdated": "2026-04-27T01:00:00.000Z",
+  "version": "0.4.2",
+  "lastUpdated": "2026-04-27T02:00:00.000Z",
   "components": [
     {
       "name": "rules",
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".agents/skills",
       "description": "Reusable skill modules (project-scoped repo skills)",
-      "files": 114
+      "files": 116
     },
     {
       "name": "guides",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -1,5 +1,5 @@
 # /pipeline auto-dev — Full-auto release pipeline
-# Pre-triages open issues → triage verify-done → plan → implement → verify → PR/release → publish → followup
+# Pre-triages open issues and release monitors → triage verify-done → plan → implement → verify → PR/release → publish → followup
 
 name: auto-dev
 description: "Full-auto release pipeline: pre-triage → triage → plan → implement → verify → PR → publish → followup"
@@ -11,11 +11,11 @@ steps:
     parallel:
       - name: pre-triage
         skill: professor-triage
-        description: Run professor-triage on open issues that lack verify-done label
-        condition: "open issues without label:verify-done exist"
+        description: Run professor-triage on open issues that lack verify-done label, including release-monitor labels codex-release and oh-my-codex-release
+        condition: "open issues without label:verify-done exist OR open release-monitor issues with label:codex-release or label:oh-my-codex-release exist"
       - name: triage
         skill: professor-triage
-        description: Analyze verify-done issues against current codebase and perform automated triage
+        description: Analyze verify-done and release-monitor issues against current codebase and perform automated triage
 
   - name: plan
     depends_on: issue-analysis

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -317,6 +317,15 @@ describe('Template Validation', () => {
   });
 
   describe('Skill frontmatter', () => {
+    it('packages Visual Ralph and Visual Verdict as mirrored skills', async () => {
+      const skillsDir = join(TEMPLATES_DIR, '.claude/skills');
+
+      for (const skillName of ['visual-ralph', 'visual-verdict']) {
+        const content = await readFile(join(skillsDir, skillName, 'SKILL.md'), 'utf-8');
+        expect(content).toContain(`name: ${skillName}`);
+      }
+    });
+
     it('every SKILL.md should have valid YAML frontmatter', async () => {
       const skillsDir = join(TEMPLATES_DIR, '.claude/skills');
       const skillDirs = await readdir(skillsDir, { withFileTypes: true });
@@ -727,6 +736,24 @@ describe('Template Validation', () => {
       );
 
       expect(repoWorkflow).toBe(templateWorkflow);
+    });
+
+    it('auto-dev workflow inventories release-monitor issues before declaring no work', async () => {
+      const repoWorkflow = await readFile(join(PROJECT_ROOT, 'workflows/auto-dev.yaml'), 'utf-8');
+      const skillWorkflow = await readFile(
+        join(PROJECT_ROOT, '.codex/skills/pipeline/workflows/auto-dev.yaml'),
+        'utf-8'
+      );
+
+      for (const content of [repoWorkflow, skillWorkflow]) {
+        expect(content).toContain('codex-release');
+        expect(content).toContain('oh-my-codex-release');
+        expect(content).toContain('release-monitor');
+      }
+
+      expect(skillWorkflow).toContain(
+        'Never terminate auto-dev from an empty `verify-done` query alone'
+      );
     });
 
     it('R006 context fork list matches actual skill frontmatter', () => {

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -492,6 +492,12 @@ pages:
     - file: skills/vercel-deploy.md
       title: "Vercel Deploy"
       summary: "Deploy applications to Vercel with environment configuration and preview URLs."
+    - file: skills/visual-ralph.md
+      title: "visual-ralph"
+      summary: "Measured frontend implementation loop using approved references, Ralph execution, Visual Verdict scoring, and reusable design-system evidence."
+    - file: skills/visual-verdict.md
+      title: "visual-verdict"
+      summary: "Structured visual QA verdict for screenshot-to-reference comparisons with a JSON pass/fail contract."
     - file: skills/web-design-guidelines.md
       title: "Web Design Guidelines"
       summary: "UI code review with 100+ rules for production-quality web interfaces."

--- a/wiki/skills/visual-ralph.md
+++ b/wiki/skills/visual-ralph.md
@@ -1,0 +1,17 @@
+# visual-ralph
+
+Visual Ralph orchestrates frontend implementation from an approved reference or
+live URL-derived baseline through Ralph execution, Visual Verdict scoring, and
+repo-native design-system extraction.
+
+## Flow
+
+1. Inspect the target frontend stack and screenshot tooling.
+2. Establish and save an approved visual reference.
+3. Hand off to `$ralph` with viewport, route/state, and screenshot commands.
+4. Run `$visual-verdict` before every next edit.
+5. Keep pixel diff as secondary debug evidence.
+6. Finish with reusable tokens/components plus build/lint/test evidence.
+
+Use this for measured UI implementation or live URL visual recreation. Do not
+use it for non-visual backend work or pure design critique.

--- a/wiki/skills/visual-verdict.md
+++ b/wiki/skills/visual-verdict.md
@@ -1,0 +1,14 @@
+# visual-verdict
+
+Structured visual QA verdict skill for comparing a generated screenshot against
+one or more references.
+
+## Contract
+
+- Inputs: reference image paths, generated screenshot path, optional category hint.
+- Output: JSON only with `score`, `verdict`, `category_match`, `differences`,
+  `suggestions`, and `reasoning`.
+- Pass threshold: `score >= 90`.
+
+Pixel diff evidence is secondary. The JSON verdict remains the authoritative
+iteration signal for visual UI work.

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -1,5 +1,5 @@
 # /pipeline auto-dev — Full-auto release pipeline
-# Pre-triages open issues → triage verify-done → plan → implement → verify → PR/release → publish → followup
+# Pre-triages open issues and release monitors → triage verify-done → plan → implement → verify → PR/release → publish → followup
 
 name: auto-dev
 description: "Full-auto release pipeline: pre-triage → triage → plan → implement → verify → PR → publish → followup"
@@ -11,11 +11,11 @@ steps:
     parallel:
       - name: pre-triage
         skill: professor-triage
-        description: Run professor-triage on open issues that lack verify-done label
-        condition: "open issues without label:verify-done exist"
+        description: Run professor-triage on open issues that lack verify-done label, including release-monitor labels codex-release and oh-my-codex-release
+        condition: "open issues without label:verify-done exist OR open release-monitor issues with label:codex-release or label:oh-my-codex-release exist"
       - name: triage
         skill: professor-triage
-        description: Analyze verify-done issues against current codebase and perform automated triage
+        description: Analyze verify-done and release-monitor issues against current codebase and perform automated triage
 
   - name: plan
     depends_on: issue-analysis


### PR DESCRIPTION
## Summary
- add packaged `visual-ralph` and `visual-verdict` skills with template and wiki coverage
- bump package/manifest/readme skill counts for v0.4.2
- update auto-dev workflow guidance so release-monitor labels (`codex-release`, `oh-my-codex-release`) are inventoried before declaring no work
- add regression coverage for Visual Ralph packaging and release-monitor queue handling

## Release issue analysis
- #911: `@openai/codex@0.125.0` is not a direct dependency; compatibility smoke passed with `npx -y @openai/codex@0.125.0 --version`
- #917: oh-my-codex v0.15.0 Visual Ralph/Visual Verdict surface was actionable and has been ported
- #926: regression guard added so this miss does not repeat

## Verification
- npx -y @openai/codex@0.125.0 --version
- bun run build
- bun run typecheck
- bun run lint
- bun run .github/scripts/validate-docs.ts --programmatic-only
- bun test tests/unit/core/template-validation.test.ts
- bun test

Closes #911
Closes #917
Closes #926