### PR TITLE
fix: align codex exec with current CLI auth

### DIFF
--- a/.codex/hooks/scripts/session-env-check.sh
+++ b/.codex/hooks/scripts/session-env-check.sh
@@ -14,10 +14,14 @@ echo "--- [Session Environment Check] ---" >&2
 # Check codex CLI availability
 CODEX_STATUS="unavailable"
 if command -v codex >/dev/null 2>&1; then
-  if [ -n "${OPENAI_API_KEY:-}" ]; then
+  CODEX_AUTH_FILE="${CODEX_HOME:-$HOME/.codex}/auth.json"
+
+  if [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${CODEX_API_KEY:-}" ]; then
     CODEX_STATUS="available (authenticated)"
+  elif [ -s "$CODEX_AUTH_FILE" ]; then
+    CODEX_STATUS="available (authenticated via stored login)"
   else
-    CODEX_STATUS="installed but OPENAI_API_KEY not set"
+    CODEX_STATUS="installed (auth may be managed via \`codex login\`)"
   fi
 fi
 

--- a/.codex/skills/codex-exec/SKILL.md
+++ b/.codex/skills/codex-exec/SKILL.md
@@ -31,7 +31,7 @@ Execute OpenAI Codex CLI prompts in non-interactive mode and return structured r
 ```
 1. Pre-checks
    - Verify `codex` binary is installed (which codex || npx codex --version)
-   - Verify authentication (OPENAI_API_KEY or logged in)
+   - Verify authentication (`OPENAI_API_KEY`, `CODEX_API_KEY`, or stored `codex login` / ChatGPT login)
 2. Build command
    - Base: codex exec --ephemeral "<prompt>"
    - Apply options: --json, --model, --full-auto, -C <dir>
@@ -132,7 +132,7 @@ Works with the orchestrator pattern:
 codex-exec requires the Codex CLI binary to be installed and authenticated. The skill is only usable when:
 
 1. `codex` binary is found in PATH (`which codex` succeeds)
-2. Authentication is valid (OPENAI_API_KEY set or `codex` logged in)
+2. Authentication is valid (`OPENAI_API_KEY`, `CODEX_API_KEY`, or stored auth from `codex login --api-key` / ChatGPT login)
 
 If either check fails, this skill cannot be used. Fall back to Claude agents for the task.
 
@@ -158,7 +158,7 @@ Orchestrator delegates generation task
 
 When the orchestrator or intent-detection detects a research/information gathering request (routing_rule in agent-triggers.yaml):
 
-1. **Check Codex availability**: Verify `codex` binary and `OPENAI_API_KEY`
+1. **Check Codex availability**: Verify `codex` binary plus `OPENAI_API_KEY`, `CODEX_API_KEY`, or stored `codex login` auth
 2. **If available**: Execute with xhigh reasoning effort for thorough research
 3. **If unavailable**: Fall back to Claude's WebFetch/WebSearch
 

--- a/.codex/skills/codex-exec/scripts/codex-wrapper.cjs
+++ b/.codex/skills/codex-exec/scripts/codex-wrapper.cjs
@@ -128,9 +128,11 @@ function validateEnvironment() {
     }
   }
 
-  // Note: OPENAI_API_KEY is optional if codex has its own stored auth (via `codex auth`)
-  if (!process.env.OPENAI_API_KEY) {
-    console.error('[codex-wrapper] Note: OPENAI_API_KEY not set, relying on codex built-in auth');
+  // OPENAI_API_KEY/CODEX_API_KEY are optional when codex has stored auth from `codex login`.
+  if (!process.env.OPENAI_API_KEY && !process.env.CODEX_API_KEY) {
+    console.error(
+      '[codex-wrapper] Note: no OPENAI_API_KEY/CODEX_API_KEY set, relying on stored codex login or ChatGPT auth'
+    );
   }
 
   return {
@@ -204,6 +206,7 @@ function executeCodex(binary, args, timeout, workingDir = null) {
     const spawnOptions = {
       cwd: workingDir || process.cwd(),
       env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
     };
 
     const child = spawn(binary, args, spawnOptions);

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.9",
-  "generatedAt": "2026-04-27T23:58:12.772Z",
-  "templateVersion": "0.4.9",
+  "generatorVersion": "0.4.10",
+  "generatedAt": "2026-04-28T00:01:33.392Z",
+  "templateVersion": "0.4.10",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.4.9",
-  "generatedAt": "2026-04-27T09:07:45.773Z",
+  "generatedAt": "2026-04-27T23:58:12.772Z",
   "templateVersion": "0.4.9",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
@@ -485,8 +485,8 @@
       "component": "hooks"
     },
     ".codex/hooks/scripts/session-env-check.sh": {
-      "templateHash": "c5a81d1c5cbf5d2c3311a948b53d3dcfc215d81041f84842dca96ad7ceee91c2",
-      "size": 9000,
+      "templateHash": "264143dbcc109777dd95c2086e174b74c7717152dfb4c74b5460e49587f4eaf6",
+      "size": 9206,
       "component": "hooks"
     },
     ".codex/hooks/scripts/feedback-collector.sh": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/codex-exec/SKILL.md
+++ b/templates/.claude/skills/codex-exec/SKILL.md
@@ -31,7 +31,7 @@ Execute OpenAI Codex CLI prompts in non-interactive mode and return structured r
 ```
 1. Pre-checks
    - Verify `codex` binary is installed (which codex || npx codex --version)
-   - Verify authentication (OPENAI_API_KEY or logged in)
+   - Verify authentication (`OPENAI_API_KEY`, `CODEX_API_KEY`, or stored `codex login` / ChatGPT login)
 2. Build command
    - Base: codex exec --ephemeral "<prompt>"
    - Apply options: --json, --model, --full-auto, -C <dir>
@@ -132,7 +132,7 @@ Works with the orchestrator pattern:
 codex-exec requires the Codex CLI binary to be installed and authenticated. The skill is only usable when:
 
 1. `codex` binary is found in PATH (`which codex` succeeds)
-2. Authentication is valid (OPENAI_API_KEY set or `codex` logged in)
+2. Authentication is valid (`OPENAI_API_KEY`, `CODEX_API_KEY`, or stored auth from `codex login --api-key` / ChatGPT login)
 
 If either check fails, this skill cannot be used. Fall back to Claude agents for the task.
 
@@ -158,7 +158,7 @@ Orchestrator delegates generation task
 
 When the orchestrator or intent-detection detects a research/information gathering request (routing_rule in agent-triggers.yaml):
 
-1. **Check Codex availability**: Verify `codex` binary and `OPENAI_API_KEY`
+1. **Check Codex availability**: Verify `codex` binary plus `OPENAI_API_KEY`, `CODEX_API_KEY`, or stored `codex login` auth
 2. **If available**: Execute with xhigh reasoning effort for thorough research
 3. **If unavailable**: Fall back to Claude's WebFetch/WebSearch
 

--- a/templates/.claude/skills/codex-exec/scripts/codex-wrapper.cjs
+++ b/templates/.claude/skills/codex-exec/scripts/codex-wrapper.cjs
@@ -128,9 +128,11 @@ function validateEnvironment() {
     }
   }
 
