### PR TITLE
feat: persist eval trajectory metrics

### DIFF
--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.6",
-  "generatedAt": "2026-04-27T04:31:56.306Z",
-  "templateVersion": "0.4.6",
+  "generatorVersion": "0.4.7",
+  "generatedAt": "2026-04-27T04:54:56.178Z",
+  "templateVersion": "0.4.7",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-04-27
+
+### Added
+- Add eval-core trajectory baselines and optional invocation metrics for agent evaluation persistence.
+- Add trajectory query helpers for baseline lookup, invocation inspection, and per-baseline aggregate analysis.
+
+### Fixed
+- Keep existing feedback and dashboard invocation queries compatible with the expanded schema through regression coverage.
+
 ## [0.4.6] - 2026-04-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/packages/eval-core/src/__tests__/feedback.test.ts
+++ b/packages/eval-core/src/__tests__/feedback.test.ts
@@ -31,14 +31,35 @@ function makeDb(): { db: EvalDb; sqlite: Database } {
 
   // DDL includes improvement_actions table
   const statements = [
+    `CREATE TABLE IF NOT EXISTS eval_baselines (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      capability TEXT NOT NULL,
+      ideal_steps INTEGER,
+      ideal_tool_calls INTEGER,
+      ideal_latency_ms INTEGER,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
     `CREATE TABLE IF NOT EXISTS agent_invocations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       session_ppid TEXT NOT NULL,
       session_id TEXT,
+      baseline_id INTEGER REFERENCES eval_baselines(id),
       timestamp TEXT NOT NULL,
       agent_type TEXT NOT NULL,
+      agent_name TEXT,
       model TEXT NOT NULL,
       outcome TEXT NOT NULL,
+      observed_steps INTEGER,
+      observed_tool_calls INTEGER,
+      observed_latency_ms INTEGER,
+      correctness REAL,
+      step_ratio REAL,
+      tool_call_ratio REAL,
+      latency_ratio REAL,
+      started_at TEXT,
+      completed_at TEXT,
       pattern_used TEXT,
       skill_name TEXT,
       description TEXT,

--- a/packages/eval-core/src/__tests__/schema-query.test.ts
+++ b/packages/eval-core/src/__tests__/schema-query.test.ts
@@ -16,6 +16,11 @@ import {
   getProjectStats,
   getRecentSessions,
 } from '../query/dashboard.js';
+import {
+  getTrajectoryAnalysis,
+  getTrajectoryBaselines,
+  getTrajectoryInvocations,
+} from '../query/trajectory.js';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -136,14 +141,35 @@ function applyDdl(db: EvalDb, sqlite: Database) {
       timestamp TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )`,
+    `CREATE TABLE IF NOT EXISTS eval_baselines (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      capability TEXT NOT NULL,
+      ideal_steps INTEGER,
+      ideal_tool_calls INTEGER,
+      ideal_latency_ms INTEGER,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
     `CREATE TABLE IF NOT EXISTS agent_invocations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       session_ppid TEXT NOT NULL,
       session_id TEXT,
+      baseline_id INTEGER REFERENCES eval_baselines(id),
       timestamp TEXT NOT NULL,
       agent_type TEXT NOT NULL,
+      agent_name TEXT,
       model TEXT NOT NULL,
       outcome TEXT NOT NULL,
+      observed_steps INTEGER,
+      observed_tool_calls INTEGER,
+      observed_latency_ms INTEGER,
+      correctness REAL,
+      step_ratio REAL,
+      tool_call_ratio REAL,
+      latency_ratio REAL,
+      started_at TEXT,
+      completed_at TEXT,
       pattern_used TEXT,
       skill_name TEXT,
       description TEXT,
@@ -213,6 +239,7 @@ describe('runMigrations', () => {
     expect(names).toContain('projects');
     expect(names).toContain('sessions');
     expect(names).toContain('turns');
+    expect(names).toContain('eval_baselines');
     expect(names).toContain('agent_invocations');
     expect(names).toContain('evaluations');
     expect(names).toContain('session_feedback');
@@ -240,8 +267,11 @@ describe('runMigrations', () => {
     expect(indexNames).toContain('idx_projects_cwd');
     expect(indexNames).toContain('idx_sessions_session_id');
     expect(indexNames).toContain('idx_sessions_project_id');
+    expect(indexNames).toContain('idx_eval_baselines_task_capability');
     expect(indexNames).toContain('idx_turns_session_id');
     expect(indexNames).toContain('idx_invocations_ppid');
+    expect(indexNames).toContain('idx_invocations_baseline_id');
+    expect(indexNames).toContain('idx_invocations_agent_model');
     expect(indexNames).toContain('idx_feedback_session_id');
     db.close();
   });
@@ -345,6 +375,171 @@ describe('schema uniqueness constraints', () => {
     expect(() => {
       seedTurn(db, 'sess-1', 'turn-dup', '2026-01-01T10:06:00.000Z');
     }).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trajectory baseline and invocation analysis
+// ---------------------------------------------------------------------------
+
+describe('trajectory eval schema and queries', () => {
+  it('stores eval baselines and optional invocation trajectory metrics', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-trajectory', null);
+
+    const baseline = db
+      .insert(schema.evalBaselines)
+      .values({
+        taskId: 'task-routing',
+        capability: 'routing',
+        idealSteps: 4,
+        idealToolCalls: 2,
+        idealLatencyMs: 1200,
+        description: 'Expected routing trajectory',
+      })
+      .returning()
+      .get();
+
+    db.insert(schema.agentInvocations)
+      .values({
+        sessionPpid: 'ppid-trajectory',
+        sessionId: 'sess-trajectory',
+        baselineId: baseline.id,
+        agentType: 'planner',
+        agentName: 'planner',
+        model: 'gpt-5.4',
+        outcome: 'success',
+        observedSteps: 5,
+        observedToolCalls: 3,
+        observedLatencyMs: 1500,
+        correctness: 0.9,
+        stepRatio: 1.25,
+        toolCallRatio: 1.5,
+        latencyRatio: 1.25,
+        startedAt: '2026-04-27T00:00:00.000Z',
+        completedAt: '2026-04-27T00:00:01.500Z',
+        timestamp: '2026-04-27T00:00:01.500Z',
+      })
+      .run();
+
+    const rows = getTrajectoryInvocations(db, { baselineId: baseline.id });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      baselineId: baseline.id,
+      taskId: 'task-routing',
+      capability: 'routing',
+      agentName: 'planner',
+      model: 'gpt-5.4',
+      observedSteps: 5,
+      observedToolCalls: 3,
+      observedLatencyMs: 1500,
+      correctness: 0.9,
+      stepRatio: 1.25,
+      toolCallRatio: 1.5,
+      latencyRatio: 1.25,
+      sessionId: 'sess-trajectory',
+    });
+  });
+
+  it('summarizes trajectory metrics by baseline', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-analysis', null);
+
+    const baseline = db
+      .insert(schema.evalBaselines)
+      .values({
+        taskId: 'task-edit',
+        capability: 'code-edit',
+        idealSteps: 4,
+        idealToolCalls: 2,
+        idealLatencyMs: 1000,
+      })
+      .returning()
+      .get();
+
+    db.insert(schema.agentInvocations)
+      .values([
+        {
+          sessionPpid: 'ppid-analysis',
+          sessionId: 'sess-analysis',
+          baselineId: baseline.id,
+          agentType: 'executor',
+          agentName: 'executor',
+          model: 'gpt-5.4',
+          outcome: 'success',
+          observedSteps: 4,
+          observedToolCalls: 2,
+          observedLatencyMs: 1100,
+          correctness: 1,
+          stepRatio: 1,
+          toolCallRatio: 1,
+          latencyRatio: 1.1,
+          timestamp: '2026-04-27T00:00:01.000Z',
+        },
+        {
+          sessionPpid: 'ppid-analysis',
+          sessionId: 'sess-analysis',
+          baselineId: baseline.id,
+          agentType: 'executor',
+          agentName: 'executor',
+          model: 'gpt-5.4',
+          outcome: 'success',
+          observedSteps: 6,
+          observedToolCalls: 4,
+          observedLatencyMs: 1300,
+          correctness: 0.8,
+          stepRatio: 1.5,
+          toolCallRatio: 2,
+          latencyRatio: 1.3,
+          timestamp: '2026-04-27T00:00:02.000Z',
+        },
+      ])
+      .run();
+
+    const [analysis] = getTrajectoryAnalysis(db, { capability: 'code-edit' });
+    expect(analysis).toMatchObject({
+      baselineId: baseline.id,
+      taskId: 'task-edit',
+      capability: 'code-edit',
+      invocationCount: 2,
+      avgCorrectness: 0.9,
+      avgStepRatio: 1.25,
+      avgToolCallRatio: 1.5,
+      avgObservedSteps: 5,
+      avgObservedToolCalls: 3,
+      avgObservedLatencyMs: 1200,
+      bestCorrectness: 1,
+      lastInvocationAt: '2026-04-27T00:00:02.000Z',
+    });
+    expect(analysis?.avgLatencyRatio).toBeCloseTo(1.2);
+  });
+
+  it('keeps baselines queryable before any invocation is recorded', () => {
+    const { db } = makeDb();
+    db.insert(schema.evalBaselines)
+      .values({
+        taskId: 'task-holdout',
+        capability: 'holdout',
+        idealSteps: 3,
+      })
+      .run();
+
+    const baselines = getTrajectoryBaselines(db, { capability: 'holdout' });
+    expect(baselines).toHaveLength(1);
+    expect(baselines[0]).toMatchObject({
+      taskId: 'task-holdout',
+      capability: 'holdout',
+      idealSteps: 3,
+    });
+
+    const [analysis] = getTrajectoryAnalysis(db, { capability: 'holdout' });
+    expect(analysis).toMatchObject({
+      taskId: 'task-holdout',
+      capability: 'holdout',
+      invocationCount: 0,
+      avgCorrectness: null,
+      lastInvocationAt: null,
+    });
   });
 });
 

--- a/packages/eval-core/src/db/migrate.ts
+++ b/packages/eval-core/src/db/migrate.ts
@@ -58,14 +58,35 @@ function runMigrationsOnDb(db: InstanceType<typeof Database>): void {
       timestamp TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )`,
+    `CREATE TABLE IF NOT EXISTS eval_baselines (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      capability TEXT NOT NULL,
+      ideal_steps INTEGER,
+      ideal_tool_calls INTEGER,
+      ideal_latency_ms INTEGER,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
     `CREATE TABLE IF NOT EXISTS agent_invocations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       session_ppid TEXT NOT NULL,
       session_id TEXT,
+      baseline_id INTEGER REFERENCES eval_baselines(id),
       timestamp TEXT NOT NULL,
       agent_type TEXT NOT NULL,
+      agent_name TEXT,
       model TEXT NOT NULL,
       outcome TEXT NOT NULL,
+      observed_steps INTEGER,
+      observed_tool_calls INTEGER,
+      observed_latency_ms INTEGER,
+      correctness REAL,
+      step_ratio REAL,
+      tool_call_ratio REAL,
+      latency_ratio REAL,
+      started_at TEXT,
+      completed_at TEXT,
       pattern_used TEXT,
       skill_name TEXT,
       description TEXT,
@@ -109,9 +130,12 @@ function runMigrationsOnDb(db: InstanceType<typeof Database>): void {
     )`,
     'CREATE INDEX IF NOT EXISTS idx_projects_cwd ON projects(cwd)',
     'CREATE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id)',
+    'CREATE INDEX IF NOT EXISTS idx_eval_baselines_task_capability ON eval_baselines(task_id, capability)',
     'CREATE INDEX IF NOT EXISTS idx_turns_session_id ON turns(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_ppid ON agent_invocations(session_ppid)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_agent_type ON agent_invocations(agent_type)',
+    'CREATE INDEX IF NOT EXISTS idx_invocations_baseline_id ON agent_invocations(baseline_id)',
+    'CREATE INDEX IF NOT EXISTS idx_invocations_agent_model ON agent_invocations(agent_type, model)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_type_outcome_ts ON agent_invocations(agent_type, outcome, timestamp)',
     'CREATE INDEX IF NOT EXISTS idx_evaluations_session_id ON evaluations(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_evaluations_turn_id ON evaluations(turn_id)',
@@ -152,6 +176,30 @@ function runMigrationsOnDb(db: InstanceType<typeof Database>): void {
     }
   }
 
+  // Migration: expand agent_invocations for optional trajectory analysis fields (idempotent)
+  for (const col of [
+    'ALTER TABLE agent_invocations ADD COLUMN baseline_id INTEGER REFERENCES eval_baselines(id)',
+    'ALTER TABLE agent_invocations ADD COLUMN agent_name TEXT',
+    'ALTER TABLE agent_invocations ADD COLUMN observed_steps INTEGER',
+    'ALTER TABLE agent_invocations ADD COLUMN observed_tool_calls INTEGER',
+    'ALTER TABLE agent_invocations ADD COLUMN observed_latency_ms INTEGER',
+    'ALTER TABLE agent_invocations ADD COLUMN correctness REAL',
+    'ALTER TABLE agent_invocations ADD COLUMN step_ratio REAL',
+    'ALTER TABLE agent_invocations ADD COLUMN tool_call_ratio REAL',
+    'ALTER TABLE agent_invocations ADD COLUMN latency_ratio REAL',
+    'ALTER TABLE agent_invocations ADD COLUMN started_at TEXT',
+    'ALTER TABLE agent_invocations ADD COLUMN completed_at TEXT',
+  ]) {
+    try {
+      db.run(col);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '';
+      if (!msg.includes('duplicate column') && !msg.includes('already exists')) {
+        throw err;
+      }
+    }
+  }
+
   // Add project_id index after the ALTER TABLE migration (column may not exist on legacy DBs)
   try {
     db.run('CREATE INDEX IF NOT EXISTS idx_sessions_project_id ON sessions(project_id)');
@@ -159,6 +207,20 @@ function runMigrationsOnDb(db: InstanceType<typeof Database>): void {
     const msg = err instanceof Error ? err.message : '';
     if (!msg.includes('already exists') && !msg.includes('no such column')) {
       throw err; // Re-throw unexpected errors
+    }
+  }
+
+  for (const indexSql of [
+    'CREATE INDEX IF NOT EXISTS idx_invocations_baseline_id ON agent_invocations(baseline_id)',
+    'CREATE INDEX IF NOT EXISTS idx_invocations_agent_model ON agent_invocations(agent_type, model)',
+  ]) {
+    try {
+      db.run(indexSql);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '';
+      if (!msg.includes('already exists') && !msg.includes('no such column')) {
+        throw err;
+      }
     }
   }
 }

--- a/packages/eval-core/src/db/schema.ts
+++ b/packages/eval-core/src/db/schema.ts
@@ -67,14 +67,38 @@ export const turns = sqliteTable('turns', {
     .$defaultFn(() => new Date().toISOString()),
 });
 
+export const evalBaselines = sqliteTable('eval_baselines', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  taskId: text('task_id').notNull(),
+  capability: text('capability').notNull(),
+  idealSteps: integer('ideal_steps'),
+  idealToolCalls: integer('ideal_tool_calls'),
+  idealLatencyMs: integer('ideal_latency_ms'),
+  description: text('description'),
+  createdAt: text('created_at')
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
 export const agentInvocations = sqliteTable('agent_invocations', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   sessionPpid: text('session_ppid').notNull(),
   sessionId: text('session_id'),
+  baselineId: integer('baseline_id').references(() => evalBaselines.id),
   timestamp: text('timestamp').notNull(),
   agentType: text('agent_type').notNull(),
+  agentName: text('agent_name'),
   model: text('model').notNull(),
   outcome: text('outcome').notNull(),
+  observedSteps: integer('observed_steps'),
+  observedToolCalls: integer('observed_tool_calls'),
+  observedLatencyMs: integer('observed_latency_ms'),
+  correctness: real('correctness'),
+  stepRatio: real('step_ratio'),
+  toolCallRatio: real('tool_call_ratio'),
+  latencyRatio: real('latency_ratio'),
+  startedAt: text('started_at'),
+  completedAt: text('completed_at'),
   patternUsed: text('pattern_used'),
   skillName: text('skill_name'),
   description: text('description'),

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -3,6 +3,7 @@ export { createDb, type EvalDb } from './db/client.js';
 export {
   agentInvocations,
   evaluations,
+  evalBaselines,
   improvementActions,
   projects,
   sessionFeedback,

--- a/packages/eval-core/src/query/index.ts
+++ b/packages/eval-core/src/query/index.ts
@@ -1,3 +1,4 @@
 export * from './types.js';
 export { getDashboardStats, getAgentStats, getProjectStats, getRecentSessions } from './dashboard.js';
 export * from './feedback.js';
+export * from './trajectory.js';

--- a/packages/eval-core/src/query/trajectory.ts
+++ b/packages/eval-core/src/query/trajectory.ts
@@ -1,0 +1,159 @@
+import { and, avg, count, desc, eq, gte, max, or, sql } from 'drizzle-orm';
+import type { EvalDb } from '../db/client.js';
+import { agentInvocations, evalBaselines } from '../db/schema.js';
+import type {
+  TrajectoryAnalysis,
+  TrajectoryBaseline,
+  TrajectoryInvocation,
+  TrajectoryQueryOptions,
+} from './types.js';
+
+function mapAgentName(row: { agentName: string | null; agentType: string }): string {
+  return row.agentName ?? row.agentType;
+}
+
+export function getTrajectoryBaselines(
+  db: EvalDb,
+  options: Pick<TrajectoryQueryOptions, 'baselineId' | 'capability' | 'limit'> = {}
+): TrajectoryBaseline[] {
+  const conditions = [
+    options.baselineId !== undefined ? eq(evalBaselines.id, options.baselineId) : undefined,
+    options.capability ? eq(evalBaselines.capability, options.capability) : undefined,
+  ].filter((condition): condition is NonNullable<typeof condition> => Boolean(condition));
+
+  let query = db
+    .select()
+    .from(evalBaselines)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(evalBaselines.createdAt))
+    .$dynamic();
+
+  if (options.limit !== undefined) {
+    query = query.limit(options.limit);
+  }
+
+  return query.all();
+}
+
+export function getTrajectoryInvocations(
+  db: EvalDb,
+  options: TrajectoryQueryOptions = {}
+): TrajectoryInvocation[] {
+  const conditions = [
+    options.baselineId !== undefined ? eq(agentInvocations.baselineId, options.baselineId) : undefined,
+    options.capability ? eq(evalBaselines.capability, options.capability) : undefined,
+    options.agentName
+      ? or(eq(agentInvocations.agentName, options.agentName), eq(agentInvocations.agentType, options.agentName))
+      : undefined,
+    options.model ? eq(agentInvocations.model, options.model) : undefined,
+    options.since ? gte(agentInvocations.timestamp, options.since) : undefined,
+  ].filter((condition): condition is NonNullable<typeof condition> => Boolean(condition));
+
+  let query = db
+    .select({
+      id: agentInvocations.id,
+      baselineId: agentInvocations.baselineId,
+      taskId: evalBaselines.taskId,
+      capability: evalBaselines.capability,
+      agentType: agentInvocations.agentType,
+      agentName: agentInvocations.agentName,
+      model: agentInvocations.model,
+      observedSteps: agentInvocations.observedSteps,
+      observedToolCalls: agentInvocations.observedToolCalls,
+      observedLatencyMs: agentInvocations.observedLatencyMs,
+      correctness: agentInvocations.correctness,
+      stepRatio: agentInvocations.stepRatio,
+      toolCallRatio: agentInvocations.toolCallRatio,
+      latencyRatio: agentInvocations.latencyRatio,
+      sessionId: agentInvocations.sessionId,
+      startedAt: agentInvocations.startedAt,
+      completedAt: agentInvocations.completedAt,
+      timestamp: agentInvocations.timestamp,
+    })
+    .from(agentInvocations)
+    .leftJoin(evalBaselines, eq(agentInvocations.baselineId, evalBaselines.id))
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(agentInvocations.timestamp))
+    .$dynamic();
+
+  if (options.limit !== undefined) {
+    query = query.limit(options.limit);
+  }
+
+  return query.all().map((row) => ({
+    id: row.id,
+    baselineId: row.baselineId ?? null,
+    taskId: row.taskId ?? null,
+    capability: row.capability ?? null,
+    agentName: mapAgentName(row),
+    model: row.model,
+    observedSteps: row.observedSteps ?? null,
+    observedToolCalls: row.observedToolCalls ?? null,
+    observedLatencyMs: row.observedLatencyMs ?? null,
+    correctness: row.correctness ?? null,
+    stepRatio: row.stepRatio ?? null,
+    toolCallRatio: row.toolCallRatio ?? null,
+    latencyRatio: row.latencyRatio ?? null,
+    sessionId: row.sessionId ?? null,
+    startedAt: row.startedAt ?? null,
+    completedAt: row.completedAt ?? null,
+    timestamp: row.timestamp,
+  }));
+}
+
+export function getTrajectoryAnalysis(
+  db: EvalDb,
+  options: Pick<TrajectoryQueryOptions, 'baselineId' | 'capability' | 'model' | 'since' | 'limit'> = {}
+): TrajectoryAnalysis[] {
+  const conditions = [
+    options.baselineId !== undefined ? eq(evalBaselines.id, options.baselineId) : undefined,
+    options.capability ? eq(evalBaselines.capability, options.capability) : undefined,
+    options.model ? eq(agentInvocations.model, options.model) : undefined,
+    options.since ? gte(agentInvocations.timestamp, options.since) : undefined,
+  ].filter((condition): condition is NonNullable<typeof condition> => Boolean(condition));
+
+  let query = db
+    .select({
+      baselineId: evalBaselines.id,
+      taskId: evalBaselines.taskId,
+      capability: evalBaselines.capability,
+      invocationCount: count(agentInvocations.id),
+      avgCorrectness: avg(agentInvocations.correctness),
+      avgStepRatio: avg(agentInvocations.stepRatio),
+      avgToolCallRatio: avg(agentInvocations.toolCallRatio),
+      avgLatencyRatio: avg(agentInvocations.latencyRatio),
+      avgObservedSteps: avg(agentInvocations.observedSteps),
+      avgObservedToolCalls: avg(agentInvocations.observedToolCalls),
+      avgObservedLatencyMs: avg(agentInvocations.observedLatencyMs),
+      bestCorrectness: max(agentInvocations.correctness),
+      lastInvocationAt: max(agentInvocations.timestamp),
+    })
+    .from(evalBaselines)
+    .leftJoin(agentInvocations, eq(agentInvocations.baselineId, evalBaselines.id))
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .groupBy(evalBaselines.id)
+    .orderBy(desc(sql`coalesce(max(${agentInvocations.timestamp}), ${evalBaselines.createdAt})`))
+    .$dynamic();
+
+  if (options.limit !== undefined) {
+    query = query.limit(options.limit);
+  }
+
+  return query.all().map((row) => ({
+    baselineId: row.baselineId,
+    taskId: row.taskId,
+    capability: row.capability,
+    invocationCount: row.invocationCount,
+    avgCorrectness: row.avgCorrectness === null ? null : Number(row.avgCorrectness),
+    avgStepRatio: row.avgStepRatio === null ? null : Number(row.avgStepRatio),
+    avgToolCallRatio: row.avgToolCallRatio === null ? null : Number(row.avgToolCallRatio),
+    avgLatencyRatio: row.avgLatencyRatio === null ? null : Number(row.avgLatencyRatio),
+    avgObservedSteps: row.avgObservedSteps === null ? null : Number(row.avgObservedSteps),
+    avgObservedToolCalls:
+      row.avgObservedToolCalls === null ? null : Number(row.avgObservedToolCalls),
+    avgObservedLatencyMs:
+      row.avgObservedLatencyMs === null ? null : Number(row.avgObservedLatencyMs),
+    bestCorrectness: row.bestCorrectness ?? null,
+    lastInvocationAt: row.lastInvocationAt ?? null,
+  }));
+}

--- a/packages/eval-core/src/query/types.ts
+++ b/packages/eval-core/src/query/types.ts
@@ -40,3 +40,59 @@ export interface DashboardStats {
   recentSessions: SessionStats[];
   topAgents: AgentStat[];
 }
+
+export interface TrajectoryBaseline {
+  id: number;
+  taskId: string;
+  capability: string;
+  idealSteps: number | null;
+  idealToolCalls: number | null;
+  idealLatencyMs: number | null;
+  description: string | null;
+  createdAt: string;
+}
+
+export interface TrajectoryInvocation {
+  id: number;
+  baselineId: number | null;
+  taskId: string | null;
+  capability: string | null;
+  agentName: string;
+  model: string;
+  observedSteps: number | null;
+  observedToolCalls: number | null;
+  observedLatencyMs: number | null;
+  correctness: number | null;
+  stepRatio: number | null;
+  toolCallRatio: number | null;
+  latencyRatio: number | null;
+  sessionId: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  timestamp: string;
+}
+
+export interface TrajectoryAnalysis {
+  baselineId: number;
+  taskId: string;
+  capability: string;
+  invocationCount: number;
+  avgCorrectness: number | null;
+  avgStepRatio: number | null;
+  avgToolCallRatio: number | null;
+  avgLatencyRatio: number | null;
+  avgObservedSteps: number | null;
+  avgObservedToolCalls: number | null;
+  avgObservedLatencyMs: number | null;
+  bestCorrectness: number | null;
+  lastInvocationAt: string | null;
+}
+
+export interface TrajectoryQueryOptions {
+  baselineId?: number;
+  capability?: string;
+  agentName?: string;
+  model?: string;
+  since?: string;
+  limit?: number;
+}

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.6",
-  "lastUpdated": "2026-04-27T02:00:00.000Z",
+  "version": "0.4.7",
+  "lastUpdated": "2026-04-27T04:55:00.000Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary
- add `eval_baselines` and optional trajectory columns on `agent_invocations`
- add trajectory query helpers for baselines, invocations, and aggregate analysis
- bump release metadata to v0.4.7

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run .github/scripts/validate-docs.ts --programmatic-only`
- `bun test packages/eval-core/src/__tests__/schema-query.test.ts packages/eval-core/src/__tests__/feedback.test.ts packages/eval-core/src/__tests__/user-feedback.test.ts`
- `bun run test`

Closes #938