### PR TITLE
fix: make ontology-rag MCP launch portable

### DIFF
--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.2",
-  "generatedAt": "2026-04-27T01:32:03.062Z",
-  "templateVersion": "0.4.2",
+  "generatorVersion": "0.4.3",
+  "generatedAt": "2026-04-27T02:57:25.921Z",
+  "templateVersion": "0.4.3",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/packages/ontology-rag/README.md
+++ b/packages/ontology-rag/README.md
@@ -160,8 +160,8 @@ Add this block to your project-scoped `.codex/config.toml`:
 
 ```toml
 [mcp_servers.ontology-rag]
-command = ".venv/bin/python"
-args = ["-m", "ontology_rag.mcp_server"]
+command = "uv"
+args = ["run", "--no-project", "--python", ".venv", "python", "-m", "ontology_rag.mcp_server"]
 
 [mcp_servers.ontology-rag.env]
 ONTOLOGY_DIR = ".codex/ontology"

--- a/src/core/mcp-config.ts
+++ b/src/core/mcp-config.ts
@@ -14,18 +14,32 @@ import { getProviderLayout } from './layout.js';
 const PROJECT_CONFIG_DIR = '.codex';
 const PROJECT_CONFIG_FILE = 'config.toml';
 const ONTOLOGY_SERVER_TABLE = '[mcp_servers.ontology-rag]';
+const ONTOLOGY_SERVER_COMMAND = 'uv';
+const ONTOLOGY_SERVER_ARGS = [
+  'run',
+  '--no-project',
+  '--python',
+  '.venv',
+  'python',
+  '-m',
+  'ontology_rag.mcp_server',
+];
 
 export function getProjectMCPConfigPath(targetDir: string): string {
   return join(targetDir, PROJECT_CONFIG_DIR, PROJECT_CONFIG_FILE);
 }
 
+function renderTomlString(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
 function renderOntologyMCPBlock(ontologyDir: string): string {
   return `${ONTOLOGY_SERVER_TABLE}
-command = ".venv/bin/python"
-args = ["-m", "ontology_rag.mcp_server"]
+command = ${renderTomlString(ONTOLOGY_SERVER_COMMAND)}
+args = [${ONTOLOGY_SERVER_ARGS.map(renderTomlString).join(', ')}]
 
 [mcp_servers.ontology-rag.env]
-ONTOLOGY_DIR = "${ontologyDir}"
+ONTOLOGY_DIR = ${renderTomlString(ontologyDir)}
 `;
 }
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lastUpdated": "2026-04-27T02:00:00.000Z",
   "components": [
     {

--- a/tests/unit/core/mcp-config.test.ts
+++ b/tests/unit/core/mcp-config.test.ts
@@ -86,8 +86,10 @@ describe('mcp-config', () => {
       const content = await readFile(configPath, 'utf-8');
 
       expect(content).toContain('[mcp_servers.ontology-rag]');
-      expect(content).toContain('command = ".venv/bin/python"');
-      expect(content).toContain('args = ["-m", "ontology_rag.mcp_server"]');
+      expect(content).toContain('command = "uv"');
+      expect(content).toContain(
+        'args = ["run", "--no-project", "--python", ".venv", "python", "-m", "ontology_rag.mcp_server"]'
+      );
       expect(content).toContain('[mcp_servers.ontology-rag.env]');
       expect(content).toContain('ONTOLOGY_DIR = ".codex/ontology"');
     });
@@ -164,18 +166,23 @@ describe('mcp-config', () => {
     it('does not overwrite an existing ontology-rag config block', async () => {
       await mkdir(join(tempDir, '.codex', 'ontology'), { recursive: true });
       const configPath = getProjectMCPConfigPath(tempDir);
-      await writeFile(
-        configPath,
-        '[mcp_servers.ontology-rag]\ncommand = "custom-python"\nargs = ["--custom"]\n',
-        'utf-8'
-      );
+      const existingBlock = [
+        '[mcp_servers.ontology-rag]',
+        'command = "custom-python"',
+        'args = ["--custom"]',
+        '',
+        '[mcp_servers.ontology-rag.env]',
+        'ONTOLOGY_DIR = "custom-ontology"',
+        'CUSTOM_FLAG = "enabled"',
+        '',
+      ].join('\n');
+      await writeFile(configPath, existingBlock, 'utf-8');
       execSyncSpy = spyOn(childProcess, 'execSync').mockImplementation(() => Buffer.from(''));
 
       await generateMCPConfig(tempDir);
 
       const content = await readFile(configPath, 'utf-8');
-      expect(content).toContain('command = "custom-python"');
-      expect(content).toContain('args = ["--custom"]');
+      expect(content).toBe(existingBlock);
       expect(content.match(/\[mcp_servers\.ontology-rag\]/g)?.length).toBe(1);
     });
 


### PR DESCRIPTION
## Summary
- Render generated ontology-rag MCP config with portable `uv run --python .venv python -m ontology_rag.mcp_server`
- Preserve existing custom ontology-rag blocks exactly
- Bump package/template version to `0.4.3` for release

## Verification
- `bun test tests/unit/core/mcp-config.test.ts` -> 12 pass, 0 fail
- `bun x biome check src/core/mcp-config.ts tests/unit/core/mcp-config.test.ts packages/ontology-rag/README.md package.json templates/manifest.json` -> pass
- `bun x tsc --noEmit --pretty false` -> pass
- `bun run build` -> pass
- `uv venv .venv && uv run --no-project --python .venv python -c 'import sys; print(sys.executable)'` -> used the project venv Python
- `bun test tests/ packages/eval-core/` -> 1748 pass, 1 fail in temp worktree only: `tests/unit/utils/fs.test.ts` expects package root path to contain `oh-my-customcodex`, but temp path was `/private/tmp/omx-auto-dev-929-Q8AhKK`

Closes #929