-  // Note: OPENAI_API_KEY is optional if codex has its own stored auth (via `codex auth`)
-  if (!process.env.OPENAI_API_KEY) {
-    console.error('[codex-wrapper] Note: OPENAI_API_KEY not set, relying on codex built-in auth');
+  // OPENAI_API_KEY/CODEX_API_KEY are optional when codex has stored auth from `codex login`.
+  if (!process.env.OPENAI_API_KEY && !process.env.CODEX_API_KEY) {
+    console.error(
+      '[codex-wrapper] Note: no OPENAI_API_KEY/CODEX_API_KEY set, relying on stored codex login or ChatGPT auth'
+    );
   }
 
   return {
@@ -204,6 +206,7 @@ function executeCodex(binary, args, timeout, workingDir = null) {
     const spawnOptions = {
       cwd: workingDir || process.cwd(),
       env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
     };
 
     const child = spawn(binary, args, spawnOptions);

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.9",
-  "lastUpdated": "2026-04-27T05:25:00.000Z",
+  "version": "0.4.10",
+  "lastUpdated": "2026-04-28T00:01:33.302Z",
   "components": [
     {
       "name": "rules",

--- a/tests/unit/core/codex-wrapper.test.ts
+++ b/tests/unit/core/codex-wrapper.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'bun';
+
+const WRAPPER = join(
+  import.meta.dir,
+  '../../../.codex/skills/codex-exec/scripts/codex-wrapper.cjs'
+);
+const TEMPLATE_WRAPPER = join(
+  import.meta.dir,
+  '../../../templates/.claude/skills/codex-exec/scripts/codex-wrapper.cjs'
+);
+
+const FAKE_CODEX = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const mode = process.env.FAKE_CODEX_MODE || 'success';
+
+function complete() {
+  if (mode === 'fail') {
+    process.stderr.write('synthetic codex failure\\n');
+    process.exit(17);
+  }
+
+  process.stderr.write('synthetic codex note\\n');
+
+  if (args.includes('--json')) {
+    process.stdout.write(
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          type: 'agent_message',
+          text: 'pong',
+        },
+      }) + '\\n'
+    );
+  } else {
+    process.stdout.write('pong\\n');
+  }
+
+  process.exit(0);
+}
+
+let ended = false;
+process.stdin.on('end', () => {
+  ended = true;
+  complete();
+});
+process.stdin.resume();
+
+setTimeout(() => {
+  if (!ended) {
+    process.stderr.write('stdin was not closed\\n');
+    process.exit(9);
+  }
+}, 200);
+`;
+
+interface WrapperResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runWrapper(extraEnv: Record<string, string> = {}): Promise<WrapperResult> {
+  const proc = spawn({
+    cmd: ['node', WRAPPER, '--prompt', 'Reply with exactly: pong', '--json', '--timeout', '5000'],
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('codex-wrapper.cjs', () => {
+  let tempDir: string;
+  let binDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'omcodex-codex-wrapper-test-'));
+    binDir = join(tempDir, 'bin');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(join(binDir, 'codex'), FAKE_CODEX);
+    await chmod(join(binDir, 'codex'), 0o755);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('closes child stdin when prompt mode is used and still parses JSON output', async () => {
+    const result = await runWrapper({
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.success).toBe(true);
+    expect(parsed.output).toBe('pong');
+    expect(parsed.events_count).toBe(1);
+    expect(result.stderr).toContain('[codex-wrapper] Executing codex with timeout: 5000ms');
+  });
+
+  it('preserves captured child stderr on failure', async () => {
+    const result = await runWrapper({
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_CODEX_MODE: 'fail',
+    });
+
+    expect(result.exitCode).toBe(17);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.success).toBe(false);
+    expect(parsed.exit_code).toBe(17);
+    expect(parsed.stderr).toContain('synthetic codex failure');
+    expect(parsed.stderr).not.toContain('stdin was not closed');
+  });
+
+  it('keeps the shipped template wrapper in sync with the live wrapper', async () => {
+    const [liveWrapper, templateWrapper] = await Promise.all([
+      readFile(WRAPPER, 'utf8'),
+      readFile(TEMPLATE_WRAPPER, 'utf8'),
+    ]);
+
+    expect(templateWrapper).toBe(liveWrapper);
+  });
+});

--- a/tests/unit/core/hooks-scripts.test.ts
+++ b/tests/unit/core/hooks-scripts.test.ts
@@ -19,7 +19,7 @@ const SOURCE_CLAUDE_SENSITIVE_PATH_GUARD_SCRIPT = join(
   SOURCE_SCRIPTS_DIR,
   'claude-sensitive-path-guard.sh'
 );
-const SESSION_ENV_CHECK_SCRIPT = join(SCRIPTS_DIR, 'session-env-check.sh');
+const SOURCE_SESSION_ENV_CHECK_SCRIPT = join(SOURCE_SCRIPTS_DIR, 'session-env-check.sh');
 const STALE_TODO_SCANNER_SCRIPT = join(SCRIPTS_DIR, 'stale-todo-scanner.sh');
 const FEEDBACK_COLLECTOR_SCRIPT = join(SCRIPTS_DIR, 'feedback-collector.sh');
 const SKILL_EXTRACTOR_ANALYZER_SCRIPT = join(SCRIPTS_DIR, 'skill-extractor-analyzer.sh');
@@ -1145,6 +1145,44 @@ describe('skill-extractor-analyzer.sh', () => {
 describe('session-env-check.sh', () => {
   const sessionInput = JSON.stringify({ event: 'session_start' });
 
+  async function createFakeCodexEnv(options?: { authFile?: boolean; codexApiKey?: boolean }) {
+    const baseDir = join(
+      tmpdir(),
+      `omcc-session-env-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    );
+    const fakeBinDir = join(baseDir, 'bin');
+    const fakeHomeDir = join(baseDir, 'home');
+    const fakeCodexHomeDir = join(baseDir, 'codex-home');
+    const fakeCodexPath = join(fakeBinDir, 'codex');
+
+    await mkdir(fakeBinDir, { recursive: true });
+    await mkdir(fakeHomeDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      '#!/bin/bash\nif [ "$1" = "--version" ]; then\n  echo "codex 0.0.0-test"\nfi\nexit 0\n'
+    );
+    execFileSync('chmod', ['+x', fakeCodexPath]);
+
+    if (options?.authFile) {
+      await mkdir(fakeCodexHomeDir, { recursive: true });
+      await writeFile(join(fakeCodexHomeDir, 'auth.json'), '{"provider":"chatgpt"}\n');
+    }
+
+    return {
+      baseDir,
+      env: {
+        PATH: `${fakeBinDir}:/usr/bin:/bin`,
+        HOME: fakeHomeDir,
+        CODEX_HOME: fakeCodexHomeDir,
+        OPENAI_API_KEY: '',
+        CODEX_API_KEY: options?.codexApiKey ? 'codex-api-key-test' : '',
+        GIT_DIR: '',
+        GIT_WORK_TREE: '',
+        GIT_INDEX_FILE: '',
+      },
+    };
+  }
+
   afterEach(() => {
     // Clean up status files created during tests.
     const { execSync } = require('node:child_process');
@@ -1158,48 +1196,48 @@ describe('session-env-check.sh', () => {
   // --- Basic pass-through behavior ---
 
   it('should always exit with code 0', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     expect(result.exitCode).toBe(0);
   });
 
   it('should pass stdin through to stdout', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     expect(result.stdout.trim()).toBe(sessionInput);
   });
 
   // --- Environment check output ---
 
   it('should output environment check header to stderr', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     expect(result.stderr).toContain('Session Environment Check');
   });
 
   it('should report codex CLI status in stderr', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     expect(result.stderr).toContain('codex CLI:');
   });
 
   it('should report Agent Teams status in stderr', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     expect(result.stderr).toContain('Agent Teams:');
   });
 
   it('should show Agent Teams disabled when env var is not set to 1', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput, {
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput, {
       OMCODEX_AGENT_TEAMS: '0',
     });
     expect(result.stderr).toContain('Agent Teams: disabled');
   });
 
   it('should show Agent Teams enabled when env var is 1', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput, {
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput, {
       OMCODEX_AGENT_TEAMS: '1',
     });
     expect(result.stderr).toContain('Agent Teams: enabled');
   });
 
   it('should show codex unavailable when binary is not in PATH', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput, {
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput, {
       PATH: '/usr/bin:/bin',
       OPENAI_API_KEY: '',
       // Unset git env vars that may be inherited from a parent hook context,
@@ -1211,8 +1249,46 @@ describe('session-env-check.sh', () => {
     expect(result.stderr).toContain('codex CLI: unavailable');
   });
 
+  it('should treat CODEX_API_KEY as authenticated when OPENAI_API_KEY is absent', async () => {
+    const { baseDir, env } = await createFakeCodexEnv({ codexApiKey: true });
+
+    try {
+      const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput, env);
+      expect(result.stderr).toContain('codex CLI: available (authenticated)');
+      expect(result.stderr).not.toContain('OPENAI_API_KEY not set');
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should treat stored auth as authenticated when OPENAI_API_KEY is absent', async () => {
+    const { baseDir, env } = await createFakeCodexEnv({ authFile: true });
+
+    try {
+      const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput, env);
+      expect(result.stderr).toContain('codex CLI: available (authenticated via stored login)');
+      expect(result.stderr).not.toContain('OPENAI_API_KEY not set');
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should mention codex login guidance when codex is installed without env auth', async () => {
+    const { baseDir, env } = await createFakeCodexEnv();
+
+    try {
+      const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput, env);
+      expect(result.stderr).toContain(
+        'codex CLI: installed (auth may be managed via `codex login`)'
+      );
+      expect(result.stderr).not.toContain('OPENAI_API_KEY not set');
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('should create a status file in /tmp', async () => {
-    await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     const { execSync } = require('node:child_process');
     // The file is named .claude-env-status-<PPID>; at least one must exist after the run.
     const output = execSync('ls /tmp/.codex-env-status-* 2>/dev/null || echo "none"')
@@ -1222,19 +1298,19 @@ describe('session-env-check.sh', () => {
   });
 
   it('should handle empty stdin gracefully', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, '');
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, '');
     expect(result.exitCode).toBe(0);
   });
 
   it('should handle arbitrary JSON stdin and pass it through', async () => {
     const input = JSON.stringify({ complex: { nested: true } });
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, input);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, input);
     expect(result.stdout.trim()).toBe(input);
     expect(result.exitCode).toBe(0);
   });
 
   it('should report both codex CLI and Agent Teams statuses in a single run', async () => {
-    const result = await runHookScript(SESSION_ENV_CHECK_SCRIPT, sessionInput);
+    const result = await runHookScript(SOURCE_SESSION_ENV_CHECK_SCRIPT, sessionInput);
     const stderrLines = result.stderr.split('\n');
     const codexLine = stderrLines.find((l) => l.includes('codex CLI:'));
     const teamsLine = stderrLines.find((l) => l.includes('Agent Teams:'));


### PR DESCRIPTION
## Summary
- recognize CODEX_API_KEY and stored `codex login` auth in the session env hook
- update codex-exec guidance away from OPENAI_API_KEY-only checks
- close codex-wrapper stdin for prompt-mode `codex exec --json` so current Codex CLI does not wait for appended stdin
- add focused regressions for Codex auth detection and wrapper stdin handling

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test` (1768 pass, 0 fail)
- `node .codex/skills/codex-exec/scripts/codex-wrapper.cjs --prompt "Reply with exactly: pong" --json --timeout 60000`
- `codex --version` -> `codex-cli 0.125.0`
- `npm view @openai/codex version` -> `0.125.0`

Closes #1068
Closes #1074
Closes #1216