### PR TITLE
chore: reduce guidance context weight

### DIFF
--- a/.codex/agents/sys-memory-keeper.md
+++ b/.codex/agents/sys-memory-keeper.md
@@ -44,6 +44,16 @@ Build semantic query with project prefix + keywords + optional date. Search via 
 
 Always include project name. Use task-based, temporal, or topic-based queries. Avoid complex where filters (they fail in Chroma).
 
+## Native MEMORY.md Compaction
+
+Treat native auto-memory as an index, not a transcript. Keep the first 200 loaded lines compact enough for reliable prompt injection:
+
+1. Target roughly 100 active index lines when session history accumulates.
+2. Keep recent or currently active sessions inline; move older detail to topic/archive files.
+3. Preserve one-line release/session summaries inline with direct archive pointers.
+4. Keep individual index lines under about 200 characters when practical.
+5. Never delete memory detail solely for line budget; archive it and keep a searchable pointer.
+
 ## Config
 
 Provider: claude-mem | Collection: claude_memories | Archive: ~/.claude-mem/archives/

--- a/.codex/rules/MUST-agent-design.md
+++ b/.codex/rules/MUST-agent-design.md
@@ -29,6 +29,9 @@ Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M tok
 
 ### Optional Frontmatter
 
+Key optional fields: `memory`, `effort`, `skills`, `soul`, `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations`, `domain`, `disableSkillShellExecution`. Supported since CC v2.1.63+. See full optional frontmatter via Read tool.
+
+<!-- DETAIL: Optional Frontmatter (full yaml block)
 ```yaml
 memory: project            # user | project | local
 effort: high               # low | medium | high | xhigh | default | max
@@ -64,8 +67,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 ```
 
 > **Note**: When `disableSkillShellExecution` is enabled (v2.1.91+), skills that rely on inline shell execution (e.g., `codex-exec`, `gemini-exec`, `rtk-exec`) will have their shell blocks disabled. This is a security hardening option.
-
-> **Note**: Optional frontmatter fields supported since CC v2.1.63+. Version-specific features listed in HTML comment below — access via Read tool.
+-->
 
 <!-- DETAIL: CC Version Compatibility History
 `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. `refreshInterval` setting for status line auto-refresh interval added in v2.1.97+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+. PreCompact hook block support (exit 2 / `{"decision":"block"}`) added in v2.1.105+. Skill description listing cap raised from 250 to 1,536 characters in v2.1.105+. Plugin `monitors` manifest key for background monitors added in v2.1.105+. `ENABLE_PROMPT_CACHING_1H` and `FORCE_PROMPT_CACHING_5M` env vars for prompt cache TTL control added in v2.1.108+. Skill tool can now discover and invoke built-in slash commands (`/init`, `/review`, `/security-review`) in v2.1.108+. `/recap` session context feature and `/undo` alias for `/rewind` added in v2.1.108+. `/tui` command and `tui` setting for fullscreen rendering added in v2.1.110+. PushNotification tool for mobile push notifications (Remote Control + config required) added in v2.1.110+. `autoScrollEnabled` config for fullscreen mode added in v2.1.110+. SDK/headless `TRACEPARENT`/`TRACESTATE` distributed trace linking added in v2.1.110+. Bash tool maximum timeout enforcement added in v2.1.110+. Write tool IDE diff feedback (informs model when user edits proposed content) added in v2.1.110+. `--resume`/`--continue` now resurrects unexpired scheduled tasks in v2.1.110+. `/focus` command (separated from Ctrl+O) added in v2.1.110+. `xhigh` effort level for Opus 4.7 (between `high` and `max`; other models fall back to `high`) added in v2.1.111+. `/effort` interactive slider with arrow-key navigation (when called without arguments) added in v2.1.111+. Auto mode no longer requires `--enable-auto-mode` in v2.1.111+. PowerShell tool progressive rollout (`CLAUDE_CODE_USE_POWERSHELL_TOOL` env var) added in v2.1.111+. Read-only bash commands with glob patterns (`ls *.ts`) and `cd <project-dir> &&` prefix no longer trigger permission prompt in v2.1.111+. `/less-permission-prompts` built-in skill for permission allowlist scanning added in v2.1.111+. `/ultrareview` parallel multi-agent cloud code review added in v2.1.111+. `/skills` menu sorting by estimated token count (press `t`) added in v2.1.111+. `OTEL_LOG_RAW_API_BODIES` env var for full API request/response body logging added in v2.1.111+. Plan files named after prompt content (not random words) in v2.1.111+. Plugin error handling improvements (dependency conflict errors, stale version recovery, install recovery) in v2.1.111+.
@@ -155,11 +157,7 @@ hooks:
 
 ## Permission Mode Guidance
 
-When spawning agents via the Agent tool, CC applies a default `mode` of `acceptEdits` if not explicitly specified. To maintain consistent permission behavior:
-
-1. **Agent frontmatter `permissionMode`**: Declares the agent's intended permission level. CC respects this when the agent is spawned via Agent tool.
-2. **Agent tool `mode` parameter**: Overrides frontmatter at spawn time. Routing skills should pass this explicitly.
-3. **Recommendation**: For agents that modify files, set `permissionMode: bypassPermissions` in frontmatter if the project uses `bypassPermissions` mode.
+CC defaults `mode` to `acceptEdits` if not specified — always pass `mode: "bypassPermissions"` explicitly in Agent tool calls when the session uses bypass permissions. See guidance details via Read tool.
 
 | Mode | Behavior |
 |------|----------|
@@ -169,6 +167,14 @@ When spawning agents via the Agent tool, CC applies a default `mode` of `acceptE
 | `plan` | Require plan approval |
 | `dontAsk` | Non-interactive, deny unapproved |
 | `auto` | AI decides safety |
