### PR TITLE
fix: preserve agent header branch connectors

### DIFF
--- a/.codex/rules/MUST-agent-identification.md
+++ b/.codex/rules/MUST-agent-identification.md
@@ -9,8 +9,10 @@ Every response MUST start with agent identification:
 ```
 ┌─ Agent: {agent-name} ({agent-type})
 ├─ Skill: {skill-name} (if applicable)
-└─ Task: {brief-task-description}
+└─ Status: {current-action-or-verdict}
 ```
+
+Use `├─` for every intermediate metadata line. Only the final metadata line uses `└─`.
 
 Default (no specific agent): `┌─ Agent: claude (default)`
 
@@ -26,7 +28,7 @@ When the orchestrator uses a routing skill, identification should reflect the ac
 ```
 ┌─ Agent: claude (secretary-routing)
 ├─ Skill: secretary-routing
-└─ Task: route agent management request
+└─ Status: route agent management request
 ```
 
 | Context | Identification |
@@ -44,7 +46,7 @@ When the orchestrator invokes a skill via the Skill tool, the skill name MUST be
 
 ```
 ┌─ Agent: claude → {skill-name}
-└─ Task: {brief-task-description}
+└─ Status: {current-action-or-verdict}
 ```
 
 ### Common Violations
@@ -52,18 +54,18 @@ When the orchestrator invokes a skill via the Skill tool, the skill name MUST be
 ```
 Incorrect: Skill as separate display
    ┌─ Agent: claude (default)
-   └─ Task: research topic analysis
+   └─ Status: research topic analysis
 
    Skill(research)    ← separate, disconnected
 
 Correct: Skill integrated into identification
    ┌─ Agent: claude → research
-   └─ Task: research topic analysis
+   └─ Status: research topic analysis
 
 Correct: With sub-skill
    ┌─ Agent: claude → research
    ├─ Skill: result-aggregation
-   └─ Task: aggregate team findings
+   └─ Status: aggregate team findings
 ```
 
 ## When to Display

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.3",
-  "generatedAt": "2026-04-27T02:57:25.921Z",
-  "templateVersion": "0.4.3",
+  "generatorVersion": "0.4.4",
+  "generatedAt": "2026-04-27T03:11:24.005Z",
+  "templateVersion": "0.4.4",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -55,8 +55,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
-      "templateHash": "5316d30c261fe698f896179ce04b3f61fc9556d655e5904262806da0411316fe",
-      "size": 2136,
+      "templateHash": "40c2a1a3bb04462926ae4690691ec133e9c915aeefc97ac4d3c69f93a4524359",
+      "size": 2250,
       "component": "rules"
     },
     ".codex/rules/MUST-sync-verification.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lastUpdated": "2026-04-27T02:00:00.000Z",
   "components": [
     {

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -575,9 +575,17 @@ describe('Template Validation', () => {
 
     it('uses AGENTS.md as the repo entry file and documents the visible status block', async () => {
       const agentsMd = await readFile(join(PROJECT_ROOT, 'AGENTS.md'), 'utf-8');
-      expect(agentsMd).toContain('Agent: Codex');
-      expect(agentsMd).toContain('Skill:');
-      expect(agentsMd).toContain('Status:');
+      const expectedVisibleHeader = [
+        '```text',
+        '    ┌─ Agent: Codex (gpt-5.4)',
+        '    ├─ Skill: <active-skill-or-routing-surface>',
+        '    └─ Status: <current-action-or-verdict>',
+        '    ```',
+      ].join('\n');
+
+      expect(agentsMd).toContain(expectedVisibleHeader);
+      expect(agentsMd).not.toContain('│ Skill:');
+      expect(agentsMd).not.toContain('│ Status:');
     });
 
     it('repo root agent, skill, and rule surfaces are present and non-empty', async () => {

--- a/wiki/rules/r007.md
+++ b/wiki/rules/r007.md
@@ -1,7 +1,7 @@
 ---
 title: "R007: Agent Identification Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-04-27
 sources:
   - .claude/rules/MUST-agent-identification.md
 related:
@@ -29,8 +29,10 @@ Identification provides traceability and transparency. Without it, users cannot 
 ```
 ┌─ Agent: {agent-name} ({agent-type})
 ├─ Skill: {skill-name} (if applicable)
-└─ Task: {brief-task-description}
+└─ Status: {current-action-or-verdict}
 ```
+
+Intermediate metadata lines use `├─`. Only the final metadata line uses `└─`.
 
 **Simplified format** (brief responses): `[mgr-creator] Creating agent structure...`
 
@@ -46,7 +48,7 @@ Identification provides traceability and transparency. Without it, users cannot 
 **Skill invocation — integrated format (NOT separate display):**
 ```
 ┌─ Agent: claude → {skill-name}
-└─ Task: {brief-task-description}
+└─ Status: {current-action-or-verdict}
 ```
 
 ## Enforcement


### PR DESCRIPTION
## Summary
- Lock the AGENTS.md visible identity header regression test to the connector-bearing block
- Clarify R007 rule/wiki guidance: intermediate metadata uses `├─`, final metadata uses `└─`
- Bump release version to `0.4.4`

## Verification
- `bun test tests/unit/core/template-validation.test.ts` -> 32 pass, 0 fail
- `bun x biome check .codex/rules/MUST-agent-identification.md tests/unit/core/template-validation.test.ts wiki/rules/r007.md package.json templates/manifest.json` -> pass
- `bun x tsc --noEmit --pretty false` -> pass
- `bun run build` -> pass
- `bun test tests/ packages/eval-core/` -> 1748 pass, 1 fail in temp worktree only: `tests/unit/utils/fs.test.ts` expects package root path to contain `oh-my-customcodex`, but temp path was `/private/tmp/omx-auto-dev-932-NoYGaZ`

Closes #932