### PR TITLE
fix: port auto-dev observability guardrails

### DIFF
--- a/.codex/agents/mgr-gitnerd.md
+++ b/.codex/agents/mgr-gitnerd.md
@@ -19,6 +19,10 @@ tools:
 permissionMode: bypassPermissions
 ---
 
+## Mandatory Sensitive Compatibility Paths
+
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+
 You are a Git operations specialist following GitHub flow best practices.
 
 ## Capabilities

--- a/.codex/agents/wiki-curator.md
+++ b/.codex/agents/wiki-curator.md
@@ -14,6 +14,10 @@ memory: project
 permissionMode: bypassPermissions
 ---
 
+## Mandatory Sensitive Compatibility Paths
+
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+
 # Wiki Curator
 
 Dedicated agent for wiki file operations. All wiki/ directory writes go through this agent per R010 delegation rules.

--- a/.codex/hooks/hooks.json
+++ b/.codex/hooks/hooks.json
@@ -499,6 +499,16 @@
           }
         ],
         "description": "Advisory reminder to sync skill counts in 6 locations when a SKILL.md is created/modified (R021)"
+      },
+      {
+        "matcher": "tool == \"Task\" || tool == \"Agent\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/auto-dev-token-tracker.sh"
+          }
+        ],
+        "description": "Advisory auto-dev token spend tracking by phase"
       }
     ],
     "Stop": [
@@ -511,6 +521,16 @@
           }
         ],
         "description": "Final console.log audit and session diagnostics before session ends"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/auto-dev-token-summary.sh"