+
+<!-- DETAIL: Permission Mode Guidance (reasoning)
+When spawning agents via the Agent tool, CC applies a default `mode` of `acceptEdits` if not explicitly specified. To maintain consistent permission behavior:
+
+1. **Agent frontmatter `permissionMode`**: Declares the agent's intended permission level. CC respects this when the agent is spawned via Agent tool.
+2. **Agent tool `mode` parameter**: Overrides frontmatter at spawn time. Routing skills should pass this explicitly.
+3. **Recommendation**: For agents that modify files, set `permissionMode: bypassPermissions` in frontmatter if the project uses `bypassPermissions` mode.
+-->
 
 <!-- DETAIL: Isolation/Token/Limitations/Escalation details
 ### Isolation Modes
@@ -241,6 +247,9 @@ Claude Code treats `.claude/` and `templates/.claude/` as sensitive directories 
 
 This Codex port uses `.codex/` as the active runtime surface, but packaged compatibility templates still live under `templates/.claude/`. Any automation that writes those templates must account for Claude Code permission prompts.
 
+**Key rule**: `.claude/` and `templates/.claude/` Bash/Write/Edit targets can trigger sensitive-path prompts regardless of allow rules. In unattended flows, delegated agents must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct `.claude/**` tool targets.
+
+<!-- DETAIL: Sensitive Path Behavior table and Recommended practice
 | Path pattern | Sensitive in Claude Code? | Affected operations |
 |--------------|---------------------------|---------------------|
 | `.claude/**` | Yes | Bash writes, Write, Edit |
@@ -255,6 +264,7 @@ Recommended practice:
 3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
 4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
 5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
+-->
 
 Delegation prompt requirement:
 
@@ -282,6 +292,9 @@ Fast Mode uses the same model with faster output. Activated via `/fast` toggle o
 | Output speed | Standard | ~2.5x faster |
 | Reasoning depth | Full | Reduced |
 
+See activation, effort interaction, and default effort change details via Read tool.
+
+<!-- DETAIL: Fast Mode Activation, Effort Interaction, Default Effort Change
 ### Activation
 
 - `/fast` — toggle in current session
@@ -297,6 +310,7 @@ When Fast Mode is active, it reduces effective reasoning depth but does NOT over
 Starting with Claude Code v2.1.94, the default effort level changed from `medium` to `high` for API-key, Bedrock/Vertex/Foundry, Team, and Enterprise users. Console (free-tier) users retain `medium` as the default.
 
 This means agents WITHOUT an explicit `effort` field now run at `high` effort by default on paid tiers. To maintain previous behavior, set `effort: medium` explicitly in agent frontmatter.
+-->
 
 ## Skill Frontmatter
 
@@ -311,6 +325,9 @@ description: Brief desc    # One-line summary
 
 ### Optional Fields
 
+Key optional fields: `scope`, `context`, `version`, `effort`, `model`, `agent`, `hooks`, `paths`, `shell`, `allowed-tools`, `keep-coding-instructions`. Skill `effort` takes precedence over agent `effort` when both specified. See full optional fields via Read tool.
+
+<!-- DETAIL: Skill Optional Fields (full yaml block)
 ```yaml
 scope: core                # core | harness | package (default: core)
 context: fork              # Forked context for isolated execution
@@ -332,6 +349,7 @@ keep-coding-instructions: true     # Preserve coding instructions in plugin outp
 ```
 
 When both an agent and its invoked skill specify `effort`, the skill's value takes precedence (more specific invocation-time setting).
+-->
 
 <!-- DETAIL: Skill Effectiveness Tracking
 Skills can optionally track effectiveness metrics via auto-populated fields:

--- a/.codex/rules/MUST-agent-teams.md
+++ b/.codex/rules/MUST-agent-teams.md
@@ -271,10 +271,14 @@ When spawning agents that may be blocked:
 
 ## Lifecycle
 
+`TeamCreate → TaskCreate → Agent(spawn members) → SendMessage → TaskUpdate → ... → TeamDelete`. See full lifecycle via Read tool.
+
+<!-- DETAIL: Lifecycle diagram
 ```
 TeamCreate → TaskCreate → Agent(spawn members) → SendMessage(coordinate)
   → TaskUpdate(progress) → ... → shutdown members → TeamDelete
 ```
+-->
 
 ## Fallback
 

