### PR TITLE
fix: gate release manifest sync and retire legacy bypass

### DIFF
--- a/.codex/agents/mgr-claude-code-bible.md
+++ b/.codex/agents/mgr-claude-code-bible.md
@@ -18,7 +18,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are the authoritative source of truth for Claude Code specifications. You fetch official documentation from code.claude.com and validate the project against official specs.
 

--- a/.codex/agents/mgr-creator.md
+++ b/.codex/agents/mgr-creator.md
@@ -21,7 +21,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are an agent creation specialist following R006 (MUST-agent-design.md) rules.
 

--- a/.codex/agents/mgr-gitnerd.md
+++ b/.codex/agents/mgr-gitnerd.md
@@ -21,7 +21,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are a Git operations specialist following GitHub flow best practices.
 

--- a/.codex/agents/mgr-sauron.md
+++ b/.codex/agents/mgr-sauron.md
@@ -20,7 +20,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are an automated verification specialist that executes the mandatory R017 verification process, acting as the "all-seeing eye" that ensures system integrity through comprehensive multi-round verification.
 

--- a/.codex/agents/mgr-supplier.md
+++ b/.codex/agents/mgr-supplier.md
@@ -21,7 +21,7 @@ permissionMode: default
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are a dependency validation specialist ensuring agents have all required skills and guides properly linked.
 

--- a/.codex/agents/mgr-updater.md
+++ b/.codex/agents/mgr-updater.md
@@ -24,7 +24,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are an external source synchronization specialist keeping external components up-to-date.
 

--- a/.codex/agents/sys-memory-keeper.md
+++ b/.codex/agents/sys-memory-keeper.md
@@ -25,7 +25,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are a session memory management specialist ensuring context survives across session compactions using claude-mem.
 

--- a/.codex/agents/sys-naggy.md
+++ b/.codex/agents/sys-naggy.md
@@ -20,7 +20,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are a task management specialist that proactively manages TODO items and reminds users of pending tasks.
 

--- a/.codex/agents/tracker-checkpoint.md
+++ b/.codex/agents/tracker-checkpoint.md
@@ -12,7 +12,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 # Tracker Checkpoint Agent
 

--- a/.codex/agents/wiki-curator.md
+++ b/.codex/agents/wiki-curator.md
@@ -16,7 +16,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 # Wiki Curator
 