+          }
+        ],
+        "description": "Print advisory auto-dev token spend summary when available"
       },
       {
         "matcher": "*",

--- a/.codex/hooks/scripts/auto-dev-token-summary.sh
+++ b/.codex/hooks/scripts/auto-dev-token-summary.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# auto-dev token spend summary.
+# Trigger: Stop event.
+# Protocol: stdin pass-through, stderr advisory summary, exit 0.
+
+input=$(cat 2>/dev/null || true)
+trap 'printf "%s" "$input"' EXIT
+
+LOG_FILE="${AUTO_DEV_SPEND_LOG:-/tmp/auto-dev-spend-${PPID}.json}"
+[ -s "$LOG_FILE" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+summary=$(jq -s -r '
+  group_by(.phase)
+  | map({
+      phase: .[0].phase,
+      calls: length,
+      tokens_in: (map(.tokens_in) | add),
+      tokens_out: (map(.tokens_out) | add),
+      total: (map(.tokens_in + .tokens_out) | add)
+    })
+  | sort_by(-.total)
+' "$LOG_FILE" 2>/dev/null) || exit 0
+
+[ -z "$summary" ] && exit 0
+[ "$summary" = "[]" ] && exit 0
+
+totals=$(printf "%s" "$summary" | jq -r '
+  {
+    total_calls: (map(.calls) | add),
+    total_in: (map(.tokens_in) | add),
+    total_out: (map(.tokens_out) | add),
+    grand: (map(.total) | add)
+  }
+')
+total_calls=$(printf "%s" "$totals" | jq -r '.total_calls')
+total_in=$(printf "%s" "$totals" | jq -r '.total_in')
+total_out=$(printf "%s" "$totals" | jq -r '.total_out')
+grand=$(printf "%s" "$totals" | jq -r '.grand')
+
+{
+  echo ""
+  echo "=== [auto-dev Token Spend Summary] advisory ==="
+  echo "Source: $LOG_FILE | heuristic: bytes / 4"
+  echo ""
+  printf "| %-32s | %5s | %10s | %10s | %10s |\n" "Phase" "Calls" "Tokens In" "Tokens Out" "Total"
+  printf "| %-32s | %5s | %10s | %10s | %10s |\n" "--------------------------------" "-----" "----------" "----------" "----------"
+  printf "%s" "$summary" | jq -r '.[] | "\(.phase)\t\(.calls)\t\(.tokens_in)\t\(.tokens_out)\t\(.total)"' | \
+    while IFS=$'\t' read -r phase calls tin tout tot; do
+      phase_trunc=$(printf "%s" "$phase" | head -c 32)
+      printf "| %-32s | %5s | %10s | %10s | %10s |\n" "$phase_trunc" "$calls" "$tin" "$tout" "$tot"
+    done
+  printf "| %-32s | %5s | %10s | %10s | %10s |\n" "TOTAL" "$total_calls" "$total_in" "$total_out" "$grand"
+  echo ""
+  echo "Note: Estimates only. Prefer exact runtime usage events when available."
+  echo "================================================"
+  echo ""
+} >&2
+
+exit 0

--- a/.codex/hooks/scripts/auto-dev-token-tracker.sh
+++ b/.codex/hooks/scripts/auto-dev-token-tracker.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# auto-dev token spend tracker.
+# Trigger: PostToolUse on Agent/Task during auto-dev pipeline.
+# Protocol: stdin JSON -> append JSONL estimate -> stdout pass-through, exit 0.
+
+input=$(cat)
+trap 'printf "%s" "$input"' EXIT
+
+PIPELINE_STATE="${AUTO_DEV_PIPELINE_STATE:-/tmp/.codex-pipeline-auto-dev-${PPID}.json}"
+[ -f "$PIPELINE_STATE" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+LOG_FILE="${AUTO_DEV_SPEND_LOG:-/tmp/auto-dev-spend-${PPID}.json}"
+
+agent_type=$(printf "%s" "$input" | jq -r '.tool_input.subagent_type // .tool_input.agent_type // "unknown"' 2>/dev/null || echo "unknown")
+description=$(printf "%s" "$input" | jq -r '.tool_input.description // ""' 2>/dev/null || echo "")
+prompt_text=$(printf "%s" "$input" | jq -r '.tool_input.prompt // .tool_input.message // ""' 2>/dev/null || echo "")
+output_text=$(printf "%s" "$input" | jq -r '.tool_output.output // .tool_output // ""' 2>/dev/null || echo "")
+
+phase=$(jq -r '.current_phase // .phase // "unknown"' "$PIPELINE_STATE" 2>/dev/null || echo "unknown")
+if [ "$phase" = "unknown" ] || [ "$phase" = "null" ]; then
+  phase=$(printf "%s" "$description" | grep -oE '^\[[0-9]+\][^|]*' | head -c 40 || true)
+  [ -z "$phase" ] && phase=$(printf "%s" "$description" | head -c 30)
+  [ -z "$phase" ] && phase="unknown"
+fi
+
+in_bytes=$(printf "%s" "$prompt_text" | wc -c | tr -d ' ')
+out_bytes=$(printf "%s" "$output_text" | wc -c | tr -d ' ')
+tokens_in=$((in_bytes / 4))
+tokens_out=$((out_bytes / 4))
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+entry=$(jq -n -c \
+  --arg ts "$ts" \
+  --arg phase "$phase" \
+  --arg agent "$agent_type" \
+  --argjson tin "$tokens_in" \
+  --argjson tout "$tokens_out" \
+  '{ts: $ts, phase: $phase, agent: $agent, tokens_in: $tin, tokens_out: $tout}' 2>/dev/null) || exit 0
+
+printf "%s\n" "$entry" >> "$LOG_FILE" 2>/dev/null || true
+
+exit 0

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.10",
-  "generatedAt": "2026-04-28T00:01:33.392Z",
-  "templateVersion": "0.4.10",
+  "generatorVersion": "0.4.11",
+  "generatedAt": "2026-04-28T00:25:35.637Z",
+  "templateVersion": "0.4.11",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -130,8 +130,8 @@
       "component": "agents"
     },
     ".codex/agents/wiki-curator.md": {
-      "templateHash": "eb5f20a3d5450bf05afcfc8ac4a51936e9fa7a8a1fdd442e05416ca811415dde",
-      "size": 2296,
+      "templateHash": "377a69c33f595329ec95fe7a7cc12a2cc362686eed2d01de1ab3dead693bac3e",
+      "size": 2696,
       "component": "agents"
     },
     ".codex/agents/arch-speckit-agent.md": {
@@ -290,8 +290,8 @@
       "component": "agents"
     },
     ".codex/agents/mgr-gitnerd.md": {
-      "templateHash": "ed56f3571a9f181580803bfb3e0090b0d53645c8371c2aff93e0bf51ebc34c43",
-      "size": 1254,
+      "templateHash": "146c62dd16de102a0cfd6cff8960b6e83922ccd2e07255467d89d859dac3d791",
+      "size": 1654,
       "component": "agents"
     },
     ".codex/agents/mgr-creator.md": {
@@ -419,6 +419,11 @@
       "size": 721,
       "component": "hooks"
     },
+    ".codex/hooks/scripts/auto-dev-token-summary.sh": {
+      "templateHash": "0c2ab04344f1320752bda46b7b71b472b6860a4b5453ca04c56239eccfe1b9c7",
+      "size": 2117,
+      "component": "hooks"
+    },
     ".codex/hooks/scripts/omcustom-auto-update.sh": {
       "templateHash": "e4f7a36be85d927a8e070b313554e56834fe9bce986ecb93f2234324640643aa",
       "size": 5612,
@@ -442,6 +447,11 @@
     ".codex/hooks/scripts/model-escalation-advisor.sh": {
       "templateHash": "986b6269a9cc866af97218dfa2aee017da524f41e8e703828f3d800ebd6a161e",
       "size": 3054,
+      "component": "hooks"
+    },
+    ".codex/hooks/scripts/auto-dev-token-tracker.sh": {
+      "templateHash": "ce6202a56d3e7b98cb088c7a6f5b6f6041a4c1d27c6ff268a10294841e98ecd4",
+      "size": 1864,
       "component": "hooks"
     },
     ".codex/hooks/scripts/schema-validator.sh": {
@@ -555,8 +565,8 @@
       "component": "hooks"
     },
     ".codex/hooks/hooks.json": {
-      "templateHash": "fc20d40f837382cbdc5f472060953cf4a080cf45e3e4e5bf2e5782ea268f2eb9",
-      "size": 26493,
+      "templateHash": "0bbff7e9d7b3a005fd8d581af31bb63ca836852a68140d4b1fcc9d2349d479e7",
+      "size": 27092,
       "component": "hooks"
     },
     ".codex/contexts/ecomode.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/mgr-gitnerd.md
+++ b/templates/.claude/agents/mgr-gitnerd.md
@@ -19,6 +19,10 @@ tools:
 permissionMode: bypassPermissions
 ---
 
+## Mandatory Sensitive Compatibility Paths
+
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+
 You are a Git operations specialist following GitHub flow best practices.
 
 ## Capabilities

--- a/templates/.claude/agents/wiki-curator.md
+++ b/templates/.claude/agents/wiki-curator.md
@@ -14,6 +14,10 @@ memory: project
 permissionMode: bypassPermissions
 ---
 
+## Mandatory Sensitive Compatibility Paths
+
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+
 # Wiki Curator
 
 Dedicated agent for wiki file operations. All wiki/ directory writes go through this agent per R010 delegation rules.

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -499,6 +499,16 @@
           }
         ],
         "description": "Advisory reminder to sync skill counts in 6 locations when a SKILL.md is created/modified (R021)"
+      },
+      {
+        "matcher": "tool == \"Task\" || tool == \"Agent\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/auto-dev-token-tracker.sh"
+          }
+        ],
+        "description": "Advisory auto-dev token spend tracking by phase"
       }
     ],
     "Stop": [
@@ -511,6 +521,16 @@
           }
         ],
         "description": "Final console.log audit and session diagnostics before session ends"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/auto-dev-token-summary.sh"
