### PR TITLE
chore: release v0.4.15 auto-dev issue sweep

### DIFF
--- a/.codex/skills/omcodex-release-notes/SKILL.md
+++ b/.codex/skills/omcodex-release-notes/SKILL.md
@@ -39,6 +39,16 @@ git diff --name-status ${PREV_TAG}..HEAD
 gh issue list --state closed --search "closed:>$(git log -1 --format=%ci ${PREV_TAG} | cut -d' ' -f1)" --json number,title,labels
 ```
 
+### Phase 1.5: Promote CHANGELOG
+
+Before creating a release, keep `CHANGELOG.md` as the durable source of release history:
+
+1. Confirm `CHANGELOG.md` has a `## [Unreleased]` section.
+2. Move non-empty `Unreleased` entries into `## [VERSION] - YYYY-MM-DD`.
+3. Insert a fresh empty `## [Unreleased]` section above the promoted version.
+4. Verify `.github/workflows/release.yml` can extract the promoted section with its existing `awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag"` logic.
+5. If `Unreleased` is empty, add the release summary there first rather than relying only on GitHub auto-generated notes.
+
 ### Phase 2: Classify Changes
 
 Categorize commits using Conventional Commits:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@
 
 ## Checklist
 
+- [ ] `CHANGELOG.md` `## [Unreleased]` updated, or this PR has no user-visible/package-visible change
 - [ ] I have run `bun run lint` (Biome) and fixed all issues
 - [ ] I have performed a self-review of my code
 - [ ] I have updated documentation if needed

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -156,7 +156,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          ISSUES=$(echo "$PR_BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
+          ISSUES=$(
+            echo "$PR_BODY" |
+              grep -ioE '(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+' |
+              grep -oE '#[0-9]+' |
+              grep -oE '[0-9]+' |
+              sort -u
+          )
           for ISSUE in $ISSUES; do
             echo "Closing issue #$ISSUE"
             gh issue close "$ISSUE" \

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.4.14",
-  "generatedAt": "2026-05-08T04:56:14.282Z",
-  "templateVersion": "0.4.14",
+  "generatorVersion": "0.4.15",
+  "generatedAt": "2026-05-08T08:19:47.731Z",
+  "templateVersion": "0.4.15",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.15] - 2026-05-08
+
+### Changed
+- Require `omcustomcodex-release-notes` to promote populated `CHANGELOG.md` `Unreleased` entries into versioned release sections before publishing.
+- Document the upstream-port sweep dispositions for the remaining May 8 port backlog.
+
+### Fixed
+- Allow `auto-tag.yml` to close multiple linked issues from one keyword, such as `Closes #1 #2 #3`.
+
 ## [0.4.14] - 2026-05-08
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,8 @@ feature/another ──────┘                                           
    bun run typecheck  # Must pass
    ```
 
+   Update `CHANGELOG.md` under `## [Unreleased]` for user-visible code, docs, workflow, or packaged-template changes. Use the existing Added/Changed/Fixed/Removed/Security categories where they fit.
+
 3. **Commit with conventional message:**
    ```bash
    git commit -m "feat: add my new feature"

--- a/docs/superpowers/plans/2026-05-08-upstream-port-sweep.md
+++ b/docs/superpowers/plans/2026-05-08-upstream-port-sweep.md
@@ -1,0 +1,35 @@
+# 2026-05-08 Upstream Port Sweep
+
+> Source: open `baekenough/oh-my-customcode` port issues as of 2026-05-08.
+
+This sweep records the pipeline disposition for the open upstream-port backlog so issue closure is tied to explicit evidence rather than an empty queue alone.
+
+## Implemented In This Sweep
+
+| Issue | Disposition | Evidence |
+| --- | --- | --- |
+| #1288 | Forward-looking CHANGELOG policy ported | `omcustomcodex-release-notes` now requires `Unreleased` promotion, `CONTRIBUTING.md` and the PR template require `Unreleased` updates. |
+| #1273 | Multi-close parsing fixed | `auto-tag.yml` now parses `Closes #A #B #C` style references and tests assert the parser shape. |
+
+## Already Present On Develop
+
+| Issue | Disposition | Evidence |
+| --- | --- | --- |
+| #1260, #1255 | Permission prompt/bypass propagation covered | `agent-mode-guard.sh`, pipeline guidance, and hook tests require `mode: "bypassPermissions"` for Agent/Task spawns. |
+| #1259 | Statusline refresh covered | installer tests assert `.codex/settings.local.json` includes `statusLine.refreshInterval: 10`. |
+| #1258 | Deleted-folder recreation guarded | updater source-project guard and deprecated-file cleanup coverage prevent update from treating this source checkout as an install target. |
+| #1254, #1253, #1252 | auto-dev verification discipline covered | pipeline workflow and template validation require release-monitor scans, CI-mimic/local verification language, and queue checks beyond `verify-done`. |
+| #1247, #1241, #1238, #1243 | Hook, SessionStart, RTK, and plugin/Codex surfaces already ported | hook scripts, RTK installer/intercept paths, upstream-release issue sync, and docs/tests exist on develop. |
+
+## Deferred Or Reference-Only Ports Closed From This Sweep
+
+These upstream issues are not direct Codex package implementation work in this release. They are recorded as reference/backlog knowledge and should be reopened only with a concrete Codex-native scope:
+
+#1282, #1281, #1280, #1279, #1277, #1269, #1268, #1267, #1266, #1265, #1264, #1263, #1262, #1261, #1257.
+
+## Verification Plan
+
+- `bun test tests/unit/core/auto-tag-workflow.test.ts`
+- `bun test tests/unit/core/template-validation.test.ts tests/unit/core/installer.test.ts tests/unit/core/updater.test.ts tests/unit/core/hooks-scripts.test.ts`
+- `bun run typecheck`
+- `bun run build`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.4.14",
+  "version": "0.4.15",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/skills/omcodex-release-notes/SKILL.md
+++ b/templates/.claude/skills/omcodex-release-notes/SKILL.md
@@ -39,6 +39,16 @@ git diff --name-status ${PREV_TAG}..HEAD
 gh issue list --state closed --search "closed:>$(git log -1 --format=%ci ${PREV_TAG} | cut -d' ' -f1)" --json number,title,labels
 ```
 
+### Phase 1.5: Promote CHANGELOG
+
+Before creating a release, keep `CHANGELOG.md` as the durable source of release history:
+
+1. Confirm `CHANGELOG.md` has a `## [Unreleased]` section.
+2. Move non-empty `Unreleased` entries into `## [VERSION] - YYYY-MM-DD`.
+3. Insert a fresh empty `## [Unreleased]` section above the promoted version.
+4. Verify `.github/workflows/release.yml` can extract the promoted section with its existing `awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag"` logic.
+5. If `Unreleased` is empty, add the release summary there first rather than relying only on GitHub auto-generated notes.
+
 ### Phase 2: Classify Changes
 
 Categorize commits using Conventional Commits:

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.14",
+  "version": "0.4.15",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/tests/unit/core/auto-tag-workflow.test.ts
+++ b/tests/unit/core/auto-tag-workflow.test.ts
@@ -310,6 +310,24 @@ describe('auto-tag.yml — tag creation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Linked issue closure
+// ---------------------------------------------------------------------------
+
+describe('auto-tag.yml — linked issue closure', () => {
+  it('should parse multiple issue references after one closing keyword', async () => {
+    const content = await readWorkflow();
+    expect(content).toContain('(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+');
+    expect(content).toContain("grep -oE '#[0-9]+'");
+  });
+
+  it('should keep closing issue numbers unique before invoking gh issue close', async () => {
+    const content = await readWorkflow();
+    expect(content).toContain('sort -u');
+    expect(content).toContain('for ISSUE in $ISSUES');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Checkout configuration
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Port the forward-looking CHANGELOG promotion policy into `omcustomcodex-release-notes`, `CONTRIBUTING.md`, and the PR template.
- Fix `auto-tag.yml` linked-issue parsing so one closing keyword can close multiple issues (`Closes #1 #2 #3`).
- Add an upstream port sweep ledger mapping the remaining May 8 port backlog to concrete evidence or reference-only closure disposition.
- Bump package/template version to `0.4.15` and refresh `.omcodex.lock.json`.

## Verification
- `bun test tests/unit/core/auto-tag-workflow.test.ts` (45 pass)
- `bun test tests/unit/core/installer.test.ts tests/unit/core/updater.test.ts tests/unit/core/hooks-scripts.test.ts tests/unit/core/template-validation.test.ts` (271 pass)
- `bun test tests/unit/core/sensitive-output-guidance.test.ts tests/unit/core/template-validation.test.ts` (41 pass)
- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Issue Sweep
Closes #1288 #1282 #1281 #1280 #1279 #1277 #1273 #1269 #1268 #1267 #1266 #1265 #1264 #1263 #1262 #1261 #1260 #1259 #1258 #1257 #1255 #1254 #1253 #1252 #1247 #1243 #1241 #1238

## Notes
- #1234 was handled separately by PR #1235 and is already merged.
- npm publish is blocked in this environment: `npm whoami` returns `E401 Unauthorized`.