--- a/.codex/rules/MUST-agent-design.md
+++ b/.codex/rules/MUST-agent-design.md
@@ -243,34 +243,39 @@ Skills persist output to `.codex/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HHm
 
 ## Sensitive Path Handling
 
-Claude Code treats `.claude/` and `templates/.claude/` as sensitive directories across Bash, Write, and Edit operations. The sensitive-path check runs above `bypassPermissions` and explicit allow rules, so allow rules do not override the sensitive-path check.
+Claude Code still treats `.claude/` and `templates/.claude/` as protected compatibility surfaces, but the current behavior is version-sensitive rather than a universal prompt wall.
 
-This Codex port uses `.codex/` as the active runtime surface, but packaged compatibility templates still live under `templates/.claude/`. Any automation that writes those templates must account for Claude Code permission prompts.
+This Codex port uses `.codex/` as the active runtime surface. `.codex/**` edits should use the normal Codex edit/patch flow with no Claude-only `/tmp` wrapper.
 
-**Key rule**: `.claude/` and `templates/.claude/` Bash/Write/Edit targets can trigger sensitive-path prompts regardless of allow rules. In unattended flows, delegated agents must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct `.claude/**` tool targets.
+**Current compatibility rule**:
+
+- **CC v2.1.121+**: `bypassPermissions` no longer prompts for direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- **CC v2.1.126+**: `bypassPermissions` also bypasses prompts for broader protected paths such as `.claude/**`, `.git/**`, `.vscode/**`, and shell config files.
+- **Historical fallback only**: if the target runtime is older than v2.1.121, not running with `bypassPermissions`, or still surfaces a protected-path prompt, use `/tmp/{skill}-{timestamp}.md` only as a compatibility fallback for the final `.claude/**` or `templates/.claude/**` write.
 
 <!-- DETAIL: Sensitive Path Behavior table and Recommended practice
-| Path pattern | Sensitive in Claude Code? | Affected operations |
-|--------------|---------------------------|---------------------|
-| `.claude/**` | Yes | Bash writes, Write, Edit |
-| `templates/.claude/**` | Yes | Bash writes, Write, Edit |
-| `.codex/**` | No | Normal Codex runtime writes; still follow R010/R017 |
-| `.codex/outputs/**` and `.claude/outputs/**` | Treat as constrained artifact paths | Use file-write APIs that create parents; do not pre-create with Bash |
+| Path pattern | Guidance |
+|--------------|----------|
+| `.claude/skills/**`, `.claude/agents/**`, `.claude/commands/**` | Direct writes are acceptable in Claude Code `bypassPermissions` on v2.1.121+ |
+| `.claude/**`, `.git/**`, `.vscode/**`, shell config files | Direct writes are acceptable in Claude Code `bypassPermissions` on v2.1.126+ |
+| `templates/.claude/**` | Mirror deliberately; use the historical `/tmp` fallback only when the runtime still prompts |
+| `.codex/**` | Normal Codex runtime writes; still follow R010/R017 |
+| `.codex/outputs/**` and `.claude/outputs/**` | Treat as constrained artifact paths; use file-write APIs that create parents and do not pre-create with Bash |
 
 Recommended practice:
 
-1. Prefer Write/Edit in an interactive session, or managed sync/update paths, over Bash copy/mkdir/tee writes for `.claude/` and `templates/.claude/`.
-2. Keep allow rules only as defensive documentation; do not rely on them to suppress sensitive-path prompts.
-3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
-4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
-5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
+1. Prefer direct Write/Edit for `.codex/**` and for compatible `.claude/**` targets when the runtime version and permission mode allow it.
+2. Keep allow rules only as defensive documentation; current behavior depends on Claude Code version and permission mode, not allow-rule wishful thinking.
+3. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
+4. Use the historical `/tmp` artifact-body fallback only for legacy Claude Code versions or sessions that still prompt on protected paths.
+5. When compatibility-template writes still require a fallback, verify the resulting diff and remove stale wrapper boilerplate from repeated prompts.
 -->
 
 Delegation prompt requirement:
 
-Any prompt that delegates work involving `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths MUST include this block verbatim:
+Delegated prompts touching `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths MUST include this block:
 
-> Sensitive-path artifact protocol (mandatory): do not ask a subagent to call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` paths. If Claude compatibility artifacts are required, have the subagent produce the artifact body in `/tmp/{skill}-{timestamp}.md`, then use a reviewed temporary script wrapper or managed file-write API for the final checked-in path. Do not use direct Write/Edit/Bash targets under `.claude/**` in unattended flows.
+> Sensitive-path compatibility note: Codex-managed `.codex/**` edits use the normal edit/patch flow. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that also extends to broader protected paths such as `.claude/**`, `.git/**`, and `.vscode/**`. Only fall back to `/tmp/{skill}-{timestamp}.md` when the target runtime is older than v2.1.121, not running with `bypassPermissions`, or still surfaces a protected-path prompt.
 
 ## Separation of Concerns
 

--- a/.codex/rules/MUST-orchestrator-coordination.md
+++ b/.codex/rules/MUST-orchestrator-coordination.md
@@ -147,6 +147,19 @@ Key violations to avoid (file writes, git commands, bundled operations — all m
 ```
 -->
 
+## Historical Sensitive-Path Bypass
+
+**Status**: deprecated as of Claude Code v2.1.121 for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; fully deprecated in `bypassPermissions` as of v2.1.126 for broader protected paths.
+
+Older guidance sometimes required a universal `/tmp` artifact-wrapper flow before touching Claude compatibility paths. Do not use that as the default in this Codex-native port.
+
+Current guidance:
+
+- Edit `.codex/**` directly with the normal Codex edit/patch flow.
+- In Claude Code `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are acceptable on v2.1.121+.
+- In Claude Code `bypassPermissions`, broader protected-path writes such as `.claude/**`, `.git/**`, and `.vscode/**` are acceptable on v2.1.126+.
+- Keep the `/tmp/{skill}-{timestamp}.md` pattern only as a legacy fallback for older Claude Code versions or sessions that still surface a protected-path prompt.
+
 <!-- DETAIL: Autonomous Execution Mode
 
 ## Autonomous Execution Mode

--- a/.codex/rules/MUST-permissions.md
+++ b/.codex/rules/MUST-permissions.md
@@ -21,6 +21,21 @@
 | Write | Source code, new files in project | .env, .git/config, paths outside project |
 | Delete | Temp files created by agent | Existing files (without request), entire directories |
 
+## Claude Code Protected-Path Compatibility
+
+Codex-native `.codex/**` edits are normal project writes and do not require the historical Claude-only `/tmp` bypass pattern.
+
+Claude Code compatibility behavior changed in two steps:
+
+- **CC v2.1.121+**: `--dangerously-skip-permissions` / `bypassPermissions` no longer prompts for writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- **CC v2.1.126+**: the same mode also bypasses prompts for broader protected paths such as `.claude/**`, `.git/**`, `.vscode/**`, and shell config files.
+
+Current guidance:
+
+- Prefer direct Write/Edit/Bash targets for `.codex/**`.
+- For `.claude/**` or `templates/.claude/**`, direct writes are acceptable when the target Claude Code runtime is new enough and the session is running with `bypassPermissions`.
+- Treat the old `/tmp/{skill}-{timestamp}.md` wrapper flow as a historical fallback only for older Claude Code versions, non-bypass sessions, or interactive runs that still surface a protected-path prompt.
+
 ## Permission Request Format
 
 ```

--- a/.codex/skills/action-validator/SKILL.md
+++ b/.codex/skills/action-validator/SKILL.md
@@ -109,7 +109,7 @@ When a synthesized harness exists for an agent (`.codex/outputs/harnesses/{agent
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/action-validator-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 
 | Mode | Source | Behavior |

--- a/.codex/skills/adaptive-harness/SKILL.md
+++ b/.codex/skills/adaptive-harness/SKILL.md
@@ -187,7 +187,7 @@ Append a record to `.codex/outputs/harness-adaptations/YYYY-MM-DD.md`:
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/adaptive-harness-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 
 ```markdown

--- a/.codex/skills/agora/SKILL.md
+++ b/.codex/skills/agora/SKILL.md
@@ -25,7 +25,7 @@ source:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/codex-exec/SKILL.md
+++ b/.codex/skills/codex-exec/SKILL.md
@@ -182,7 +182,7 @@ When the orchestrator or intent-detection detects a research/information gatheri
 
 When routing skills detect a code generation task and codex is available:
 
-1. **Check availability**: Verify codex CLI via `/tmp/.codex-env-status-*`
+1. **Check availability**: Verify the codex CLI directly (`command -v codex`) or via current session diagnostics
 2. **If available + new file creation**: Suggest hybrid workflow
 3. **Hybrid pattern**:
    - codex-exec generates initial code (fast, broad generation)

--- a/.codex/skills/dag-orchestration/SKILL.md
+++ b/.codex/skills/dag-orchestration/SKILL.md
@@ -86,7 +86,7 @@ config:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Execution Rules
 

--- a/.codex/skills/de-lead-routing/SKILL.md
+++ b/.codex/skills/de-lead-routing/SKILL.md
@@ -221,7 +221,7 @@ Delegate to mgr-creator with context:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/deep-plan/SKILL.md
+++ b/.codex/skills/deep-plan/SKILL.md
@@ -50,18 +50,18 @@ Research-validated planning that eliminates the gap between research assumptions
 | `/structured-dev-cycle` | Implementation pipeline | Yes, stage by stage |
 | `/deep-plan` | Analysis + planning + verification | Yes, 3-pass cross-verification |
 
-## Sensitive-path artifact protocol (mandatory)
+## Sensitive-path compatibility note
 
 Codex-native verification artifacts go under `.codex/outputs/sessions/YYYY-MM-DD/deep-plan-HHmmss.md` and may be written with the repo's normal file-write APIs.
 
-If any research, planning, or verification delegate must touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block verbatim in that delegate prompt:
+If any research, planning, or verification delegate must touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block in that delegate prompt:
 
 ```text
-Sensitive-path artifact protocol (mandatory):
-1. Build the artifact body in /tmp first, for example /tmp/deep-plan-<timestamp>.md.
-2. If the final target is under .claude/** or templates/.claude/**, create and execute a /tmp/*.sh script that copies or writes the /tmp artifact to the final path.
-3. Do not call Read, Bash, Write, or Edit directly on .claude/** or templates/.claude/** in unattended flows.
-4. Verify the final file through the least sensitive available path and report the exact artifact path.
+Sensitive-path compatibility note:
+1. Keep Codex-native .codex/** artifacts on the normal file-write path.
+2. On Claude Code v2.1.121+ with bypassPermissions, direct writes to .claude/skills/, .claude/agents/, and .claude/commands/ are allowed.
+3. On Claude Code v2.1.126+ with bypassPermissions, broader protected paths such as .claude/**, .git/**, and .vscode/** are also covered.
+4. Use /tmp/deep-plan-<timestamp>.md only as a legacy fallback when the runtime is older or still prompts, then verify the resulting diff.
 ```
 
 The protocol must be copied into delegate prompts. A parent-only mention is insufficient because forked contexts can lose the directive.

--- a/.codex/skills/deep-verify/SKILL.md
+++ b/.codex/skills/deep-verify/SKILL.md
@@ -73,7 +73,7 @@ Each agent receives the full diff and returns findings as structured JSON:
 - Verify all changes align with project's compilation metaphor (Skills=source, Agents=artifacts, Rules=spec)
 - Check separation of concerns: no agents containing skill logic, no skills with agent definitions
 - Verify orchestrator rules: no new file writes from orchestrator context
-- Verify sensitive-path delegation: prompts that touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**` include the exact phrase `Sensitive-path artifact protocol (mandatory)`, require an explicit `/tmp/{skill}-{timestamp}.md` artifact body path, mention `Read, Bash, Write, or Edit` coverage, and do not rely on a single vague `/tmp` recommendation
+- Verify sensitive-path compatibility: prompts that touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**` include the `Sensitive-path compatibility note`, keep `.codex/**` artifacts on the normal file-write path, and treat `/tmp/{skill}-{timestamp}.md` only as a legacy fallback for older Claude Code versions or sessions that still prompt
 - Check advisory-first: no new hard-blocking hooks introduced
 - Confirm no feature regressions: existing APIs preserved, test coverage maintained
 - Performance sanity: no O(n^2) on large datasets, no missing indexes for new queries

--- a/.codex/skills/dev-lead-routing/SKILL.md
+++ b/.codex/skills/dev-lead-routing/SKILL.md
@@ -10,7 +10,7 @@ context: fork
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Engineers
 

--- a/.codex/skills/dev-review/SKILL.md
+++ b/.codex/skills/dev-review/SKILL.md
@@ -116,7 +116,7 @@ If only PASS/INFO: proceed automatically.
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/dev-review-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
    ```
    With metadata header:

--- a/.codex/skills/hada-scout/SKILL.md
+++ b/.codex/skills/hada-scout/SKILL.md
@@ -15,7 +15,7 @@ high-scoring candidates.
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Purpose
 

--- a/.codex/skills/harness-eval/SKILL.md
+++ b/.codex/skills/harness-eval/SKILL.md
@@ -16,7 +16,7 @@ Evaluate agent quality using 15 structured software engineering task definitions
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/harness-synthesizer/SKILL.md
+++ b/.codex/skills/harness-synthesizer/SKILL.md
@@ -96,7 +96,7 @@ harness:
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/harness-synthesizer-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 3. **Synthesize validation harness** — generate YAML harness matching agent's declared capabilities
 4. **Refine via evaluator-optimizer loop** — iterate harness against edge cases (3 rounds max)

--- a/.codex/skills/omcodex-improve-report/SKILL.md
+++ b/.codex/skills/omcodex-improve-report/SKILL.md
@@ -15,7 +15,7 @@ Surface actionable improvement suggestions gathered by the eval-core analysis en
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/omcodex-takeover/SKILL.md
+++ b/.codex/skills/omcodex-takeover/SKILL.md
@@ -16,7 +16,7 @@ When an agent or skill has evolved organically without a formal spec, `omcodex:t
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/optimize-analyze/SKILL.md
+++ b/.codex/skills/optimize-analyze/SKILL.md
@@ -24,7 +24,7 @@ target           Build output path or project root (optional, auto-detects)
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Workflow
 

--- a/.codex/skills/optimize-report/SKILL.md
+++ b/.codex/skills/optimize-report/SKILL.md
@@ -20,7 +20,7 @@ Generate comprehensive optimization report with analysis, metrics, and recommend
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Workflow
 

--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -95,9 +95,9 @@ steps:
       - Issues whose prerequisites failed in-run MUST be skipped (log reason)
       - No direct orchestrator writes (R010)
       - Codex-managed `.codex/` edits use the normal edit/patch flow
-      - Do not adopt upstream Claude-only `/tmp` bypass guidance as the default Codex path
+      - Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path writes available on v2.1.126+
       - If `.claude` template parity changes are required, make them explicit and verify sensitive-path guard tests
-      - Sensitive-path artifact protocol (mandatory): delegated prompts that touch `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurements of those paths must instruct the subagent to produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct Read/Bash/Write/Edit targets under `.claude/**` in unattended flows
+      - Use `/tmp/{skill}-{timestamp}.md` only as a historical fallback for older Claude Code versions, non-bypass sessions, or runs that still surface a protected-path prompt
     description: "Per-issue implementation with lifecycle and specialist routing"
     depends_on: deep-plan
 

--- a/.codex/skills/post-release-followup/SKILL.md
+++ b/.codex/skills/post-release-followup/SKILL.md
@@ -27,7 +27,7 @@ Gather unfinished work from multiple sources:
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/post-release-followup-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 - Extract any MEDIUM or LOW severity findings that were flagged but not fixed
 

--- a/.codex/skills/professor-triage/SKILL.md
+++ b/.codex/skills/professor-triage/SKILL.md
@@ -58,18 +58,18 @@ Agent selection constraint: artifact-writing delegated agents need Bash access f
 - 10+ issues: prefer a coordinated team surface when available.
 - Phase 4A and 4B are parallel; Phase 4C waits for both; Phase 4D and 4E are parallel after synthesis.
 
-## Sensitive-path artifact protocol (mandatory)
+## Sensitive-path compatibility note
 
 Codex-native artifacts go under `.codex/outputs/sessions/YYYY-MM-DD/professor-triage-HHmmss.md` and may be written with the repo's normal file-write APIs.
 
-If a delegated task must create, inspect, or modify Claude compatibility artifacts under `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block verbatim in the delegated prompt:
+If a delegated task must create, inspect, or modify Claude compatibility artifacts under `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block in the delegated prompt:
 
 ```text
-Sensitive-path artifact protocol (mandatory):
-1. Build the artifact body in /tmp first, for example /tmp/professor-triage-<timestamp>.md.
-2. If the final target is under .claude/** or templates/.claude/**, create and execute a /tmp/*.sh script that copies or writes the /tmp artifact to the final path.
-3. Do not call Read, Bash, Write, or Edit directly on .claude/** or templates/.claude/** in unattended flows.
-4. Verify the final file through the least sensitive available path and report the exact artifact path.
+Sensitive-path compatibility note:
+1. Keep Codex-native .codex/** artifacts on the normal file-write path.
+2. On Claude Code v2.1.121+ with bypassPermissions, direct writes to .claude/skills/, .claude/agents/, and .claude/commands/ are allowed.
+3. On Claude Code v2.1.126+ with bypassPermissions, broader protected paths such as .claude/**, .git/**, and .vscode/** are also covered.
+4. Use /tmp/professor-triage-<timestamp>.md only as a legacy fallback when the runtime is older or still prompts, then verify the resulting diff.
 ```
 
 This protocol must be inline in the delegate prompt; relying on this SKILL.md being present in the parent context is not enough.

--- a/.codex/skills/qa-lead-routing/SKILL.md
+++ b/.codex/skills/qa-lead-routing/SKILL.md
@@ -94,7 +94,7 @@ Delegate to mgr-creator with context:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/research/SKILL.md
+++ b/.codex/skills/research/SKILL.md
@@ -207,7 +207,7 @@ Convergence expected by round 3. Hard stop at round 30.
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/research-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
    ```
    With metadata header:
@@ -219,7 +219,7 @@ When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.
    ---
    ```
    The agent writes the artifact file using a file-write API that creates missing parent directories; do not run any Bash directory-creation pre-step for session outputs (R010 compliance).
-   Sensitive-path artifact protocol (mandatory): if a delegated research agent must inspect or create Claude compatibility artifacts under `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, the delegated prompt must require `/tmp/research-{timestamp}.md` as the first artifact body target and must forbid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+   Sensitive-path compatibility note: delegated research agents should keep `.codex/**` artifacts on the normal write path and use `/tmp/research-{timestamp}.md` only as a legacy fallback when an older Claude Code runtime still prompts on compatibility paths.
 3. GitHub issue auto-created with findings
 4. Action items with effort estimates
 

--- a/.codex/skills/result-aggregation/SKILL.md
+++ b/.codex/skills/result-aggregation/SKILL.md
@@ -117,7 +117,7 @@ Secretary outputs:
 
 ### Compatibility artifact protocol
 
-When delegated work must read or consolidate artifacts from `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass in unattended flows: copy the required body to `/tmp/result-aggregation-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that reads or writes the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**`.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 ### With Ecomode
 

--- a/.codex/skills/roundtable-debate/SKILL.md
+++ b/.codex/skills/roundtable-debate/SKILL.md
@@ -22,7 +22,7 @@ Run a bounded debate when convergence would hide useful disagreement. Unlike `ag
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Workflow
 

--- a/.codex/skills/scout/SKILL.md
+++ b/.codex/skills/scout/SKILL.md
@@ -13,7 +13,7 @@ Analyze an external URL (tech blog, tool, library, methodology) to evaluate its 
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/secretary-routing/SKILL.md
+++ b/.codex/skills/secretary-routing/SKILL.md
@@ -134,7 +134,7 @@ Evaluate: Is this a specialized management/tooling task?
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/.codex/skills/skill-extractor/SKILL.md
+++ b/.codex/skills/skill-extractor/SKILL.md
@@ -148,7 +148,7 @@ The `skill-extractor-analyzer.sh` Stop hook provides a lightweight pre-analysis:
 
 ## Compatibility Artifact Protocol
 
-When delegated work must write extraction evidence under `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass in unattended flows: write the evidence body to `/tmp/skill-extractor-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes the body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**`.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 ## Safety
 

--- a/.codex/skills/task-decomposition/SKILL.md
+++ b/.codex/skills/task-decomposition/SKILL.md
@@ -12,7 +12,7 @@ Analyzes task complexity and decomposes large tasks into smaller, parallelizable
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Trigger Conditions
 

--- a/.codex/skills/worker-reviewer-pipeline/SKILL.md
+++ b/.codex/skills/worker-reviewer-pipeline/SKILL.md
@@ -14,7 +14,7 @@ Defines an iterative Worker→Reviewer pipeline where one agent implements chang
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## When to Activate
 

--- a/.github/scripts/verify-version-sync.sh
+++ b/.github/scripts/verify-version-sync.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Verify package.json and templates/manifest.json versions stay aligned.
+# Usage: bash .github/scripts/verify-version-sync.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PACKAGE_JSON="${ROOT}/package.json"
+MANIFEST_JSON="${ROOT}/templates/manifest.json"
+
+if [[ ! -f "${PACKAGE_JSON}" ]]; then
+  echo "error: ${PACKAGE_JSON} not found" >&2
+  exit 1
+fi
+
+if [[ ! -f "${MANIFEST_JSON}" ]]; then
+  echo "error: ${MANIFEST_JSON} not found" >&2
+  exit 1
+fi
+
+PACKAGE_VERSION="$(node -p "require('${PACKAGE_JSON}').version")"
+MANIFEST_VERSION="$(node -p "require('${MANIFEST_JSON}').version")"
+
+echo "package.json version: ${PACKAGE_VERSION}"
+echo "templates/manifest.json version: ${MANIFEST_VERSION}"
+
+if [[ "${PACKAGE_VERSION}" != "${MANIFEST_VERSION}" ]]; then
+  echo "::error::Version mismatch! package.json (${PACKAGE_VERSION}) != templates/manifest.json (${MANIFEST_VERSION}). Update templates/manifest.json to match package.json."
+  exit 1
+fi
+
+echo "Version sync check passed: ${PACKAGE_VERSION}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,20 +209,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Verify package.json and manifest.json versions match
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          MANIFEST_VERSION=$(node -p "require('./templates/manifest.json').version")
-
-          echo "package.json version: $PKG_VERSION"
-          echo "manifest.json version: $MANIFEST_VERSION"
-
-          if [ "$PKG_VERSION" != "$MANIFEST_VERSION" ]; then
-            echo "::error::Version mismatch! package.json ($PKG_VERSION) != templates/manifest.json ($MANIFEST_VERSION). Run: update manifest.json version to match package.json"
-            exit 1
-          fi
-
-          echo "Version sync check passed: $PKG_VERSION"
+      - name: Verify version sync
+        run: bash .github/scripts/verify-version-sync.sh
 
   template-sync:
     name: Template Sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,9 @@ jobs:
           test -f dist/index.js || { echo "::error::Missing dist/index.js"; exit 1; }
           echo "Build artifacts verified"
 
+      - name: Verify version sync
+        run: bash .github/scripts/verify-version-sync.sh
+
       # Check if version already exists on npm
       - name: Check npm version
         id: npm_check

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.12",
-  "generatedAt": "2026-04-28T00:37:38.035Z",
-  "templateVersion": "0.4.12",
+  "generatorVersion": "0.4.13",
+  "generatedAt": "2026-05-02T04:09:13.397Z",
+  "templateVersion": "0.4.13",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "d42928e60e2c20bd670265588b7ab88ae5b5c1ca5fb6150f64f086bbb5bda07b",
-      "size": 19413,
+      "templateHash": "520fb9b45716e7ac7da4e50c18f0cda4ac7c262b37660e8d923c105dec76d7d3",
+      "size": 20372,
       "component": "rules"
     },
     ".codex/rules/MUST-intent-transparency.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-design.md": {
-      "templateHash": "06c0b1b9cece77f3f99912b5c1a0cddc7efa38a0a7b4d577d2225972ddd5c30b",
-      "size": 23993,
+      "templateHash": "4a7989cf1b7213583087367a3143e64d8c703acf50ea59ee4b34cf46ad89c8f2",
+      "size": 24382,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-permissions.md": {
-      "templateHash": "814153e387f2214458b2907c02ceece69d7b766673ef240a41afe1f9aea39e73",
-      "size": 1466,
+      "templateHash": "94f78cbedf41abc2929f0d6e47534f960a4a1da6e333b76a9a1b1511d7e5dd64",
+      "size": 2483,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ontology-rag-routing.md": {
@@ -130,8 +130,8 @@
       "component": "agents"
     },
     ".codex/agents/wiki-curator.md": {
-      "templateHash": "377a69c33f595329ec95fe7a7cc12a2cc362686eed2d01de1ab3dead693bac3e",
-      "size": 2696,
+      "templateHash": "676222776c43434702d8fee475077a4f8505043f922117c2bbf3983c65d5cdeb",
+      "size": 2718,
       "component": "agents"
     },
     ".codex/agents/arch-speckit-agent.md": {
@@ -145,8 +145,8 @@
       "component": "agents"
     },
     ".codex/agents/mgr-updater.md": {
-      "templateHash": "079949e2db42c18f41b4785684638580fff98356e7c22df9afbcc2fa253bcd91",
-      "size": 1427,
+      "templateHash": "1fcf9dbc2daa82b710618434956b13a154ba49b0ffdbe1207c3a26da4a56ca1f",
+      "size": 1449,
       "component": "agents"
     },
     ".codex/agents/lang-kotlin-expert.md": {
@@ -165,8 +165,8 @@
       "component": "agents"
     },
     ".codex/agents/mgr-sauron.md": {
-      "templateHash": "4c8f0a36532007c19e08bcf258e0793f61df54fdafa25386dd7241947509fb46",
-      "size": 4800,
+      "templateHash": "c8a574a947a72baccef699d25b3c8ca1b39068343ded96e54975d4df03f59cd6",
+      "size": 4822,
       "component": "agents"
     },
     ".codex/agents/fe-svelte-agent.md": {
@@ -185,8 +185,8 @@
       "component": "agents"
     },
     ".codex/agents/sys-naggy.md": {
-      "templateHash": "15926b65b0f7668a173af0ed86d72992bbaf99e26577aa5504b3f691b3c21e21",
-      "size": 2575,
+      "templateHash": "40d0ac6388cbefc0f7b7982de1fead890d2bc17285a4958435a3e0844872070b",
+      "size": 2597,
       "component": "agents"
     },
     ".codex/agents/db-redis-expert.md": {
@@ -240,8 +240,8 @@
       "component": "agents"
     },
     ".codex/agents/tracker-checkpoint.md": {
-      "templateHash": "79e550de81a187e3b7656a0b58a5f3d98bc61048e58ded8ea6f71dd895df1f9d",
-      "size": 3029,
+      "templateHash": "3ce24b86fceee8deb121c1b5a4018d8a948f88cf0ae374ec04307eeb45b74231",
+      "size": 3051,
       "component": "agents"
     },
     ".codex/agents/de-dbt-expert.md": {
@@ -270,8 +270,8 @@
       "component": "agents"
     },
     ".codex/agents/mgr-claude-code-bible.md": {
-      "templateHash": "05fa25c9087b58125902d7e3b3a7ba5cb673bd9e919307d0f3a11884849f2ff3",
-      "size": 2655,
+      "templateHash": "9cda83cda94c621c3148d5a9dd2603f2886f125523a90851904f684b62659930",
+      "size": 2677,
       "component": "agents"
     },
     ".codex/agents/fe-flutter-agent.md": {
@@ -290,13 +290,13 @@
       "component": "agents"
     },
     ".codex/agents/mgr-gitnerd.md": {
-      "templateHash": "146c62dd16de102a0cfd6cff8960b6e83922ccd2e07255467d89d859dac3d791",
-      "size": 1654,
+      "templateHash": "2cdde561d86976a44504d00805932906d5670436f3d373b44dd0d884efbf28ac",
+      "size": 1676,
       "component": "agents"
     },
     ".codex/agents/mgr-creator.md": {
-      "templateHash": "066dcda6aeef5eb35788724fa0dc4011ee9b5486bf7ef23548d35964798646c4",
-      "size": 2700,
+      "templateHash": "c7b9428b39615f8ad08c1937023b3cbc872eecc731caa49cd2b9866421158f34",
+      "size": 2722,
       "component": "agents"
     },
     ".codex/agents/qa-writer.md": {
@@ -320,8 +320,8 @@
       "component": "agents"
     },
     ".codex/agents/mgr-supplier.md": {
-      "templateHash": "18a1f285b77fd8c9390250b8ef68e874f74f725da3fbd662ec0953400455b0b6",
-      "size": 1481,
+      "templateHash": "0bc6445c325bd971037201865793ad48e2c72c895ac72ee1e7318ad636f82b68",
+      "size": 1503,
       "component": "agents"
     },
     ".codex/agents/arch-documenter.md": {
@@ -345,8 +345,8 @@
       "component": "agents"
     },
     ".codex/agents/sys-memory-keeper.md": {
-      "templateHash": "9a666d4bc85461caf740b985ae49868e62bd49a728901702ade11f2dbf36e015",
-      "size": 5873,
+      "templateHash": "726a57895dece4213d2f904535c2953313f9e87cfcfc6aa8aab2ca9c86ee532c",
+      "size": 5895,
       "component": "agents"
     },
     ".codex/agents/infra-aws-expert.md": {
@@ -910,8 +910,8 @@
       "component": "guides"
     },
     "guides/professor-triage/phases.md": {
-      "templateHash": "164be0bf4e738eaa38fbb026c33718d7d85b2643db124de7e44ee4ff94adaaff",
-      "size": 12619,
+      "templateHash": "46942d283367abb7437a0a72c979832021f3a769ba33d14713839ea977130670",
+      "size": 12442,
       "component": "guides"
     },
     "guides/professor-triage/README.md": {

--- a/guides/professor-triage/phases.md
+++ b/guides/professor-triage/phases.md
@@ -229,18 +229,7 @@ _`/professor-triage` v2.3.0에 의해 현재 코드베이스 대비 분석됨 �
 
 Delegate to general-purpose. Path: `.codex/outputs/sessions/YYYY-MM-DD/professor-triage-HHmmss.md`
 
-**Sensitive-path protocol**: Use `/tmp/*.sh` bypass — direct Write/Edit/Bash on `.codex/outputs/` triggers Codex/Claude-compat sensitive-path guard.
-
-```bash
-cat > /tmp/professor-triage-$(date +%H%M%S).sh << 'ARTIFACT_SCRIPT'
-mkdir -p .codex/outputs/sessions/YYYY-MM-DD
-cat > .codex/outputs/sessions/YYYY-MM-DD/professor-triage-HHmmss.md << 'ARTIFACT_CONTENT'
-{artifact content here}
-ARTIFACT_CONTENT
-ARTIFACT_SCRIPT
-bash /tmp/professor-triage-HHmmss.sh
-rm /tmp/professor-triage-HHmmss.sh
-```
+**Sensitive-path compatibility note**: Write `.codex/outputs/` artifacts with the normal file-write path. Use `/tmp/professor-triage-<timestamp>.md` only as a legacy fallback when an older Claude Code runtime still prompts on `.claude/**` or `templates/.claude/**` compatibility paths, then verify the resulting diff.
 
 Artifact template:
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.12",
+  "version": "0.4.13",
+  "requiresCC": ">=2.1.121",
+  "claudeCode": {
+    "minimumVersion": "2.1.121",
+    "protectedPathBypassVersion": "2.1.126"
+  },
   "description": "Batteries-included agent harness on top of GPT Codex + OMX",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/mgr-creator.md
+++ b/templates/.claude/agents/mgr-creator.md
@@ -21,7 +21,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are an agent creation specialist following R006 (MUST-agent-design.md) rules.
 

--- a/templates/.claude/agents/mgr-gitnerd.md
+++ b/templates/.claude/agents/mgr-gitnerd.md
@@ -21,7 +21,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are a Git operations specialist following GitHub flow best practices.
 

--- a/templates/.claude/agents/sys-memory-keeper.md
+++ b/templates/.claude/agents/sys-memory-keeper.md
@@ -25,7 +25,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 You are a session memory management specialist ensuring context survives across session compactions using claude-mem.
 

--- a/templates/.claude/agents/tracker-checkpoint.md
+++ b/templates/.claude/agents/tracker-checkpoint.md
@@ -12,7 +12,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 # Tracker Checkpoint Agent
 

--- a/templates/.claude/agents/wiki-curator.md
+++ b/templates/.claude/agents/wiki-curator.md
@@ -16,7 +16,7 @@ permissionMode: bypassPermissions
 
 ## Mandatory Sensitive Compatibility Paths
 
-When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, do not call Write/Edit directly on those paths in unattended automation. Produce the artifact body in `/tmp`, then apply it through the repo-approved sensitive-path script/artifact protocol so Codex-native `.codex/**` work remains autonomous and reviewable.
+When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
 # Wiki Curator
 

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -243,34 +243,39 @@ Skills persist output to `.codex/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HHm
 
 ## Sensitive Path Handling
 
-Claude Code treats `.claude/` and `templates/.claude/` as sensitive directories across Bash, Write, and Edit operations. The sensitive-path check runs above `bypassPermissions` and explicit allow rules, so allow rules do not override the sensitive-path check.
+Claude Code still treats `.claude/` and `templates/.claude/` as protected compatibility surfaces, but the current behavior is version-sensitive rather than a universal prompt wall.
 
-This Codex port uses `.codex/` as the active runtime surface, but packaged compatibility templates still live under `templates/.claude/`. Any automation that writes those templates must account for Claude Code permission prompts.
+This Codex port uses `.codex/` as the active runtime surface. `.codex/**` edits should use the normal Codex edit/patch flow with no Claude-only `/tmp` wrapper.
 
-**Key rule**: `.claude/` and `templates/.claude/` Bash/Write/Edit targets can trigger sensitive-path prompts regardless of allow rules. In unattended flows, delegated agents must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct `.claude/**` tool targets.
+**Current compatibility rule**:
+
+- **CC v2.1.121+**: `bypassPermissions` no longer prompts for direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- **CC v2.1.126+**: `bypassPermissions` also bypasses prompts for broader protected paths such as `.claude/**`, `.git/**`, `.vscode/**`, and shell config files.
+- **Historical fallback only**: if the target runtime is older than v2.1.121, not running with `bypassPermissions`, or still surfaces a protected-path prompt, use `/tmp/{skill}-{timestamp}.md` only as a compatibility fallback for the final `.claude/**` or `templates/.claude/**` write.
 
 <!-- DETAIL: Sensitive Path Behavior table and Recommended practice
-| Path pattern | Sensitive in Claude Code? | Affected operations |
-|--------------|---------------------------|---------------------|
-| `.claude/**` | Yes | Bash writes, Write, Edit |
-| `templates/.claude/**` | Yes | Bash writes, Write, Edit |
-| `.codex/**` | No | Normal Codex runtime writes; still follow R010/R017 |
-| `.codex/outputs/**` and `.claude/outputs/**` | Treat as constrained artifact paths | Use file-write APIs that create parents; do not pre-create with Bash |
+| Path pattern | Guidance |
+|--------------|----------|
+| `.claude/skills/**`, `.claude/agents/**`, `.claude/commands/**` | Direct writes are acceptable in Claude Code `bypassPermissions` on v2.1.121+ |
+| `.claude/**`, `.git/**`, `.vscode/**`, shell config files | Direct writes are acceptable in Claude Code `bypassPermissions` on v2.1.126+ |
+| `templates/.claude/**` | Mirror deliberately; use the historical `/tmp` fallback only when the runtime still prompts |
+| `.codex/**` | Normal Codex runtime writes; still follow R010/R017 |
+| `.codex/outputs/**` and `.claude/outputs/**` | Treat as constrained artifact paths; use file-write APIs that create parents and do not pre-create with Bash |
 
 Recommended practice:
 
-1. Prefer Write/Edit in an interactive session, or managed sync/update paths, over Bash copy/mkdir/tee writes for `.claude/` and `templates/.claude/`.
-2. Keep allow rules only as defensive documentation; do not rely on them to suppress sensitive-path prompts.
-3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
-4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
-5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
+1. Prefer direct Write/Edit for `.codex/**` and for compatible `.claude/**` targets when the runtime version and permission mode allow it.
+2. Keep allow rules only as defensive documentation; current behavior depends on Claude Code version and permission mode, not allow-rule wishful thinking.
+3. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
+4. Use the historical `/tmp` artifact-body fallback only for legacy Claude Code versions or sessions that still prompt on protected paths.
+5. When compatibility-template writes still require a fallback, verify the resulting diff and remove stale wrapper boilerplate from repeated prompts.
 -->
 
 Delegation prompt requirement:
 
-Any prompt that delegates work involving `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths MUST include this block verbatim:
+Delegated prompts touching `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths MUST include this block:
 
-> Sensitive-path artifact protocol (mandatory): do not ask a subagent to call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` paths. If Claude compatibility artifacts are required, have the subagent produce the artifact body in `/tmp/{skill}-{timestamp}.md`, then use a reviewed temporary script wrapper or managed file-write API for the final checked-in path. Do not use direct Write/Edit/Bash targets under `.claude/**` in unattended flows.
+> Sensitive-path compatibility note: Codex-managed `.codex/**` edits use the normal edit/patch flow. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that also extends to broader protected paths such as `.claude/**`, `.git/**`, and `.vscode/**`. Only fall back to `/tmp/{skill}-{timestamp}.md` when the target runtime is older than v2.1.121, not running with `bypassPermissions`, or still surfaces a protected-path prompt.
 
 ## Separation of Concerns
 

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -147,6 +147,19 @@ Key violations to avoid (file writes, git commands, bundled operations — all m
 ```
 -->
 
+## Historical Sensitive-Path Bypass
+
+**Status**: deprecated as of Claude Code v2.1.121 for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; fully deprecated in `bypassPermissions` as of v2.1.126 for broader protected paths.
+
+Older guidance sometimes required a universal `/tmp` artifact-wrapper flow before touching Claude compatibility paths. Do not use that as the default in this Codex-native port.
+
+Current guidance:
+
+- Edit `.codex/**` directly with the normal Codex edit/patch flow.
+- In Claude Code `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are acceptable on v2.1.121+.
+- In Claude Code `bypassPermissions`, broader protected-path writes such as `.claude/**`, `.git/**`, and `.vscode/**` are acceptable on v2.1.126+.
+- Keep the `/tmp/{skill}-{timestamp}.md` pattern only as a legacy fallback for older Claude Code versions or sessions that still surface a protected-path prompt.
+
 <!-- DETAIL: Autonomous Execution Mode
 
 ## Autonomous Execution Mode

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -21,6 +21,21 @@
 | Write | Source code, new files in project | .env, .git/config, paths outside project |
 | Delete | Temp files created by agent | Existing files (without request), entire directories |
 
+## Claude Code Protected-Path Compatibility
+
+Codex-native `.codex/**` edits are normal project writes and do not require the historical Claude-only `/tmp` bypass pattern.
+
+Claude Code compatibility behavior changed in two steps:
+
+- **CC v2.1.121+**: `--dangerously-skip-permissions` / `bypassPermissions` no longer prompts for writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- **CC v2.1.126+**: the same mode also bypasses prompts for broader protected paths such as `.claude/**`, `.git/**`, `.vscode/**`, and shell config files.
+
+Current guidance:
+
+- Prefer direct Write/Edit/Bash targets for `.codex/**`.
+- For `.claude/**` or `templates/.claude/**`, direct writes are acceptable when the target Claude Code runtime is new enough and the session is running with `bypassPermissions`.
+- Treat the old `/tmp/{skill}-{timestamp}.md` wrapper flow as a historical fallback only for older Claude Code versions, non-bypass sessions, or interactive runs that still surface a protected-path prompt.
+
 ## Permission Request Format
 
 ```

--- a/templates/.claude/skills/action-validator/SKILL.md
+++ b/templates/.claude/skills/action-validator/SKILL.md
@@ -109,7 +109,7 @@ When a synthesized harness exists for an agent (`.codex/outputs/harnesses/{agent
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/action-validator-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 
 | Mode | Source | Behavior |

--- a/templates/.claude/skills/adaptive-harness/SKILL.md
+++ b/templates/.claude/skills/adaptive-harness/SKILL.md
@@ -187,7 +187,7 @@ Append a record to `.codex/outputs/harness-adaptations/YYYY-MM-DD.md`:
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/adaptive-harness-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 
 ```markdown

--- a/templates/.claude/skills/agora/SKILL.md
+++ b/templates/.claude/skills/agora/SKILL.md
@@ -25,7 +25,7 @@ source:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/dag-orchestration/SKILL.md
+++ b/templates/.claude/skills/dag-orchestration/SKILL.md
@@ -86,7 +86,7 @@ config:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Execution Rules
 

--- a/templates/.claude/skills/de-lead-routing/SKILL.md
+++ b/templates/.claude/skills/de-lead-routing/SKILL.md
@@ -221,7 +221,7 @@ Delegate to mgr-creator with context:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/deep-plan/SKILL.md
+++ b/templates/.claude/skills/deep-plan/SKILL.md
@@ -50,18 +50,18 @@ Research-validated planning that eliminates the gap between research assumptions
 | `/structured-dev-cycle` | Implementation pipeline | Yes, stage by stage |
 | `/deep-plan` | Analysis + planning + verification | Yes, 3-pass cross-verification |
 
-## Sensitive-path artifact protocol (mandatory)
+## Sensitive-path compatibility note
 
 Codex-native verification artifacts go under `.codex/outputs/sessions/YYYY-MM-DD/deep-plan-HHmmss.md` and may be written with the repo's normal file-write APIs.
 
-If any research, planning, or verification delegate must touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block verbatim in that delegate prompt:
+If any research, planning, or verification delegate must touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block in that delegate prompt:
 
 ```text
-Sensitive-path artifact protocol (mandatory):
-1. Build the artifact body in /tmp first, for example /tmp/deep-plan-<timestamp>.md.
-2. If the final target is under .claude/** or templates/.claude/**, create and execute a /tmp/*.sh script that copies or writes the /tmp artifact to the final path.
-3. Do not call Read, Bash, Write, or Edit directly on .claude/** or templates/.claude/** in unattended flows.
-4. Verify the final file through the least sensitive available path and report the exact artifact path.
+Sensitive-path compatibility note:
+1. Keep Codex-native .codex/** artifacts on the normal file-write path.
+2. On Claude Code v2.1.121+ with bypassPermissions, direct writes to .claude/skills/, .claude/agents/, and .claude/commands/ are allowed.
+3. On Claude Code v2.1.126+ with bypassPermissions, broader protected paths such as .claude/**, .git/**, and .vscode/** are also covered.
+4. Use /tmp/deep-plan-<timestamp>.md only as a legacy fallback when the runtime is older or still prompts, then verify the resulting diff.
 ```
 
 The protocol must be copied into delegate prompts. A parent-only mention is insufficient because forked contexts can lose the directive.

--- a/templates/.claude/skills/deep-verify/SKILL.md
+++ b/templates/.claude/skills/deep-verify/SKILL.md
@@ -73,7 +73,7 @@ Each agent receives the full diff and returns findings as structured JSON:
 - Verify all changes align with project's compilation metaphor (Skills=source, Agents=artifacts, Rules=spec)
 - Check separation of concerns: no agents containing skill logic, no skills with agent definitions
 - Verify orchestrator rules: no new file writes from orchestrator context
-- Verify sensitive-path delegation: prompts that touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**` include the exact phrase `Sensitive-path artifact protocol (mandatory)`, require an explicit `/tmp/{skill}-{timestamp}.md` artifact body path, mention `Read, Bash, Write, or Edit` coverage, and do not rely on a single vague `/tmp` recommendation
+- Verify sensitive-path compatibility: prompts that touch `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**` include the `Sensitive-path compatibility note`, keep `.codex/**` artifacts on the normal file-write path, and treat `/tmp/{skill}-{timestamp}.md` only as a legacy fallback for older Claude Code versions or sessions that still prompt
 - Check advisory-first: no new hard-blocking hooks introduced
 - Confirm no feature regressions: existing APIs preserved, test coverage maintained
 - Performance sanity: no O(n^2) on large datasets, no missing indexes for new queries

--- a/templates/.claude/skills/dev-lead-routing/SKILL.md
+++ b/templates/.claude/skills/dev-lead-routing/SKILL.md
@@ -10,7 +10,7 @@ context: fork
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Engineers
 

--- a/templates/.claude/skills/dev-review/SKILL.md
+++ b/templates/.claude/skills/dev-review/SKILL.md
@@ -116,7 +116,7 @@ If only PASS/INFO: proceed automatically.
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/dev-review-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
    ```
    With metadata header:

--- a/templates/.claude/skills/hada-scout/SKILL.md
+++ b/templates/.claude/skills/hada-scout/SKILL.md
@@ -15,7 +15,7 @@ high-scoring candidates.
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Purpose
 

--- a/templates/.claude/skills/harness-eval/SKILL.md
+++ b/templates/.claude/skills/harness-eval/SKILL.md
@@ -16,7 +16,7 @@ Evaluate agent quality using 15 structured software engineering task definitions
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/harness-synthesizer/SKILL.md
+++ b/templates/.claude/skills/harness-synthesizer/SKILL.md
@@ -96,7 +96,7 @@ harness:
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/harness-synthesizer-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 3. **Synthesize validation harness** — generate YAML harness matching agent's declared capabilities
 4. **Refine via evaluator-optimizer loop** — iterate harness against edge cases (3 rounds max)

--- a/templates/.claude/skills/omcodex-improve-report/SKILL.md
+++ b/templates/.claude/skills/omcodex-improve-report/SKILL.md
@@ -15,7 +15,7 @@ Surface actionable improvement suggestions gathered by the eval-core analysis en
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/omcodex-takeover/SKILL.md
+++ b/templates/.claude/skills/omcodex-takeover/SKILL.md
@@ -16,7 +16,7 @@ When an agent or skill has evolved organically without a formal spec, `omcodex:t
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/optimize-analyze/SKILL.md
+++ b/templates/.claude/skills/optimize-analyze/SKILL.md
@@ -24,7 +24,7 @@ target           Build output path or project root (optional, auto-detects)
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Workflow
 

--- a/templates/.claude/skills/optimize-report/SKILL.md
+++ b/templates/.claude/skills/optimize-report/SKILL.md
@@ -20,7 +20,7 @@ Generate comprehensive optimization report with analysis, metrics, and recommend
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Workflow
 

--- a/templates/.claude/skills/post-release-followup/SKILL.md
+++ b/templates/.claude/skills/post-release-followup/SKILL.md
@@ -27,7 +27,7 @@ Gather unfinished work from multiple sources:
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/post-release-followup-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 - Extract any MEDIUM or LOW severity findings that were flagged but not fixed
 

--- a/templates/.claude/skills/professor-triage/SKILL.md
+++ b/templates/.claude/skills/professor-triage/SKILL.md
@@ -58,18 +58,18 @@ Agent selection constraint: artifact-writing delegated agents need Bash access f
 - 10+ issues: prefer a coordinated team surface when available.
 - Phase 4A and 4B are parallel; Phase 4C waits for both; Phase 4D and 4E are parallel after synthesis.
 
-## Sensitive-path artifact protocol (mandatory)
+## Sensitive-path compatibility note
 
 Codex-native artifacts go under `.codex/outputs/sessions/YYYY-MM-DD/professor-triage-HHmmss.md` and may be written with the repo's normal file-write APIs.
 
-If a delegated task must create, inspect, or modify Claude compatibility artifacts under `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block verbatim in the delegated prompt:
+If a delegated task must create, inspect, or modify Claude compatibility artifacts under `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, include this block in the delegated prompt:
 
 ```text
-Sensitive-path artifact protocol (mandatory):
-1. Build the artifact body in /tmp first, for example /tmp/professor-triage-<timestamp>.md.
-2. If the final target is under .claude/** or templates/.claude/**, create and execute a /tmp/*.sh script that copies or writes the /tmp artifact to the final path.
-3. Do not call Read, Bash, Write, or Edit directly on .claude/** or templates/.claude/** in unattended flows.
-4. Verify the final file through the least sensitive available path and report the exact artifact path.
+Sensitive-path compatibility note:
+1. Keep Codex-native .codex/** artifacts on the normal file-write path.
+2. On Claude Code v2.1.121+ with bypassPermissions, direct writes to .claude/skills/, .claude/agents/, and .claude/commands/ are allowed.
+3. On Claude Code v2.1.126+ with bypassPermissions, broader protected paths such as .claude/**, .git/**, and .vscode/** are also covered.
+4. Use /tmp/professor-triage-<timestamp>.md only as a legacy fallback when the runtime is older or still prompts, then verify the resulting diff.
 ```
 
 This protocol must be inline in the delegate prompt; relying on this SKILL.md being present in the parent context is not enough.

--- a/templates/.claude/skills/qa-lead-routing/SKILL.md
+++ b/templates/.claude/skills/qa-lead-routing/SKILL.md
@@ -94,7 +94,7 @@ Delegate to mgr-creator with context:
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/research/SKILL.md
+++ b/templates/.claude/skills/research/SKILL.md
@@ -207,7 +207,7 @@ Convergence expected by round 3. Hard stop at round 30.
 
 ### Compatibility artifact protocol
 
-When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass: write the artifact body to `/tmp/research-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes that body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**` in unattended flows.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
    ```
    With metadata header:
@@ -219,7 +219,7 @@ When delegated work must touch `.claude/outputs/`, `.claude/**`, or `templates/.
    ---
    ```
    The agent writes the artifact file using a file-write API that creates missing parent directories; do not run any Bash directory-creation pre-step for session outputs (R010 compliance).
-   Sensitive-path artifact protocol (mandatory): if a delegated research agent must inspect or create Claude compatibility artifacts under `.claude/**`, `.claude/outputs/**`, or `templates/.claude/**`, the delegated prompt must require `/tmp/research-{timestamp}.md` as the first artifact body target and must forbid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+   Sensitive-path compatibility note: delegated research agents should keep `.codex/**` artifacts on the normal write path and use `/tmp/research-{timestamp}.md` only as a legacy fallback when an older Claude Code runtime still prompts on compatibility paths.
 3. GitHub issue auto-created with findings
 4. Action items with effort estimates
 

--- a/templates/.claude/skills/result-aggregation/SKILL.md
+++ b/templates/.claude/skills/result-aggregation/SKILL.md
@@ -117,7 +117,7 @@ Secretary outputs:
 
 ### Compatibility artifact protocol
 
-When delegated work must read or consolidate artifacts from `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass in unattended flows: copy the required body to `/tmp/result-aggregation-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that reads or writes the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**`.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 ### With Ecomode
 

--- a/templates/.claude/skills/roundtable-debate/SKILL.md
+++ b/templates/.claude/skills/roundtable-debate/SKILL.md
@@ -22,7 +22,7 @@ Run a bounded debate when convergence would hide useful disagreement. Unlike `ag
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Workflow
 

--- a/templates/.claude/skills/scout/SKILL.md
+++ b/templates/.claude/skills/scout/SKILL.md
@@ -13,7 +13,7 @@ Analyze an external URL (tech blog, tool, library, methodology) to evaluate its 
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/secretary-routing/SKILL.md
+++ b/templates/.claude/skills/secretary-routing/SKILL.md
@@ -134,7 +134,7 @@ Evaluate: Is this a specialized management/tooling task?
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Usage
 

--- a/templates/.claude/skills/skill-extractor/SKILL.md
+++ b/templates/.claude/skills/skill-extractor/SKILL.md
@@ -148,7 +148,7 @@ The `skill-extractor-analyzer.sh` Stop hook provides a lightweight pre-analysis:
 
 ## Compatibility Artifact Protocol
 
-When delegated work must write extraction evidence under `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, use the mandatory 2-step bypass in unattended flows: write the evidence body to `/tmp/skill-extractor-$(date +%H%M%S).md` first, then execute a `/tmp/*.sh` Bash script that copies or writes the body to the final compatibility path. Do not call Read, Bash, Write, or Edit directly on `.claude/**` or `templates/.claude/**`.
+Sensitive-path compatibility note: when delegated work touches `.claude/outputs/`, `.claude/**`, or `templates/.claude/**`, keep `.codex/**` artifacts on the normal file-write path. On Claude Code v2.1.121+ with `bypassPermissions`, direct compatibility writes are allowed for `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`; on v2.1.126+ broader protected paths are covered. Use `/tmp/<skill>-<timestamp>.md` only as a legacy fallback when the runtime is older or still prompts.
 
 ## Safety
 

--- a/templates/.claude/skills/task-decomposition/SKILL.md
+++ b/templates/.claude/skills/task-decomposition/SKILL.md
@@ -12,7 +12,7 @@ Analyzes task complexity and decomposes large tasks into smaller, parallelizable
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## Trigger Conditions
 

--- a/templates/.claude/skills/worker-reviewer-pipeline/SKILL.md
+++ b/templates/.claude/skills/worker-reviewer-pipeline/SKILL.md
@@ -14,7 +14,7 @@ Defines an iterative Worker→Reviewer pipeline where one agent implements chang
 
 ## Sensitive-Path Delegation
 
-Sensitive-path artifact protocol (mandatory): if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, include this protocol directly in the delegated prompt. The delegate must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and must avoid direct Read, Bash, Write, or Edit targets under `.claude/**` in unattended flows.
+Sensitive-path compatibility note: if this skill delegates work that touches `.claude/**`, `.claude/outputs/**`, `templates/.claude/**`, or read-only measurements of those paths, keep `.codex/**` edits on the normal Codex path. On Claude Code v2.1.121+ with `bypassPermissions`, direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` are allowed; on v2.1.126+ that extends to broader protected paths. Only use `/tmp/{skill}-{timestamp}.md` as a legacy fallback when the target runtime is older or still prompts.
 
 ## When to Activate
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,10 @@
 {
-  "version": "0.4.12",
+  "version": "0.4.13",
+  "requiresCC": ">=2.1.121",
+  "claudeCode": {
+    "minimumVersion": "2.1.121",
+    "protectedPathBypassVersion": "2.1.126"
+  },
   "lastUpdated": "2026-04-28T00:01:33.302Z",
   "components": [
     {

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -40,9 +40,9 @@ steps:
 
       Codex-native sensitive-path policy:
       - Codex-managed `.codex/` edits use the normal edit/patch flow.
-      - Do not adopt upstream Claude-only `/tmp` bypass guidance as the default path.
+      - Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path writes available on v2.1.126+.
       - If a port requires `.claude` template parity changes, make the change explicit and verify sensitive-path guard tests.
-      - Sensitive-path artifact protocol (mandatory): delegated prompts that touch `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurements of those paths must instruct the subagent to produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct Read/Bash/Write/Edit targets under `.claude/**` in unattended flows.
+      - Use `/tmp/{skill}-{timestamp}.md` only as a historical fallback for older Claude Code versions, non-bypass sessions, or runs that still surface a protected-path prompt.
     description: Execute implementation plan with appropriate agents
     foreach: planned-issue
 

--- a/tests/unit/core/release-workflow.test.ts
+++ b/tests/unit/core/release-workflow.test.ts
@@ -46,3 +46,19 @@ describe('release.yml — CI gate', () => {
     expect(content).toContain('docs-validate:');
   });
 });
+
+describe('release.yml — publish safeguards', () => {
+  it('should verify version sync before npm publish checks', async () => {
+    const content = await readWorkflow();
+    const verifyBuildIndex = content.indexOf('- name: Verify build artifacts');
+    const verifyVersionSyncIndex = content.indexOf('- name: Verify version sync');
+    const checkNpmVersionIndex = content.indexOf('- name: Check npm version');
+    const publishIndex = content.indexOf('- name: Publish to npm');
+
+    expect(verifyBuildIndex).toBeGreaterThan(-1);
+    expect(verifyVersionSyncIndex).toBeGreaterThan(verifyBuildIndex);
+    expect(checkNpmVersionIndex).toBeGreaterThan(verifyVersionSyncIndex);
+    expect(publishIndex).toBeGreaterThan(checkNpmVersionIndex);
+    expect(content).toContain('run: bash .github/scripts/verify-version-sync.sh');
+  });
+});

--- a/tests/unit/core/sensitive-output-guidance.test.ts
+++ b/tests/unit/core/sensitive-output-guidance.test.ts
@@ -13,28 +13,17 @@ const GUIDANCE_DIRS = [
 const SOURCE_R006 = join(ROOT, '.codex/rules/MUST-agent-design.md');
 const TEMPLATE_R006 = join(ROOT, 'templates/.claude/rules/MUST-agent-design.md');
 const WIKI_R006 = join(ROOT, 'wiki/rules/r006.md');
-const SENSITIVE_DELEGATION_SKILLS = [
-  'professor-triage',
-  'deep-plan',
-  'deep-verify',
-  'research',
-  'scout',
-  'hada-scout',
-  'agora',
-  'roundtable-debate',
-  'harness-eval',
-  'omcodex-improve-report',
-  'omcodex-takeover',
-  'optimize-report',
-  'optimize-analyze',
-  'secretary-routing',
-  'dev-lead-routing',
-  'de-lead-routing',
-  'qa-lead-routing',
-  'dag-orchestration',
-  'task-decomposition',
-  'worker-reviewer-pipeline',
+const PACKAGE_JSON = join(ROOT, 'package.json');
+const TEMPLATE_MANIFEST = join(ROOT, 'templates/manifest.json');
+const VERSION_AWARE_COMPATIBILITY_FILES = [
+  '.codex/agents/mgr-creator.md',
+  '.codex/agents/mgr-updater.md',
+  '.codex/skills/agora/SKILL.md',
+  '.codex/skills/pipeline/workflows/auto-dev.yaml',
+  'workflows/auto-dev.yaml',
+  'templates/workflows/auto-dev.yaml',
 ];
+const CODEX_EXEC_SKILL = join(ROOT, '.codex/skills/codex-exec/SKILL.md');
 
 async function collectMarkdownFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -96,11 +85,12 @@ describe('sensitive output guidance', () => {
     const wiki = await readFile(WIKI_R006, 'utf-8');
     const required = [
       'templates/.claude/**',
-      'Bash writes, Write, Edit',
-      'allow rules do not override the sensitive-path check',
-      'do not rely on them to suppress sensitive-path prompts',
+      'Codex edit/patch flow',
+      'CC v2.1.121+',
+      'CC v2.1.126+',
+      'Historical fallback only',
       'update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately',
-      'Sensitive-path artifact protocol (mandatory)',
+      'Sensitive-path compatibility note',
     ];
 
     for (const phrase of required) {
@@ -112,18 +102,46 @@ describe('sensitive output guidance', () => {
     expect(wiki).not.toContain('.claude/rules/MUST-agent-design.md');
   });
 
-  it('keeps delegated artifact skills on the mandatory sensitive-path protocol', async () => {
-    for (const skill of SENSITIVE_DELEGATION_SKILLS) {
-      const source = await readFile(join(ROOT, '.codex/skills', skill, 'SKILL.md'), 'utf-8');
-      const template = await readFile(
-        join(ROOT, 'templates/.claude/skills', skill, 'SKILL.md'),
-        'utf-8'
-      );
-
-      expect(source).toContain('Sensitive-path artifact protocol (mandatory)');
-      expect(source).toContain('/tmp/');
-      expect(source).toContain('Read, Bash, Write, or Edit');
-      expect(template).toContain('Sensitive-path artifact protocol (mandatory)');
+  it('keeps high-traffic compatibility surfaces on version-aware .claude guidance', async () => {
+    for (const relativePath of VERSION_AWARE_COMPATIBILITY_FILES) {
+      const content = await readFile(join(ROOT, relativePath), 'utf-8');
+      expect(content).toContain('v2.1.121+');
+      expect(content).toContain('v2.1.126+');
+      expect(/(?:historical|legacy) fallback/.test(content)).toBe(true);
+      expect(content).not.toContain('Sensitive-path artifact protocol (mandatory)');
     }
+  });
+
+  it('removes the codex-exec /tmp status-file boilerplate', async () => {
+    const content = await readFile(CODEX_EXEC_SKILL, 'utf-8');
+    expect(content).toContain('command -v codex');
+    expect(content).not.toContain('/tmp/.codex-env-status-*');
+  });
+
+  it('tracks minimum Claude Code compatibility metadata in package and manifest', async () => {
+    const packageJson = JSON.parse(await readFile(PACKAGE_JSON, 'utf-8')) as {
+      version: string;
+      requiresCC?: string;
+      claudeCode?: {
+        minimumVersion?: string;
+        protectedPathBypassVersion?: string;
+      };
+    };
+    const manifest = JSON.parse(await readFile(TEMPLATE_MANIFEST, 'utf-8')) as {
+      version: string;
+      requiresCC?: string;
+      claudeCode?: {
+        minimumVersion?: string;
+        protectedPathBypassVersion?: string;
+      };
+    };
+
+    expect(packageJson.version).toBe(manifest.version);
+    expect(packageJson.requiresCC).toBe('>=2.1.121');
+    expect(manifest.requiresCC).toBe('>=2.1.121');
+    expect(packageJson.claudeCode?.minimumVersion).toBe('2.1.121');
+    expect(manifest.claudeCode?.minimumVersion).toBe('2.1.121');
+    expect(packageJson.claudeCode?.protectedPathBypassVersion).toBe('2.1.126');
+    expect(manifest.claudeCode?.protectedPathBypassVersion).toBe('2.1.126');
   });
 });

--- a/wiki/rules/r002.md
+++ b/wiki/rules/r002.md
@@ -1,9 +1,9 @@
 ---
 title: "R002: Permission Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-05-02
 sources:
-  - .claude/rules/MUST-permissions.md
+  - .codex/rules/MUST-permissions.md
 related:
   - [[r001]]
   - [[r010]]
@@ -45,6 +45,16 @@ Tools are grouped into six tiers from always-allowed read-only tools to conditio
 
 **Permission request format:**
 ```
+
+## Claude Code Compatibility
+
+Codex-native `.codex/**` edits are normal project writes and do not require the historical Claude-only `/tmp` bypass pattern.
+
+Claude Code compatibility behavior is version-sensitive:
+
+- CC v2.1.121+ with `bypassPermissions` no longer prompts for writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- CC v2.1.126+ with `bypassPermissions` also covers broader protected paths such as `.claude/**`, `.git/**`, `.vscode/**`, and shell config files.
+- Use `/tmp/{skill}-{timestamp}.md` only as a legacy fallback for older Claude Code versions, non-bypass sessions, or runs that still surface protected-path prompts.
 [Permission Request]
 Action: {action} | Required: {tool} | Reason: {why} | Risk: Low/Medium/High
 Approve?
@@ -61,4 +71,4 @@ Prompt-based per [[r021]]. On insufficient permission: do not attempt, notify us
 
 ## Sources
 
-- `.claude/rules/MUST-permissions.md` — rule definition
+- `.codex/rules/MUST-permissions.md` — rule definition

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -61,30 +61,35 @@ Skills persist output to `.codex/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HHm
 
 ## Sensitive Path Handling
 
-Claude Code treats `.claude/` and `templates/.claude/` as sensitive directories across Bash, Write, and Edit operations. The sensitive-path check runs above `bypassPermissions` and explicit allow rules, so allow rules do not override the sensitive-path check.
+Claude Code still treats `.claude/` and `templates/.claude/` as protected compatibility surfaces, but the current behavior is version-sensitive rather than a universal prompt wall.
 
-This Codex port uses `.codex/` as the active runtime surface, but packaged compatibility templates still live under `templates/.claude/`. Any automation that writes those templates must account for Claude Code permission prompts.
+This Codex port uses `.codex/` as the active runtime surface. `.codex/**` edits should use the normal Codex edit/patch flow with no Claude-only `/tmp` wrapper.
 
-Key rule: `.claude/` and `templates/.claude/` Bash/Write/Edit targets can trigger sensitive-path prompts regardless of allow rules. In unattended flows, delegated agents must produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct `.claude/**` tool targets.
+Current compatibility rule:
 
-| Path pattern | Sensitive in Claude Code? | Affected operations |
-|--------------|---------------------------|---------------------|
-| `.claude/**` | Yes | Bash writes, Write, Edit |
-| `templates/.claude/**` | Yes | Bash writes, Write, Edit |
-| `.codex/**` | No | Normal Codex runtime writes; still follow [[r010]]/[[r017]] |
-| `.codex/outputs/**` and `.claude/outputs/**` | Treat as constrained artifact paths | Use file-write APIs that create parents; do not pre-create with Bash |
+- **CC v2.1.121+**: `bypassPermissions` no longer prompts for direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- **CC v2.1.126+**: `bypassPermissions` also bypasses prompts for broader protected paths such as `.claude/**`, `.git/**`, `.vscode/**`, and shell config files.
+- **Historical fallback only**: if the target runtime is older than v2.1.121, not running with `bypassPermissions`, or still surfaces a protected-path prompt, use `/tmp/{skill}-{timestamp}.md` only as a compatibility fallback for the final `.claude/**` or `templates/.claude/**` write.
+
+| Path pattern | Guidance |
+|--------------|----------|
+| `.claude/skills/**`, `.claude/agents/**`, `.claude/commands/**` | Direct writes are acceptable in Claude Code `bypassPermissions` on v2.1.121+ |
+| `.claude/**`, `.git/**`, `.vscode/**`, shell config files | Direct writes are acceptable in Claude Code `bypassPermissions` on v2.1.126+ |
+| `templates/.claude/**` | Mirror deliberately; use the historical `/tmp` fallback only when the runtime still prompts |
+| `.codex/**` | Normal Codex runtime writes; still follow [[r010]]/[[r017]] |
+| `.codex/outputs/**` and `.claude/outputs/**` | Treat as constrained artifact paths; use file-write APIs that create parents and do not pre-create with Bash |
 
 Recommended practice:
 
-1. Prefer Write/Edit in an interactive session, or managed sync/update paths, over Bash copy/mkdir/tee writes for `.claude/` and `templates/.claude/`.
-2. Keep allow rules only as defensive documentation; do not rely on them to suppress sensitive-path prompts.
-3. Do not run unattended Claude Code release automation that writes `templates/.claude/**` unless the workflow can handle interactive approval.
-4. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
-5. For unattended Claude compatibility-template writes, use a reviewed temporary script wrapper and verify the resulting diff; direct Bash/Write/Edit targets under `templates/.claude/**` can all trigger the sensitive-path guard.
+1. Prefer direct Write/Edit for `.codex/**` and for compatible `.claude/**` targets when the runtime version and permission mode allow it.
+2. Keep allow rules only as defensive documentation; current behavior depends on Claude Code version and permission mode, not allow-rule wishful thinking.
+3. In this Codex port, update `.codex/...` source files and their `templates/.claude/...` mirrors deliberately instead of bulk-copying with shell commands.
+4. Use the historical `/tmp` artifact-body fallback only for legacy Claude Code versions or sessions that still prompt on protected paths.
+5. When compatibility-template writes still require a fallback, verify the resulting diff and remove stale wrapper boilerplate from repeated prompts.
 
 Delegation prompt requirement:
 
-Any delegated prompt that touches `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths must include `Sensitive-path artifact protocol (mandatory)` from `.codex/rules/MUST-agent-design.md`.
+Any delegated prompt that touches `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurement of those paths must include `Sensitive-path compatibility note` from `.codex/rules/MUST-agent-design.md`.
 
 Long optional frontmatter examples and compatibility tables are retained in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
 

--- a/wiki/rules/r010.md
+++ b/wiki/rules/r010.md
@@ -1,9 +1,9 @@
 ---
 title: "R010: Orchestrator Coordination Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-05-02
 sources:
-  - .claude/rules/MUST-orchestrator-coordination.md
+  - .codex/rules/MUST-orchestrator-coordination.md
 related:
   - [[r006]]
   - [[r007]]
@@ -52,6 +52,15 @@ The orchestrator's role is routing and coordination only. File operations, git c
 
 **Agent Teams exception:** Agent Teams members are peers and CAN spawn sub-agents to execute complex workflows.
 
+## Historical Sensitive-Path Bypass
+
+The universal `/tmp` artifact-wrapper guidance for Claude compatibility paths is deprecated for current Claude Code runtimes:
+
+- Claude Code v2.1.121+ with `bypassPermissions` permits direct writes to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
+- Claude Code v2.1.126+ extends that behavior to broader protected paths such as `.claude/**`, `.git/**`, and `.vscode/**`.
+- Codex-native `.codex/**` edits use the normal Codex edit/patch flow.
+- Keep `/tmp/{skill}-{timestamp}.md` only as a legacy fallback for older Claude Code versions or sessions that still prompt.
+
 ## Enforcement
 
 Advisory PostToolUse hook (`git-delegation-guard.sh`) + PostCompact re-injection per [[r021]]. Candidate for hard-block if direct-write violations exceed 3/session.
@@ -64,4 +73,4 @@ Advisory PostToolUse hook (`git-delegation-guard.sh`) + PostCompact re-injection
 
 ## Sources
 
-- `.claude/rules/MUST-orchestrator-coordination.md` — rule definition
+- `.codex/rules/MUST-orchestrator-coordination.md` — rule definition

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -40,9 +40,9 @@ steps:
 
       Codex-native sensitive-path policy:
       - Codex-managed `.codex/` edits use the normal edit/patch flow.
-      - Do not adopt upstream Claude-only `/tmp` bypass guidance as the default path.
+      - Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path writes available on v2.1.126+.
       - If a port requires `.claude` template parity changes, make the change explicit and verify sensitive-path guard tests.
-      - Sensitive-path artifact protocol (mandatory): delegated prompts that touch `.claude/**`, `templates/.claude/**`, `.claude/outputs/**`, or read-only measurements of those paths must instruct the subagent to produce artifact bodies in `/tmp/{skill}-{timestamp}.md` first and avoid direct Read/Bash/Write/Edit targets under `.claude/**` in unattended flows.
+      - Use `/tmp/{skill}-{timestamp}.md` only as a historical fallback for older Claude Code versions, non-bypass sessions, or runs that still surface a protected-path prompt.
     description: Execute implementation plan with appropriate agents
     foreach: planned-issue
 


### PR DESCRIPTION
## Summary
- add a reusable version-sync script and run it in CI plus release publish before npm checks
- bump package/template version to 0.4.13 and add Claude Code compatibility metadata
- update R002/R006/R010, templates, wiki, and high-traffic skill guidance so direct .claude writes are version-aware and /tmp staging is legacy fallback only

Closes #1226
Closes #1227
Closes #1228

## Verification
- bash .github/scripts/verify-version-sync.sh
- git diff --check
- bun run build
- bun test tests/unit/core/release-workflow.test.ts tests/unit/core/sensitive-output-guidance.test.ts tests/unit/core/context-optimization-guidance.test.ts
- bun run lint
- bun run typecheck
- bun run test

## Release
- release branch: release/v0.4.13-auto-dev
- expected tag after merge: v0.4.13
- expected npm package version: 0.4.13