+          }
+        ],
+        "description": "Print advisory auto-dev token spend summary when available"
       },
       {
         "matcher": "*",

--- a/templates/.claude/hooks/scripts/auto-dev-token-summary.sh
+++ b/templates/.claude/hooks/scripts/auto-dev-token-summary.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# auto-dev token spend summary.
+# Trigger: Stop event.
+# Protocol: stdin pass-through, stderr advisory summary, exit 0.
+
+input=$(cat 2>/dev/null || true)
+trap 'printf "%s" "$input"' EXIT
+
+LOG_FILE="${AUTO_DEV_SPEND_LOG:-/tmp/auto-dev-spend-${PPID}.json}"
+[ -s "$LOG_FILE" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+summary=$(jq -s -r '
+  group_by(.phase)
+  | map({
+      phase: .[0].phase,
+      calls: length,
+      tokens_in: (map(.tokens_in) | add),
+      tokens_out: (map(.tokens_out) | add),
+      total: (map(.tokens_in + .tokens_out) | add)
+    })
+  | sort_by(-.total)
+' "$LOG_FILE" 2>/dev/null) || exit 0
+
+[ -z "$summary" ] && exit 0
+[ "$summary" = "[]" ] && exit 0
+
+totals=$(printf "%s" "$summary" | jq -r '
+  {
+    total_calls: (map(.calls) | add),
+    total_in: (map(.tokens_in) | add),
+    total_out: (map(.tokens_out) | add),
+    grand: (map(.total) | add)
+  }
+')
+total_calls=$(printf "%s" "$totals" | jq -r '.total_calls')
+total_in=$(printf "%s" "$totals" | jq -r '.total_in')
+total_out=$(printf "%s" "$totals" | jq -r '.total_out')
+grand=$(printf "%s" "$totals" | jq -r '.grand')
+
+{
+  echo ""
+  echo "=== [auto-dev Token Spend Summary] advisory ==="
+  echo "Source: $LOG_FILE | heuristic: bytes / 4"
+  echo ""
+  printf "| %-32s | %5s | %10s | %10s | %10s |\n" "Phase" "Calls" "Tokens In" "Tokens Out" "Total"
+  printf "| %-32s | %5s | %10s | %10s | %10s |\n" "--------------------------------" "-----" "----------" "----------" "----------"
+  printf "%s" "$summary" | jq -r '.[] | "\(.phase)\t\(.calls)\t\(.tokens_in)\t\(.tokens_out)\t\(.total)"' | \
+    while IFS=$'\t' read -r phase calls tin tout tot; do
+      phase_trunc=$(printf "%s" "$phase" | head -c 32)
+      printf "| %-32s | %5s | %10s | %10s | %10s |\n" "$phase_trunc" "$calls" "$tin" "$tout" "$tot"
+    done
+  printf "| %-32s | %5s | %10s | %10s | %10s |\n" "TOTAL" "$total_calls" "$total_in" "$total_out" "$grand"
+  echo ""
+  echo "Note: Estimates only. Prefer exact runtime usage events when available."
+  echo "================================================"
+  echo ""
+} >&2
+
+exit 0

--- a/templates/.claude/hooks/scripts/auto-dev-token-tracker.sh
+++ b/templates/.claude/hooks/scripts/auto-dev-token-tracker.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# auto-dev token spend tracker.
+# Trigger: PostToolUse on Agent/Task during auto-dev pipeline.
+# Protocol: stdin JSON -> append JSONL estimate -> stdout pass-through, exit 0.
+
+input=$(cat)
+trap 'printf "%s" "$input"' EXIT
+
+PIPELINE_STATE="${AUTO_DEV_PIPELINE_STATE:-/tmp/.codex-pipeline-auto-dev-${PPID}.json}"
+[ -f "$PIPELINE_STATE" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+LOG_FILE="${AUTO_DEV_SPEND_LOG:-/tmp/auto-dev-spend-${PPID}.json}"
+
+agent_type=$(printf "%s" "$input" | jq -r '.tool_input.subagent_type // .tool_input.agent_type // "unknown"' 2>/dev/null || echo "unknown")
+description=$(printf "%s" "$input" | jq -r '.tool_input.description // ""' 2>/dev/null || echo "")
+prompt_text=$(printf "%s" "$input" | jq -r '.tool_input.prompt // .tool_input.message // ""' 2>/dev/null || echo "")
+output_text=$(printf "%s" "$input" | jq -r '.tool_output.output // .tool_output // ""' 2>/dev/null || echo "")
+
+phase=$(jq -r '.current_phase // .phase // "unknown"' "$PIPELINE_STATE" 2>/dev/null || echo "unknown")
+if [ "$phase" = "unknown" ] || [ "$phase" = "null" ]; then
+  phase=$(printf "%s" "$description" | grep -oE '^\[[0-9]+\][^|]*' | head -c 40 || true)
+  [ -z "$phase" ] && phase=$(printf "%s" "$description" | head -c 30)
+  [ -z "$phase" ] && phase="unknown"
+fi
+
+in_bytes=$(printf "%s" "$prompt_text" | wc -c | tr -d ' ')
+out_bytes=$(printf "%s" "$output_text" | wc -c | tr -d ' ')
+tokens_in=$((in_bytes / 4))
+tokens_out=$((out_bytes / 4))
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+entry=$(jq -n -c \
+  --arg ts "$ts" \
+  --arg phase "$phase" \
+  --arg agent "$agent_type" \
+  --argjson tin "$tokens_in" \
+  --argjson tout "$tokens_out" \
+  '{ts: $ts, phase: $phase, agent: $agent, tokens_in: $tin, tokens_out: $tout}' 2>/dev/null) || exit 0
+
+printf "%s\n" "$entry" >> "$LOG_FILE" 2>/dev/null || true
+
+exit 0

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lastUpdated": "2026-04-28T00:01:33.302Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- add auto-dev token-spend tracker and Stop summary hooks in Codex-native and template hook trees
- add missing sensitive compatibility path guidance to mgr-gitnerd and wiki-curator mirrors
- bump package/template version to 0.4.11 for release

## Upstream Port Coverage
- Closes #1164
- Closes #1165
- Closes #1162 (already satisfied by existing Codex-native ontology-rag setup; verified during this port pass)
- Closes #1166 (already satisfied by existing memory unification docs; verified during this port pass)

## Verification
- bun install
- hook smoke for auto-dev token tracker and summary
- jq empty .codex/hooks/hooks.json templates/.claude/hooks/hooks.json
- bash -n auto-dev token hook scripts
- bun run lint
- bun run typecheck
- bun run build
- bun test tests/unit/core/hooks-validation.test.ts tests/unit/core/hooks-scripts.test.ts tests/unit/core/sensitive-output-guidance.test.ts
- bun test (1768 pass, 0 fail)

## Notes
- Stop hook ordering intentionally keeps stop-console-audit first because hooks-validation asserts that contract.
- The token-spend hook is advisory and gated on auto-dev pipeline state; missing data never blocks a release.