--- a/.codex/rules/MUST-parallel-execution.md
+++ b/.codex/rules/MUST-parallel-execution.md
@@ -96,6 +96,9 @@ In that shape, read/search lanes may fan out in parallel, while the push lane re
 
 Runtime detection and splitting of stalled parallel agents. Complements pre-execution parallelization.
 
+See detection signals, splitting rules, and example via Read tool.
+
+<!-- DETAIL: Adaptive Parallel Splitting — Detection, Splitting Rules, Example
 ### Detection
 
 | Signal | Threshold | Action |
@@ -124,9 +127,13 @@ After (adaptive split):
   P4 ████████████████████████████████  (spawned immediately)
   P5 ████████████████████████████████  (spawned immediately)
 ```
+-->
 
 ## Stability Testing Protocol
 
+Soft default: 4 concurrent agents; hard cap: 5. Reduce to 4 if latency >2x, failure rate >10%, or context errors. See full protocol via Read tool.
+
+<!-- DETAIL: Stability Testing Protocol
 When testing 5 concurrent agents (above the soft default of 4):
 
 | Observation | Threshold | Action |
@@ -136,6 +143,7 @@ When testing 5 concurrent agents (above the soft default of 4):
 | Context errors | Any | Reduce to 4 |
 
 5-agent concurrency is supported but should be monitored during initial adoption. Fall back to 4 if instability is observed.
+-->
 
 ## Agent Tool Requirements
 
@@ -157,6 +165,9 @@ Single agent spawns do NOT use the `[N]` prefix.
 
 ## Narrative Announcement Format (Before Spawn)
 
+Use markdown list format, not inline comma-separated text, for parallel dispatch announcements. See correct/incorrect examples via Read tool.
+
+<!-- DETAIL: Narrative Announcement Format (Before Spawn)
 When announcing a parallel dispatch in prose text (not the Agent tool call itself), use a markdown list rather than inline comma-separated description:
 
 ### Correct
@@ -174,6 +185,7 @@ When announcing a parallel dispatch in prose text (not the Agent tool call itsel
 ```
 
 The list form mirrors the tool-call `[N]` prefix pattern and scales better to 3+ concurrent agents.
+-->
 
 ## Result Aggregation
 

--- a/.codex/rules/SHOULD-memory-integration.md
+++ b/.codex/rules/SHOULD-memory-integration.md
@@ -288,6 +288,9 @@ Save memory IMMEDIATELY upon surprising discovery — do not defer to session en
 | Subagent false-positive detected | Save `feedback_*.md` now | Prevent repeat in same session |
 | User correction / feedback | Save `feedback_*.md` now | Honor correction immediately |
 
+See rationale and cross-references via Read tool.
+
+<!-- DETAIL: Why Immediate? and Cross-reference
 ### Why Immediate?
 
 Session-end saves lose context: by the time the session ends, multiple discoveries have compounded and nuance is lost. Immediate saves preserve the exact trigger context that makes the memory actionable.
@@ -300,6 +303,7 @@ Related records from session v0.87.2~v0.88.0 (issue #869):
 - `feedback_subagent_pre_existing_claims.md`
 - `feedback_github_workflows_inventory.md`
 - `feedback_bun_mock_module.md`
+-->
 
 ## Session-End Auto-Save
 
@@ -307,6 +311,9 @@ Related records from session v0.87.2~v0.88.0 (issue #869):
 
 Session-end detected when user says: "끝", "종료", "마무리", "done", "wrap up", "end session", or explicitly requests session save.
 
+See flow diagram, responsibility split, and dual-system save table via Read tool.
+
+<!-- DETAIL: Session-End Flow, Responsibility Split, Dual-System Save
 ### Flow
 
 ```
@@ -340,9 +347,13 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 | Native auto-memory | sys-memory-keeper | Write | Update MEMORY.md with session learnings | Yes |
 | claude-mem | Orchestrator | `mcp__plugin_claude-mem_mcp-search__save_memory` | Save session summary with project, tasks, decisions | No (best-effort) |
 | episodic-memory | Automatic | (auto-indexed) | No action needed — conversations are indexed automatically after session ends | N/A |
+-->
 
 ### Session-End Self-Check (MANDATORY)
 
+(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? Both are required before confirming session-end to the user. See full self-check via Read tool.
+
+<!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
 ╔══════════════════════════════════════════════════════════════════╗
 ║  BEFORE CONFIRMING SESSION-END TO USER:                          ║
@@ -363,6 +374,7 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ║  is NOT.                                                          ║
 ╚══════════════════════════════════════════════════════════════════╝
 ```
+-->
 
 ### Failure Policy
 

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.5",
-  "generatedAt": "2026-04-27T04:09:54.167Z",
-  "templateVersion": "0.4.5",
+  "generatorVersion": "0.4.6",
+  "generatedAt": "2026-04-27T04:31:56.306Z",
+  "templateVersion": "0.4.6",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-parallel-execution.md": {
-      "templateHash": "55744b87529fcbaab767723e50ee283cf099d575fd593438188871f22bb00494",
-      "size": 7299,
+      "templateHash": "80348744a85decb1904d823de4c810755545f1abc171ff72935ed0361b4f7537",
+      "size": 7849,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ecomode.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-design.md": {
-      "templateHash": "7610bf7ae0f4ae48321003a0fd840d28d9ab8bcaf39b866afc45d915316fe0ac",
-      "size": 22677,
+      "templateHash": "06c0b1b9cece77f3f99912b5c1a0cddc7efa38a0a7b4d577d2225972ddd5c30b",
+      "size": 23993,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-teams.md": {
-      "templateHash": "8714a38a22b35de190f5eb8c0140151f55abe5b7e9b6b7f2beb290373244e27d",
-      "size": 15223,
+      "templateHash": "e20dca80f4775e9cd906fa369b95e83296584f4475ce26778d5aa4da9aac2381",
+      "size": 15401,
       "component": "rules"
     },
     ".codex/rules/MAY-optimization.md": {
@@ -100,8 +100,8 @@
       "component": "rules"
     },
     ".codex/rules/SHOULD-memory-integration.md": {
-      "templateHash": "5116c226e578e40223c5d713ac4d3f759b2b6c57f221e79904ccb7c3d7d8d2cf",
-      "size": 15491,
+      "templateHash": "a92539c7eb129e19e7068247d33efcd2279328c59c5d6eaccacb863dd102cf0e",
+      "size": 15972,
       "component": "rules"
     },
     ".codex/rules/MUST-enforcement-policy.md": {
@@ -345,8 +345,8 @@
       "component": "agents"
     },
     ".codex/agents/sys-memory-keeper.md": {
-      "templateHash": "1fb3bb932cf7f451f3250e0b3aff79963dfe30aa66d0723d9401b330396beaef",
-      "size": 4882,
+      "templateHash": "a4756729dcfeb98a062423660b2b0895140b2a7917e78ce809b63b2de480b861",
+      "size": 5473,
       "component": "agents"
     },
     ".codex/agents/infra-aws-expert.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-04-27
+
+### Changed
+- Move high-volume R006/R009/R011/R018 rule detail behind HTML comment `DETAIL` blocks while keeping concise visible summaries and Read-tool access to full detail.
+- Add sys-memory-keeper guidance for treating native `MEMORY.md` as an index with archive pointers rather than an ever-growing transcript.
+
+### Fixed
+- Add regression coverage for rule visible-byte budgets, source/template rule mirror sync, and native memory compaction guidance.
+
 ## [0.4.5] - 2026-04-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -29,6 +29,9 @@ Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M tok
 
 ### Optional Frontmatter
 
+Key optional fields: `memory`, `effort`, `skills`, `soul`, `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations`, `domain`, `disableSkillShellExecution`. Supported since CC v2.1.63+. See full optional frontmatter via Read tool.
+
+<!-- DETAIL: Optional Frontmatter (full yaml block)
 ```yaml
 memory: project            # user | project | local
 effort: high               # low | medium | high | xhigh | default | max
@@ -64,8 +67,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 ```
 
 > **Note**: When `disableSkillShellExecution` is enabled (v2.1.91+), skills that rely on inline shell execution (e.g., `codex-exec`, `gemini-exec`, `rtk-exec`) will have their shell blocks disabled. This is a security hardening option.
-
-> **Note**: Optional frontmatter fields supported since CC v2.1.63+. Version-specific features listed in HTML comment below — access via Read tool.
+-->
 
 <!-- DETAIL: CC Version Compatibility History
 `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. `refreshInterval` setting for status line auto-refresh interval added in v2.1.97+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+. PreCompact hook block support (exit 2 / `{"decision":"block"}`) added in v2.1.105+. Skill description listing cap raised from 250 to 1,536 characters in v2.1.105+. Plugin `monitors` manifest key for background monitors added in v2.1.105+. `ENABLE_PROMPT_CACHING_1H` and `FORCE_PROMPT_CACHING_5M` env vars for prompt cache TTL control added in v2.1.108+. Skill tool can now discover and invoke built-in slash commands (`/init`, `/review`, `/security-review`) in v2.1.108+. `/recap` session context feature and `/undo` alias for `/rewind` added in v2.1.108+. `/tui` command and `tui` setting for fullscreen rendering added in v2.1.110+. PushNotification tool for mobile push notifications (Remote Control + config required) added in v2.1.110+. `autoScrollEnabled` config for fullscreen mode added in v2.1.110+. SDK/headless `TRACEPARENT`/`TRACESTATE` distributed trace linking added in v2.1.110+. Bash tool maximum timeout enforcement added in v2.1.110+. Write tool IDE diff feedback (informs model when user edits proposed content) added in v2.1.110+. `--resume`/`--continue` now resurrects unexpired scheduled tasks in v2.1.110+. `/focus` command (separated from Ctrl+O) added in v2.1.110+. `xhigh` effort level for Opus 4.7 (between `high` and `max`; other models fall back to `high`) added in v2.1.111+. `/effort` interactive slider with arrow-key navigation (when called without arguments) added in v2.1.111+. Auto mode no longer requires `--enable-auto-mode` in v2.1.111+. PowerShell tool progressive rollout (`CLAUDE_CODE_USE_POWERSHELL_TOOL` env var) added in v2.1.111+. Read-only bash commands with glob patterns (`ls *.ts`) and `cd <project-dir> &&` prefix no longer trigger permission prompt in v2.1.111+. `/less-permission-prompts` built-in skill for permission allowlist scanning added in v2.1.111+. `/ultrareview` parallel multi-agent cloud code review added in v2.1.111+. `/skills` menu sorting by estimated token count (press `t`) added in v2.1.111+. `OTEL_LOG_RAW_API_BODIES` env var for full API request/response body logging added in v2.1.111+. Plan files named after prompt content (not random words) in v2.1.111+. Plugin error handling improvements (dependency conflict errors, stale version recovery, install recovery) in v2.1.111+.
@@ -155,11 +157,7 @@ hooks:
 
 ## Permission Mode Guidance
 
-When spawning agents via the Agent tool, CC applies a default `mode` of `acceptEdits` if not explicitly specified. To maintain consistent permission behavior:
-
-1. **Agent frontmatter `permissionMode`**: Declares the agent's intended permission level. CC respects this when the agent is spawned via Agent tool.
-2. **Agent tool `mode` parameter**: Overrides frontmatter at spawn time. Routing skills should pass this explicitly.
-3. **Recommendation**: For agents that modify files, set `permissionMode: bypassPermissions` in frontmatter if the project uses `bypassPermissions` mode.
+CC defaults `mode` to `acceptEdits` if not specified — always pass `mode: "bypassPermissions"` explicitly in Agent tool calls when the session uses bypass permissions. See guidance details via Read tool.
 
 | Mode | Behavior |
 |------|----------|
@@ -169,6 +167,14 @@ When spawning agents via the Agent tool, CC applies a default `mode` of `acceptE
 | `plan` | Require plan approval |
 | `dontAsk` | Non-interactive, deny unapproved |
 | `auto` | AI decides safety |
+
+<!-- DETAIL: Permission Mode Guidance (reasoning)
+When spawning agents via the Agent tool, CC applies a default `mode` of `acceptEdits` if not explicitly specified. To maintain consistent permission behavior:
+
+1. **Agent frontmatter `permissionMode`**: Declares the agent's intended permission level. CC respects this when the agent is spawned via Agent tool.
+2. **Agent tool `mode` parameter**: Overrides frontmatter at spawn time. Routing skills should pass this explicitly.
+3. **Recommendation**: For agents that modify files, set `permissionMode: bypassPermissions` in frontmatter if the project uses `bypassPermissions` mode.
+-->
 
 <!-- DETAIL: Isolation/Token/Limitations/Escalation details
 ### Isolation Modes
@@ -241,6 +247,9 @@ Claude Code treats `.claude/` and `templates/.claude/` as sensitive directories 
 
 This Codex port uses `.codex/` as the active runtime surface, but packaged compatibility templates still live under `templates/.claude/`. Any automation that writes those templates must account for Claude Code permission prompts.
 
+**Key rule**: `.claude/` and `templates/.claude/` Bash/Write/Edit targets can trigger sensitive-path prompts regardless of allow rules. In unattended flows, delegated agents must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct `.claude/**` tool targets.
+
+<!-- DETAIL: Sensitive Path Behavior table and Recommended practice
 | Path pattern | Sensitive in Claude Code? | Affected operations |
 |--------------|---------------------------|---------------------|
 | `.claude/**` | Yes | Bash writes, Write, Edit |
@@ -255,6 +264,7 @@ Recommended practice:
 3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
 4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
 5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
+-->
 
 Delegation prompt requirement:
 
@@ -282,6 +292,9 @@ Fast Mode uses the same model with faster output. Activated via `/fast` toggle o
 | Output speed | Standard | ~2.5x faster |
 | Reasoning depth | Full | Reduced |
 
+See activation, effort interaction, and default effort change details via Read tool.
+
+<!-- DETAIL: Fast Mode Activation, Effort Interaction, Default Effort Change
 ### Activation
 
 - `/fast` — toggle in current session
@@ -297,6 +310,7 @@ When Fast Mode is active, it reduces effective reasoning depth but does NOT over
 Starting with Claude Code v2.1.94, the default effort level changed from `medium` to `high` for API-key, Bedrock/Vertex/Foundry, Team, and Enterprise users. Console (free-tier) users retain `medium` as the default.
 
 This means agents WITHOUT an explicit `effort` field now run at `high` effort by default on paid tiers. To maintain previous behavior, set `effort: medium` explicitly in agent frontmatter.
+-->
 
 ## Skill Frontmatter
 
@@ -311,6 +325,9 @@ description: Brief desc    # One-line summary
 
 ### Optional Fields
 
+Key optional fields: `scope`, `context`, `version`, `effort`, `model`, `agent`, `hooks`, `paths`, `shell`, `allowed-tools`, `keep-coding-instructions`. Skill `effort` takes precedence over agent `effort` when both specified. See full optional fields via Read tool.
+
+<!-- DETAIL: Skill Optional Fields (full yaml block)
 ```yaml
 scope: core                # core | harness | package (default: core)
 context: fork              # Forked context for isolated execution
@@ -332,6 +349,7 @@ keep-coding-instructions: true     # Preserve coding instructions in plugin outp
 ```
 
 When both an agent and its invoked skill specify `effort`, the skill's value takes precedence (more specific invocation-time setting).
+-->
 
 <!-- DETAIL: Skill Effectiveness Tracking
 Skills can optionally track effectiveness metrics via auto-populated fields:

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -271,10 +271,14 @@ When spawning agents that may be blocked:
 
 ## Lifecycle
 
+`TeamCreate → TaskCreate → Agent(spawn members) → SendMessage → TaskUpdate → ... → TeamDelete`. See full lifecycle via Read tool.
+
+<!-- DETAIL: Lifecycle diagram
 ```
 TeamCreate → TaskCreate → Agent(spawn members) → SendMessage(coordinate)
   → TaskUpdate(progress) → ... → shutdown members → TeamDelete
 ```
+-->
 
 ## Fallback
 

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -96,6 +96,9 @@ In that shape, read/search lanes may fan out in parallel, while the push lane re
 
 Runtime detection and splitting of stalled parallel agents. Complements pre-execution parallelization.
 
+See detection signals, splitting rules, and example via Read tool.
+
+<!-- DETAIL: Adaptive Parallel Splitting — Detection, Splitting Rules, Example
 ### Detection
 
 | Signal | Threshold | Action |
@@ -124,9 +127,13 @@ After (adaptive split):
   P4 ████████████████████████████████  (spawned immediately)
   P5 ████████████████████████████████  (spawned immediately)
 ```
+-->
 
 ## Stability Testing Protocol
 
+Soft default: 4 concurrent agents; hard cap: 5. Reduce to 4 if latency >2x, failure rate >10%, or context errors. See full protocol via Read tool.
+
+<!-- DETAIL: Stability Testing Protocol
 When testing 5 concurrent agents (above the soft default of 4):
 
 | Observation | Threshold | Action |
@@ -136,6 +143,7 @@ When testing 5 concurrent agents (above the soft default of 4):
 | Context errors | Any | Reduce to 4 |
 
 5-agent concurrency is supported but should be monitored during initial adoption. Fall back to 4 if instability is observed.
+-->
 
 ## Agent Tool Requirements
 
@@ -157,6 +165,9 @@ Single agent spawns do NOT use the `[N]` prefix.
 
 ## Narrative Announcement Format (Before Spawn)
 
+Use markdown list format, not inline comma-separated text, for parallel dispatch announcements. See correct/incorrect examples via Read tool.
+
+<!-- DETAIL: Narrative Announcement Format (Before Spawn)
 When announcing a parallel dispatch in prose text (not the Agent tool call itself), use a markdown list rather than inline comma-separated description:
 
 ### Correct
@@ -174,6 +185,7 @@ When announcing a parallel dispatch in prose text (not the Agent tool call itsel
 ```
 
 The list form mirrors the tool-call `[N]` prefix pattern and scales better to 3+ concurrent agents.
+-->
 
 ## Result Aggregation
 

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -288,6 +288,9 @@ Save memory IMMEDIATELY upon surprising discovery — do not defer to session en
 | Subagent false-positive detected | Save `feedback_*.md` now | Prevent repeat in same session |
 | User correction / feedback | Save `feedback_*.md` now | Honor correction immediately |
 
+See rationale and cross-references via Read tool.
+
+<!-- DETAIL: Why Immediate? and Cross-reference
 ### Why Immediate?
 
 Session-end saves lose context: by the time the session ends, multiple discoveries have compounded and nuance is lost. Immediate saves preserve the exact trigger context that makes the memory actionable.
@@ -300,6 +303,7 @@ Related records from session v0.87.2~v0.88.0 (issue #869):
 - `feedback_subagent_pre_existing_claims.md`
 - `feedback_github_workflows_inventory.md`
 - `feedback_bun_mock_module.md`
+-->
 
 ## Session-End Auto-Save
 
@@ -307,6 +311,9 @@ Related records from session v0.87.2~v0.88.0 (issue #869):
 
 Session-end detected when user says: "끝", "종료", "마무리", "done", "wrap up", "end session", or explicitly requests session save.
 
+See flow diagram, responsibility split, and dual-system save table via Read tool.
+
+<!-- DETAIL: Session-End Flow, Responsibility Split, Dual-System Save
 ### Flow
 
 ```
@@ -340,9 +347,13 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 | Native auto-memory | sys-memory-keeper | Write | Update MEMORY.md with session learnings | Yes |
 | claude-mem | Orchestrator | `mcp__plugin_claude-mem_mcp-search__save_memory` | Save session summary with project, tasks, decisions | No (best-effort) |
 | episodic-memory | Automatic | (auto-indexed) | No action needed — conversations are indexed automatically after session ends | N/A |
+-->
 
 ### Session-End Self-Check (MANDATORY)
 
+(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? Both are required before confirming session-end to the user. See full self-check via Read tool.
+
+<!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
 ╔══════════════════════════════════════════════════════════════════╗
 ║  BEFORE CONFIRMING SESSION-END TO USER:                          ║
@@ -363,6 +374,7 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ║  is NOT.                                                          ║
 ╚══════════════════════════════════════════════════════════════════╝
 ```
+-->
 
 ### Failure Policy
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lastUpdated": "2026-04-27T02:00:00.000Z",
   "components": [
     {

--- a/tests/unit/core/context-optimization-guidance.test.ts
+++ b/tests/unit/core/context-optimization-guidance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const ROOT = join(import.meta.dir, '../../..');
+
+const RULES = [
+  {
+    source: '.codex/rules/MUST-agent-design.md',
+    template: 'templates/.claude/rules/MUST-agent-design.md',
+    visibleLimit: 7_000,
+    detailMarkers: [
+      'DETAIL: Optional Frontmatter',
+      'DETAIL: Sensitive Path Behavior',
+      'DETAIL: Fast Mode Activation',
+      'DETAIL: Skill Optional Fields',
+    ],
+  },
+  {
+    source: '.codex/rules/MUST-parallel-execution.md',
+    template: 'templates/.claude/rules/MUST-parallel-execution.md',
+    visibleLimit: 4_500,
+    detailMarkers: [
+      'DETAIL: Adaptive Parallel Splitting',
+      'DETAIL: Stability Testing Protocol',
+      'DETAIL: Narrative Announcement Format',
+    ],
+  },
+  {
+    source: '.codex/rules/SHOULD-memory-integration.md',
+    template: 'templates/.claude/rules/SHOULD-memory-integration.md',
+    visibleLimit: 3_000,
+    detailMarkers: [
+      'DETAIL: Why Immediate',
+      'DETAIL: Session-End Flow',
+      'DETAIL: Session-End Self-Check',
+    ],
+  },
+  {
+    source: '.codex/rules/MUST-agent-teams.md',
+    template: 'templates/.claude/rules/MUST-agent-teams.md',
+    visibleLimit: 4_500,
+    detailMarkers: ['DETAIL: Lifecycle diagram'],
+  },
+];
+
+function stripHtmlComments(content: string): string {
+  return content.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+describe('context optimization guidance', () => {
+  it('keeps high-volume rule detail hidden behind HTML comments in source and template mirrors', async () => {
+    for (const rule of RULES) {
+      const source = await readFile(join(ROOT, rule.source), 'utf-8');
+      const template = await readFile(join(ROOT, rule.template), 'utf-8');
+      const visibleBytes = Buffer.byteLength(stripHtmlComments(source), 'utf-8');
+
+      expect(template).toBe(source);
+      expect(visibleBytes).toBeLessThanOrEqual(rule.visibleLimit);
+
+      for (const marker of rule.detailMarkers) {
+        expect(source).toContain(marker);
+      }
+    }
+  });
+
+  it('documents native MEMORY.md compaction as index-plus-archive workflow', async () => {
+    const source = await readFile(join(ROOT, '.codex/agents/sys-memory-keeper.md'), 'utf-8');
+    const wiki = await readFile(join(ROOT, 'wiki/agents/sys-memory-keeper.md'), 'utf-8');
+
+    for (const phrase of [
+      'Treat native auto-memory as an index, not a transcript',
+      'Target roughly 100 active index lines',
+      'archive it and keep a searchable pointer',
+    ]) {
+      expect(source).toContain(phrase);
+    }
+
+    expect(wiki).toContain('Native MEMORY.md should remain an index');
+    expect(wiki).toContain('avoid deleting detail solely for line count');
+  });
+});

--- a/wiki/agents/sys-memory-keeper.md
+++ b/wiki/agents/sys-memory-keeper.md
@@ -19,6 +19,8 @@ Session memory management specialist for saving/restoring context across compact
 
 Important: MCP tools (claude-mem, episodic-memory) are orchestrator-scoped — `sys-memory-keeper` only handles MEMORY.md; the orchestrator handles MCP saves directly after receiving the summary.
 
+Native MEMORY.md should remain an index, not a transcript. When session/release history approaches the loaded 200-line budget, keep recent active context inline, move older detail to topic/archive files, retain one-line summaries with archive pointers, and avoid deleting detail solely for line count.
+
 ## Key Details
 
 - **Model**: sonnet

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -65,6 +65,8 @@ Claude Code treats `.claude/` and `templates/.claude/` as sensitive directories 
 
 This Codex port uses `.codex/` as the active runtime surface, but packaged compatibility templates still live under `templates/.claude/`. Any automation that writes those templates must account for Claude Code permission prompts.
 
+Key rule: `.claude/` and `templates/.claude/` Bash/Write/Edit targets can trigger sensitive-path prompts regardless of allow rules. In unattended flows, delegated agents must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct `.claude/**` tool targets.
+
 | Path pattern | Sensitive in Claude Code? | Affected operations |
 |--------------|---------------------------|---------------------|
 | `.claude/**` | Yes | Bash writes, Write, Edit |
@@ -83,6 +85,8 @@ Recommended practice:
 Delegation prompt requirement:
 
 Any delegated prompt that touches `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths must include `Sensitive-path artifact protocol (mandatory)` from `.codex/rules/MUST-agent-design.md`.
+
+Long optional frontmatter examples and compatibility tables are retained in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
 
 ## Enforcement
 

--- a/wiki/rules/r009.md
+++ b/wiki/rules/r009.md
@@ -3,7 +3,7 @@ title: "R009: Parallel Execution Rules"
 type: rule
 updated: 2026-04-12
 sources:
-  - .claude/rules/MUST-parallel-execution.md
+  - .codex/rules/MUST-parallel-execution.md
 related:
   - [[r008]]
   - [[r010]]
@@ -42,6 +42,8 @@ Parallel execution maximizes throughput and reduces wall-clock time. Before spaw
 
 **Adaptive parallel splitting:** When an agent takes 2x+ longer than peers, spawn independent follow-up tasks immediately without canceling the stalled agent.
 
+Detailed detection, stability, and announcement examples are preserved in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
+
 **Display format:**
 ```
 [1] mgr-creator:sonnet → Create Go agent
@@ -66,4 +68,4 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 
 ## Sources
 
-- `.claude/rules/MUST-parallel-execution.md` — rule definition
+- `.codex/rules/MUST-parallel-execution.md` — rule definition

--- a/wiki/rules/r011.md
+++ b/wiki/rules/r011.md
@@ -3,7 +3,7 @@ title: "R011: Memory Integration Rules"
 type: rule
 updated: 2026-04-15
 sources:
-  - .claude/rules/SHOULD-memory-integration.md
+  - .codex/rules/SHOULD-memory-integration.md
 related:
   - [[r010]]
   - [[r013]]
@@ -51,7 +51,8 @@ Native auto-memory (agent frontmatter `memory` field) is the primary persistence
 | episodic-memory | Automatic (no action needed) |
 
 **Best practices:**
-- Keep MEMORY.md under 200 lines
+- Keep MEMORY.md as an index; target roughly 100 active lines when accumulated session detail approaches the 200-line loaded budget
+- Archive older detail to topic files and keep one-line inline pointers
 - Do not store secrets or duplicate CLAUDE.md content
 - Memory write failures are non-blocking
 
@@ -70,6 +71,8 @@ Save memory IMMEDIATELY upon surprising discovery — do not defer to session en
 
 **Anti-pattern**: "I'll batch all learnings at session end" — by then you'll have forgotten WHY each one mattered, and further violations may have occurred using the un-saved pattern.
 
+Extended rationale, session-end flow diagrams, and self-check examples are retained in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
+
 ## Enforcement
 
 Prompt-based + Stop hook (soft block for session-end saves) per [[r021]].
@@ -82,5 +85,5 @@ Prompt-based + Stop hook (soft block for session-end saves) per [[r021]].
 
 ## Sources
 
-- `.claude/rules/SHOULD-memory-integration.md` — rule definition
+- `.codex/rules/SHOULD-memory-integration.md` — rule definition
 - Issue #869 — mid-session immediate save triggers (2026-04-15)

--- a/wiki/rules/r018.md
+++ b/wiki/rules/r018.md
@@ -3,7 +3,7 @@ title: "R018: Agent Teams Rules"
 type: rule
 updated: 2026-04-12
 sources:
-  - .claude/rules/MUST-agent-teams.md
+  - .codex/rules/MUST-agent-teams.md
 related:
   - [[r009]]
   - [[r010]]
@@ -43,6 +43,8 @@ TeamCreate → TaskCreate → Agent(spawn members) → SendMessage(coordinate)
   → TaskUpdate(progress) → ... → shutdown members → TeamDelete
 ```
 
+Full lifecycle diagrams and extended violation examples are retained in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
+
 **Spawn completeness check:** All members MUST be spawned in a single message — partial spawning is a violation.
 
 **Scope distinction:**
@@ -62,4 +64,4 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 
 ## Sources
 
-- `.claude/rules/MUST-agent-teams.md` — rule definition
+- `.codex/rules/MUST-agent-teams.md` — rule definition


### PR DESCRIPTION
## Summary
- Move high-volume R006/R009/R011/R018 rule detail into HTML `DETAIL` blocks while keeping concise visible summaries.
- Keep `.codex/rules/**` and `templates/.claude/rules/**` mirrors synchronized.
- Add sys-memory-keeper guidance for native `MEMORY.md` index-plus-archive compaction.
- Bump release metadata to `0.4.6` and add regression coverage for visible-byte budgets and compaction guidance.

## Verification
- `bun test tests/unit/core/context-optimization-guidance.test.ts`
- `bun test tests/unit/core/sensitive-output-guidance.test.ts`
- `bun test tests/unit/core/template-validation.test.ts`
- `bash .github/scripts/verify-fork-list.sh`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

## Local gap
- `bun .github/scripts/validate-docs.ts` needs `OPENAI_API_KEY` locally; rely on GitHub Actions docs validation for this gate.

Closes #943
Closes #944