### PR TITLE
fix: harden auto-dev release workflow plumbing

### DIFF
--- a/.codex/hooks/scripts/omcustom-auto-update.sh
+++ b/.codex/hooks/scripts/omcustom-auto-update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SessionStart auto-update hook — interactive omcodex update check
+# SessionStart auto-update hook — interactive omcustomcodex update check
 # Trigger: SessionStart (runs BEFORE session-env-check.sh)
 # Purpose: Check for oh-my-customcodex updates, prompt user, optionally update
 # Protocol: stdin JSON -> stdout pass-through, exit 0 ALWAYS
@@ -135,17 +135,17 @@ if read -r -t "$INPUT_TIMEOUT" answer </dev/tty 2>/dev/null; then
         echo "  ✓ Updated to v${LATEST_VERSION}" >&2
 
         # Check if project harness should be updated too
-        if [ -f ".omcustomrc.json" ]; then
+        if [ -f ".omcodexrc.json" ] || [ -f ".omcustomrc.json" ]; then
           printf "  Update project harness too? [y/N] " >/dev/tty 2>/dev/null
           if read -r -t "$INPUT_TIMEOUT" harness_answer </dev/tty 2>/dev/null; then
             case "$harness_answer" in
               [yY]|[yY][eE][sS])
                 echo "  Updating project harness..." >&2
-                if command -v omcustom >/dev/null 2>&1; then
-                  omcustom update --force >&2 2>&1 || echo "  ⚠ Harness update failed (non-blocking)" >&2
+                if command -v omcustomcodex >/dev/null 2>&1; then
+                  omcustomcodex update --force >&2 2>&1 || echo "  ⚠ Harness update failed (non-blocking)" >&2
                   echo "  ✓ Project harness updated" >&2
                 else
-                  echo "  ⚠ omcustom command not found after install" >&2
+                  echo "  ⚠ omcustomcodex command not found after install" >&2
                 fi
                 ;;
               *)

--- a/.codex/hooks/scripts/session-env-check.sh
+++ b/.codex/hooks/scripts/session-env-check.sh
@@ -130,8 +130,10 @@ OMCUSTOM_UPDATE_STATUS="unknown"
 INSTALLED_VERSION=""
 CACHED_LATEST=""
 
-# Read installed version from .omcustomrc.json
-if [ -f ".omcustomrc.json" ]; then
+# Read installed version from the Codex config, falling back to the legacy parent config.
+if [ -f ".omcodexrc.json" ]; then
+  INSTALLED_VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' .omcodexrc.json 2>/dev/null | head -1 | grep -o '"[^"]*"$' | tr -d '"')
+elif [ -f ".omcustomrc.json" ]; then
   INSTALLED_VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' .omcustomrc.json 2>/dev/null | head -1 | grep -o '"[^"]*"$' | tr -d '"')
 fi
 
@@ -226,8 +228,8 @@ case "$DRIFT_STATUS" in
 esac
 echo "" >&2
 echo "  [Lockfile Drift]" >&2
-echo "  Note: file-level lockfile drift (template hash changes) is checked via 'omcodex doctor'" >&2
-echo "  Run 'omcodex doctor' to detect modified/removed template files since install." >&2
+echo "  Note: file-level lockfile drift (template hash changes) is checked via 'omcustomcodex doctor'" >&2
+echo "  Run 'omcustomcodex doctor' to detect modified/removed template files since install." >&2
 echo "------------------------------------" >&2
 
 # SessionEnd hooks timeout (v2.1.74+)
@@ -242,12 +244,12 @@ echo "  [Update Check]" >&2
 if [ -n "$INSTALLED_VERSION" ] && [ -n "$CACHED_LATEST" ]; then
   if [ "$OMCUSTOM_UPDATE_STATUS" = "available" ]; then
     echo "  ⚡ oh-my-customcodex v${CACHED_LATEST} available (current: v${INSTALLED_VERSION})" >&2
-    echo "     Run 'omcodex update' to apply" >&2
+    echo "     Run 'omcustomcodex update' to apply" >&2
   else
     echo "  ✓ oh-my-customcodex is up to date (v${INSTALLED_VERSION})" >&2
   fi
 elif [ -n "$INSTALLED_VERSION" ]; then
-  echo "  ℹ oh-my-customcodex v${INSTALLED_VERSION} (run 'omcodex doctor --updates' to check for updates)" >&2
+  echo "  ℹ oh-my-customcodex v${INSTALLED_VERSION} (run 'omcustomcodex doctor --updates' to check for updates)" >&2
 else
   echo "  ℹ oh-my-customcodex not detected in this project" >&2
 fi

--- a/.codex/skills/harness-synthesizer/SKILL.md
+++ b/.codex/skills/harness-synthesizer/SKILL.md
@@ -112,6 +112,38 @@ Sensitive-path compatibility note: when delegated work touches `.claude/outputs/
 | `evaluator-optimizer` | Provides iterative refinement loop (gradient-free optimization) |
 | `pipeline-guards` | Harness checks usable as pipeline quality gates |
 
+## Two-Stage Isolation Pattern
+
+Use two-stage isolation when generated verifier/filter/policy code must execute sample inputs during synthesis. Stage 1 encodes the candidate harness and fixtures as Base64 so shell quoting, prompt delimiters, and embedded newlines cannot change the payload. Stage 2 decodes inside a subprocess with a narrow environment and validates the behavior through stdin/stdout only.
+
+```yaml
+harness:
+  agent: mgr-gitnerd
+  mode: verifier
+  isolation:
+    stage_1_payload:
+      encoding: base64
+      includes:
+        - candidate_harness
+        - fixtures
+        - expected_results
+    stage_2_runner:
+      command: "node /tmp/harness-runner.mjs"
+      env:
+        NODE_OPTIONS: "--no-warnings"
+      stdin: base64_payload
+      timeout_ms: 5000
+      network: disabled
+  checks:
+    - name: rejects force push
+      fixture: "git push --force origin main"
+      expect:
+        valid: false
+        reason_contains: "Force push"
+```
+
+Prefer this pattern over inline shell snippets when the fixture contains quotes, heredocs, JSON, or code blocks. The subprocess must receive only the encoded payload and return structured JSON; do not let it read project files unless the policy explicitly requires file-system evidence.
+
 ## Usage Examples
 
 ```bash

--- a/.codex/skills/omcodex-release-notes/SKILL.md
+++ b/.codex/skills/omcodex-release-notes/SKILL.md
@@ -46,8 +46,9 @@ Before creating a release, keep `CHANGELOG.md` as the durable source of release 
 1. Confirm `CHANGELOG.md` has a `## [Unreleased]` section.
 2. Move non-empty `Unreleased` entries into `## [VERSION] - YYYY-MM-DD`.
 3. Insert a fresh empty `## [Unreleased]` section above the promoted version.
-4. Verify `.github/workflows/release.yml` can extract the promoted section with its existing `awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag"` logic.
-5. If `Unreleased` is empty, add the release summary there first rather than relying only on GitHub auto-generated notes.
+4. Keep Keep a Changelog categories (`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`) intact.
+5. Verify `.github/workflows/release.yml` can extract the promoted section with its existing `awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag"` logic.
+6. If `Unreleased` is empty, add the release summary there first rather than relying only on GitHub auto-generated notes.
 
 ### Phase 2: Classify Changes
 
@@ -63,7 +64,7 @@ Categorize commits using Conventional Commits:
 | chore: | Chores | :wrench: |
 | security | Security | :lock: |
 
-### Phase 3: Generate Notes
+### Phase 4: Generate Notes
 
 Output format:
 
@@ -102,7 +103,7 @@ Output format:
 _Release notes generated with oh-my-customcodex_
 ```
 
-### Phase 4: Apply
+### Phase 5: Apply
 
 The generated notes can be:
 1. **Direct**: Passed to `gh release create --notes "{notes}"`

--- a/.codex/skills/post-release-followup/SKILL.md
+++ b/.codex/skills/post-release-followup/SKILL.md
@@ -96,7 +96,7 @@ Use AskUserQuestion (or equivalent user prompt) to get the choice.
 
 **Option C (모두 이슈 등록)**:
 - All Immediate + Trackable items → `gh issue create` with appropriate labels
-- Label: `professor` for auto-triage in next workflow run
+- Label: `triage-needed` for the next workflow run; reserve `professor` for manual analysis requests
 
 **Option D (개별 선택)**:
 - For each item, ask: `[{n}] {description} — 실행(E) / 이슈(I) / 건너뛰기(S)?`

--- a/.codex/statusline.sh
+++ b/.codex/statusline.sh
@@ -246,7 +246,7 @@ if [[ -n "$git_branch" ]] && command -v gh >/dev/null 2>&1; then
         pr_number="$cached_pr"
     else
         # Cache miss — query gh and update cache
-        pr_number="$(gh pr view --json number -q .number 2>/dev/null || echo "")"
+        pr_number="$(timeout 2 gh pr view --json number -q .number 2>/dev/null || echo "")"
         printf '%s\t%s\n' "$git_branch" "$pr_number" > "$cache_file"
     fi
 
@@ -360,21 +360,42 @@ if [[ -n "$wl_display" ]]; then
     wl_segment=" | ${wl_color}${wl_display}${COLOR_RESET}"
 fi
 
+# Build the RTK segment from the session-env bridge if available.
+rtk_segment=""
+env_status_file="/tmp/.codex-env-status-${PPID}"
+if [[ -f "$env_status_file" ]]; then
+    rtk_status=""
+    while IFS='=' read -r key value; do
+        if [[ "$key" == "rtk" ]]; then
+            rtk_status="$value"
+            break
+        fi
+    done < "$env_status_file"
+
+    if [[ "$rtk_status" == "available" ]]; then
+        rtk_segment=" | ${COLOR_CTX_OK}RTK:on${COLOR_RESET}"
+    elif [[ "$rtk_status" == "unavailable" ]]; then
+        rtk_segment=" | ${COLOR_CTX_WARN}RTK:off${COLOR_RESET}"
+    fi
+fi
+
 if [[ -n "$git_branch" ]]; then
-    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$branch_display" \
         "$pr_segment" \
         "$rl_segment" \
         "$wl_segment" \
+        "$rtk_segment" \
         "$ctx_display"
 else
-    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$pr_segment" \
         "$rl_segment" \
         "$wl_segment" \
+        "$rtk_segment" \
         "$ctx_display"
 fi

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@
 - [ ] I have run `bun run lint` (Biome) and fixed all issues
 - [ ] I have performed a self-review of my code
 - [ ] I have updated documentation if needed
+- [ ] I have updated `CHANGELOG.md` under `[Unreleased]` if this changes user-facing behavior
 - [ ] I have added tests that prove my fix/feature works
 - [ ] All tests pass with 100% coverage
 - [ ] My changes generate no new warnings

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -156,13 +156,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          ISSUES=$(
-            echo "$PR_BODY" |
-              grep -ioE '(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+' |
-              grep -oE '#[0-9]+' |
-              grep -oE '[0-9]+' |
-              sort -u
-          )
+          ISSUES=$(printf '%s\n' "$PR_BODY" \
+            | grep -oiE '(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+' \
+            | grep -oE '#[0-9]+' \
+            | tr -d '#' \
+            | sort -u)
           for ISSUE in $ISSUES; do
             echo "Closing issue #$ISSUE"
             gh issue close "$ISSUE" \

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.4.15",
-  "generatedAt": "2026-05-08T08:19:47.731Z",
+  "generatedAt": "2026-05-08T08:23:50.971Z",
   "templateVersion": "0.4.15",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
@@ -425,8 +425,8 @@
       "component": "hooks"
     },
     ".codex/hooks/scripts/omcustom-auto-update.sh": {
-      "templateHash": "e4f7a36be85d927a8e070b313554e56834fe9bce986ecb93f2234324640643aa",
-      "size": 5612,
+      "templateHash": "842bda2ac6d6a7196aa4224120597208f7f261fe335ee0f28864278d76886acf",
+      "size": 5661,
       "component": "hooks"
     },
     ".codex/hooks/scripts/stale-todo-scanner.sh": {
@@ -495,8 +495,8 @@
       "component": "hooks"
     },
     ".codex/hooks/scripts/session-env-check.sh": {
-      "templateHash": "264143dbcc109777dd95c2086e174b74c7717152dfb4c74b5460e49587f4eaf6",
-      "size": 9206,
+      "templateHash": "c558a08acacc0cd02bbd1788abeae11356bb3d9f7f227318688c3ad1847fb523",
+      "size": 9455,
       "component": "hooks"
     },
     ".codex/hooks/scripts/feedback-collector.sh": {
@@ -1080,8 +1080,8 @@
       "component": "guides"
     },
     "guides/hook-data-flow/README.md": {
-      "templateHash": "ec6541160b66eb0f599e954290d6073bd73eead5e3d4dc93648ad967d9e7493a",
-      "size": 6712,
+      "templateHash": "3eb238f5ee27668821ecfe4800e68e2695135d3843eee8ed2ee2dd1bfb4a8379",
+      "size": 6696,
       "component": "guides"
     },
     "guides/browser-automation/README.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -613,7 +613,7 @@ The `omcodex:takeover` skill enables reverse compilation: analyzing an existing 
 | Native binary spawning | No | Yes (v2.1.113+) | Compatible — per-platform optional dependency replaces bundled JavaScript |
 | `/loop` Esc cancel | No | Yes (v2.1.113+) | Compatible — Esc now cancels pending wakeups |
 
-Tested and compatible with Claude Code v2.1.72 through v2.1.114+.
+Tested and compatible with Claude Code v2.1.72 through v2.1.132+, with Codex-native behavior managed through `.codex/**` and OMX.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.15] - 2026-05-08
 
+### Added
+- Add release workflow coverage for multi-issue `Closes #A #B` auto-close parsing and package the professor-triage detailed phase guide in templates.
+- Surface RTK availability in the statusline from the Codex session environment bridge.
+- Document the harness-synthesizer two-stage Base64 plus subprocess isolation pattern.
+
 ### Changed
 - Require `omcustomcodex-release-notes` to promote populated `CHANGELOG.md` `Unreleased` entries into versioned release sections before publishing.
 - Document the upstream-port sweep dispositions for the remaining May 8 port backlog.
+- Tighten release-note guidance so `CHANGELOG.md` `[Unreleased]` entries are promoted into versioned sections during release preparation.
+- Port SessionStart auto-update prompts and environment guidance to the `omcustomcodex` command boundary.
 
 ### Fixed
 - Allow `auto-tag.yml` to close multiple linked issues from one keyword, such as `Closes #1 #2 #3`.
+- Skip stale registry project paths during project discovery and clean the registry before `omcustomcodex update --all`.
+- Add a timeout to statusline PR lookup and update hook data-flow docs to use `.codex` temp-file names.
+- Backfill `statusLine.refreshInterval` during full `omcustomcodex update` runs for existing installations.
 
 ## [0.4.14] - 2026-05-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,8 @@ The release pipeline is fully automated:
 2. **Bump version and update CHANGELOG:**
    ```bash
    npm version [major|minor|patch]
-   # Update CHANGELOG.md
+   # Promote CHANGELOG.md [Unreleased] to ## [x.y.z] - YYYY-MM-DD
+   # Then create a fresh empty ## [Unreleased] section
    git add .
    git commit -m "chore: prepare release x.y.z"
    ```
@@ -217,7 +218,7 @@ For critical bugs in production:
    # Make fix
    bun test
    npm version patch
-   # Update CHANGELOG.md
+   # Add the fix to CHANGELOG.md [Unreleased], then promote it for the hotfix tag
    git add .
    git commit -m "fix: critical bug description"
    ```

--- a/guides/hook-data-flow/README.md
+++ b/guides/hook-data-flow/README.md
@@ -26,22 +26,22 @@ The pipeline spans two hook events and three scripts:
 SubagentStart event
   └─ agent-start-recorder.sh
        reads:  stdin JSON (agent_type, model, description)
-       writes: /tmp/.claude-agent-starts-$PPID  (appends 1 JSON line)
+       writes: /tmp/.codex-agent-starts-$PPID  (appends 1 JSON line)
 
 SubagentStop event  [hooks execute in array order — ordering is critical]
   │
   ├─ [1] task-outcome-recorder.sh
   │       reads:  stdin JSON (agent_type, model, outcome)
-  │       reads:  /tmp/.claude-agent-starts-$PPID  (duration calc — entry still present)
-  │       writes: /tmp/.claude-task-outcomes-$PPID  (appends 1 JSON line with duration_seconds)
+  │       reads:  /tmp/.codex-agent-starts-$PPID  (duration calc — entry still present)
+  │       writes: /tmp/.codex-task-outcomes-$PPID  (appends 1 JSON line with duration_seconds)
   │       writes: stderr  (on failure only)
   │
   └─ [2] stall-detection-advisor.sh
           reads:  stdin JSON (agent_type, model, description)
-          reads:  /tmp/.claude-agent-starts-$PPID  (finds matching start entry for duration)
-          reads:  /tmp/.claude-agent-durations-$PPID  (peer durations for average calculation)
-          writes: /tmp/.claude-agent-durations-$PPID  (appends completed agent's duration)
-          writes: /tmp/.claude-agent-starts-$PPID  (removes consumed start entry)
+          reads:  /tmp/.codex-agent-starts-$PPID  (finds matching start entry for duration)
+          reads:  /tmp/.codex-agent-durations-$PPID  (peer durations for average calculation)
+          writes: /tmp/.codex-agent-durations-$PPID  (appends completed agent's duration)
+          writes: /tmp/.codex-agent-starts-$PPID  (removes consumed start entry)
           writes: stderr  (advisory block if stall detected — R021 advisory-only)
 ```
 
@@ -49,9 +49,9 @@ SubagentStop event  [hooks execute in array order — ordering is critical]
 
 At SubagentStop, after at least one peer has already completed:
 
-1. Calculate `avg_duration` from all entries in `.claude-agent-durations-$PPID`
+1. Calculate `avg_duration` from all entries in `.codex-agent-durations-$PPID`
 2. Set `stall_threshold = avg_duration * 2`
-3. Scan `.claude-agent-starts-$PPID` for agents not yet in the duration file (still running)
+3. Scan `.codex-agent-starts-$PPID` for agents not yet in the duration file (still running)
 4. For each still-running agent where `elapsed > stall_threshold`, emit advisory to stderr
 
 The current agent's duration is recorded *after* stall detection so it does not inflate the average for its own check.
@@ -73,9 +73,9 @@ The current agent's duration is recorded *after* stall detection so it does not 
 
 | File | Writer | Readers | Lifecycle |
 |------|--------|---------|-----------|
-| `/tmp/.claude-agent-starts-$PPID` | `agent-start-recorder.sh` (append) | `task-outcome-recorder.sh` (read), `stall-detection-advisor.sh` (read + remove entry) | Session-scoped via PPID; ring buffer 50 entries; entry removed after `stall-detection-advisor` consumes it |
-| `/tmp/.claude-task-outcomes-$PPID` | `task-outcome-recorder.sh` (append) | `feedback-collector.sh`, `eval-core-batch-save.sh` (at Stop) | Session-scoped via PPID; ring buffer 50 entries |
-| `/tmp/.claude-agent-durations-$PPID` | `stall-detection-advisor.sh` (append) | `stall-detection-advisor.sh` (read for average calculation) | Session-scoped via PPID; ring buffer 50 entries |
+| `/tmp/.codex-agent-starts-$PPID` | `agent-start-recorder.sh` (append) | `task-outcome-recorder.sh` (read), `stall-detection-advisor.sh` (read + remove entry) | Session-scoped via PPID; ring buffer 50 entries; entry removed after `stall-detection-advisor` consumes it |
+| `/tmp/.codex-task-outcomes-$PPID` | `task-outcome-recorder.sh` (append) | `feedback-collector.sh`, `eval-core-batch-save.sh` (at Stop) | Session-scoped via PPID; ring buffer 50 entries |
+| `/tmp/.codex-agent-durations-$PPID` | `stall-detection-advisor.sh` (append) | `stall-detection-advisor.sh` (read for average calculation) | Session-scoped via PPID; ring buffer 50 entries |
 
 ---
 
@@ -93,7 +93,7 @@ The SubagentStop hook array in `hooks.json` defines a strict ordering:
 
 **task-outcome-recorder MUST run before stall-detection-advisor.**
 
-Reason: `stall-detection-advisor.sh` removes the matching start entry from `.claude-agent-starts-$PPID` after reading it (to prevent re-matching on the next SubagentStop). If the order were reversed, `task-outcome-recorder.sh` would find no start entry for the agent and would always record `duration_seconds=0`.
+Reason: `stall-detection-advisor.sh` removes the matching start entry from `.codex-agent-starts-$PPID` after reading it (to prevent re-matching on the next SubagentStop). If the order were reversed, `task-outcome-recorder.sh` would find no start entry for the agent and would always record `duration_seconds=0`.
 
 If the order is swapped:
 - `task-outcome-recorder` records `duration_seconds=0` for all agents
@@ -107,10 +107,10 @@ If the order is swapped:
 ```
 Session start (PPID assigned)
   │
-  ├─ First SubagentStart  →  .claude-agent-starts-$PPID  created
+  ├─ First SubagentStart  →  .codex-agent-starts-$PPID  created
   │
-  ├─ First SubagentStop   →  .claude-task-outcomes-$PPID  created
-  │                          .claude-agent-durations-$PPID  created
+  ├─ First SubagentStop   →  .codex-task-outcomes-$PPID  created
+  │                          .codex-agent-durations-$PPID  created
   │
   ├─ Each SubagentStop    →  start entry consumed (removed by stall-detection-advisor)
   │                          duration entry appended

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -164,6 +164,28 @@ function sortProjects(projects: ProjectInfo[]): ProjectInfo[] {
   });
 }
 
+async function buildRegistryProjectInfo(
+  projectPath: string,
+  entry: { version?: string; installedAt?: string; updatedAt?: string },
+  options: ProjectsOptions,
+  home: string,
+  currentVersion: string
+): Promise<ProjectInfo | null> {
+  if (!matchesSearchPaths(projectPath, options.paths)) return null;
+  if (!isUnderHome(projectPath, home)) return null;
+  if (!(await fileExists(projectPath))) return null;
+
+  return {
+    name: basename(projectPath),
+    path: projectPath,
+    version: entry.version || null,
+    installedAt: entry.installedAt || null,
+    updatedAt: entry.updatedAt || null,
+    status: computeStatus(entry.version || null, currentVersion),
+    detectionMethod: 'registry',
+  };
+}
+
 /**
  * Find all projects registered in the local registry.
  *
@@ -197,18 +219,14 @@ export async function findProjects(options: ProjectsOptions = {}): Promise<Proje
   const home = process.env.HOME ?? homedir();
 
   for (const [projectPath, entry] of Object.entries(registry.projects)) {
-    if (!matchesSearchPaths(projectPath, options.paths)) continue;
-    if (!isUnderHome(projectPath, home)) continue;
-
-    results.push({
-      name: basename(projectPath),
-      path: projectPath,
-      version: entry.version || null,
-      installedAt: entry.installedAt || null,
-      updatedAt: entry.updatedAt || null,
-      status: computeStatus(entry.version || null, currentVersion),
-      detectionMethod: 'registry',
-    });
+    const project = await buildRegistryProjectInfo(
+      projectPath,
+      entry,
+      options,
+      home,
+      currentVersion
+    );
+    if (project) results.push(project);
   }
 
   return sortProjects(results);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -256,9 +256,11 @@ function reportProjectUpdateResult(
  */
 async function updateAllProjects(options: UpdateCommandOptions): Promise<void> {
   const { findProjects } = await import('./projects.js');
+  const { cleanRegistry } = await import('../core/registry.js');
   const currentVersion = packageJson.version as string;
 
   console.log(i18n.t('cli.update.allScanning'));
+  await cleanRegistry();
   const projects = await findProjects();
 
   if (projects.length === 0) {

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -458,6 +458,7 @@ async function runFullUpdatePostProcessing(
     result.removedDeprecatedFiles = removed;
 
     if (!options.dryRun) {
+      await ensureStatusLineConfig(options.targetDir);
       await updateEntryDoc(options.targetDir, config, options);
     }
   }
@@ -477,6 +478,43 @@ async function runFullUpdatePostProcessing(
       version: result.newVersion,
       components: result.updatedComponents.join(', '),
     });
+  }
+}
+
+/**
+ * Backfill statusLine settings for installations created before
+ * refreshInterval was added. Preserve custom commands and padding.
+ */
+async function ensureStatusLineConfig(targetDir: string): Promise<void> {
+  const layout = getProviderLayout();
+  const settingsPath = join(targetDir, layout.rootDir, 'settings.local.json');
+  const statusLineConfig = {
+    type: 'command' as const,
+    command: `${layout.rootDir}/statusline.sh`,
+    padding: 0,
+    refreshInterval: 10,
+  };
+
+  if (!(await fileExists(settingsPath))) {
+    await ensureDirectory(join(settingsPath, '..'));
+    await writeJsonFile(settingsPath, { statusLine: statusLineConfig });
+    return;
+  }
+
+  const settings = await readJsonFile<Record<string, unknown>>(settingsPath);
+  const statusLine = settings.statusLine;
+
+  if (!statusLine || typeof statusLine !== 'object' || Array.isArray(statusLine)) {
+    settings.statusLine = statusLineConfig;
+    await writeJsonFile(settingsPath, settings);
+    return;
+  }
+
+  const mergedStatusLine = statusLine as Record<string, unknown>;
+  if (mergedStatusLine.refreshInterval === undefined) {
+    mergedStatusLine.refreshInterval = statusLineConfig.refreshInterval;
+    settings.statusLine = mergedStatusLine;
+    await writeJsonFile(settingsPath, settings);
   }
 }
 
@@ -584,6 +622,16 @@ function checkAndInstallOmxAfterUpdate(): void {
   }
 }
 
+async function handleNoUpdateResult(options: UpdateOptions, result: UpdateResult): Promise<void> {
+  const isFullUpdate = !options.components || options.components.length === 0;
+  if (isFullUpdate && !options.dryRun) {
+    await ensureStatusLineConfig(options.targetDir);
+  }
+  info('update.no_updates');
+  result.success = true;
+  result.skippedComponents = options.components || getAllUpdateComponents();
+}
+
 /**
  * Update the current installation
  */
@@ -617,9 +665,7 @@ export async function update(options: UpdateOptions): Promise<UpdateResult> {
     result.newVersion = updateCheck.latestVersion;
 
     if (!updateCheck.hasUpdates && !options.force) {
-      info('update.no_updates');
-      result.success = true;
-      result.skippedComponents = options.components || getAllUpdateComponents();
+      await handleNoUpdateResult(options, result);
       return result;
     }
 

--- a/templates/.claude/hooks/scripts/omcustom-auto-update.sh
+++ b/templates/.claude/hooks/scripts/omcustom-auto-update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SessionStart auto-update hook — interactive omcodex update check
+# SessionStart auto-update hook — interactive omcustomcodex update check
 # Trigger: SessionStart (runs BEFORE session-env-check.sh)
 # Purpose: Check for oh-my-customcodex updates, prompt user, optionally update
 # Protocol: stdin JSON -> stdout pass-through, exit 0 ALWAYS
@@ -135,17 +135,17 @@ if read -r -t "$INPUT_TIMEOUT" answer </dev/tty 2>/dev/null; then
         echo "  ✓ Updated to v${LATEST_VERSION}" >&2
 
         # Check if project harness should be updated too
-        if [ -f ".omcustomrc.json" ]; then
+        if [ -f ".omcodexrc.json" ] || [ -f ".omcustomrc.json" ]; then
           printf "  Update project harness too? [y/N] " >/dev/tty 2>/dev/null
           if read -r -t "$INPUT_TIMEOUT" harness_answer </dev/tty 2>/dev/null; then
             case "$harness_answer" in
               [yY]|[yY][eE][sS])
                 echo "  Updating project harness..." >&2
-                if command -v omcustom >/dev/null 2>&1; then
-                  omcustom update --force >&2 2>&1 || echo "  ⚠ Harness update failed (non-blocking)" >&2
+                if command -v omcustomcodex >/dev/null 2>&1; then
+                  omcustomcodex update --force >&2 2>&1 || echo "  ⚠ Harness update failed (non-blocking)" >&2
                   echo "  ✓ Project harness updated" >&2
                 else
-                  echo "  ⚠ omcustom command not found after install" >&2
+                  echo "  ⚠ omcustomcodex command not found after install" >&2
                 fi
                 ;;
               *)

--- a/templates/.claude/hooks/scripts/session-env-check.sh
+++ b/templates/.claude/hooks/scripts/session-env-check.sh
@@ -126,8 +126,10 @@ OMCUSTOM_UPDATE_STATUS="unknown"
 INSTALLED_VERSION=""
 CACHED_LATEST=""
 
-# Read installed version from .omcustomrc.json
-if [ -f ".omcustomrc.json" ]; then
+# Read installed version from the Codex config, falling back to the legacy parent config.
+if [ -f ".omcodexrc.json" ]; then
+  INSTALLED_VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' .omcodexrc.json 2>/dev/null | head -1 | grep -o '"[^"]*"$' | tr -d '"')
+elif [ -f ".omcustomrc.json" ]; then
   INSTALLED_VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' .omcustomrc.json 2>/dev/null | head -1 | grep -o '"[^"]*"$' | tr -d '"')
 fi
 
@@ -222,8 +224,8 @@ case "$DRIFT_STATUS" in
 esac
 echo "" >&2
 echo "  [Lockfile Drift]" >&2
-echo "  Note: file-level lockfile drift (template hash changes) is checked via 'omcodex doctor'" >&2
-echo "  Run 'omcodex doctor' to detect modified/removed template files since install." >&2
+echo "  Note: file-level lockfile drift (template hash changes) is checked via 'omcustomcodex doctor'" >&2
+echo "  Run 'omcustomcodex doctor' to detect modified/removed template files since install." >&2
 echo "------------------------------------" >&2
 
 # SessionEnd hooks timeout (v2.1.74+)
@@ -238,12 +240,12 @@ echo "  [Update Check]" >&2
 if [ -n "$INSTALLED_VERSION" ] && [ -n "$CACHED_LATEST" ]; then
   if [ "$OMCUSTOM_UPDATE_STATUS" = "available" ]; then
     echo "  ⚡ oh-my-customcodex v${CACHED_LATEST} available (current: v${INSTALLED_VERSION})" >&2
-    echo "     Run 'omcodex update' to apply" >&2
+    echo "     Run 'omcustomcodex update' to apply" >&2
   else
     echo "  ✓ oh-my-customcodex is up to date (v${INSTALLED_VERSION})" >&2
   fi
 elif [ -n "$INSTALLED_VERSION" ]; then
-  echo "  ℹ oh-my-customcodex v${INSTALLED_VERSION} (run 'omcodex doctor --updates' to check for updates)" >&2
+  echo "  ℹ oh-my-customcodex v${INSTALLED_VERSION} (run 'omcustomcodex doctor --updates' to check for updates)" >&2
 else
   echo "  ℹ oh-my-customcodex not detected in this project" >&2
 fi

--- a/templates/.claude/skills/harness-synthesizer/SKILL.md
+++ b/templates/.claude/skills/harness-synthesizer/SKILL.md
@@ -112,6 +112,38 @@ Sensitive-path compatibility note: when delegated work touches `.claude/outputs/
 | `evaluator-optimizer` | Provides iterative refinement loop (gradient-free optimization) |
 | `pipeline-guards` | Harness checks usable as pipeline quality gates |
 
+## Two-Stage Isolation Pattern
+
+Use two-stage isolation when generated verifier/filter/policy code must execute sample inputs during synthesis. Stage 1 encodes the candidate harness and fixtures as Base64 so shell quoting, prompt delimiters, and embedded newlines cannot change the payload. Stage 2 decodes inside a subprocess with a narrow environment and validates the behavior through stdin/stdout only.
+
+```yaml
+harness:
+  agent: mgr-gitnerd
+  mode: verifier
+  isolation:
+    stage_1_payload:
+      encoding: base64
+      includes:
+        - candidate_harness
+        - fixtures
+        - expected_results
+    stage_2_runner:
+      command: "node /tmp/harness-runner.mjs"
+      env:
+        NODE_OPTIONS: "--no-warnings"
+      stdin: base64_payload
+      timeout_ms: 5000
+      network: disabled
+  checks:
+    - name: rejects force push
+      fixture: "git push --force origin main"
+      expect:
+        valid: false
+        reason_contains: "Force push"
+```
+
+Prefer this pattern over inline shell snippets when the fixture contains quotes, heredocs, JSON, or code blocks. The subprocess must receive only the encoded payload and return structured JSON; do not let it read project files unless the policy explicitly requires file-system evidence.
+
 ## Usage Examples
 
 ```bash

--- a/templates/.claude/skills/omcodex-release-notes/SKILL.md
+++ b/templates/.claude/skills/omcodex-release-notes/SKILL.md
@@ -46,8 +46,9 @@ Before creating a release, keep `CHANGELOG.md` as the durable source of release 
 1. Confirm `CHANGELOG.md` has a `## [Unreleased]` section.
 2. Move non-empty `Unreleased` entries into `## [VERSION] - YYYY-MM-DD`.
 3. Insert a fresh empty `## [Unreleased]` section above the promoted version.
-4. Verify `.github/workflows/release.yml` can extract the promoted section with its existing `awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag"` logic.
-5. If `Unreleased` is empty, add the release summary there first rather than relying only on GitHub auto-generated notes.
+4. Keep Keep a Changelog categories (`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`) intact.
+5. Verify `.github/workflows/release.yml` can extract the promoted section with its existing `awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag"` logic.
+6. If `Unreleased` is empty, add the release summary there first rather than relying only on GitHub auto-generated notes.
 
 ### Phase 2: Classify Changes
 
@@ -63,7 +64,7 @@ Categorize commits using Conventional Commits:
 | chore: | Chores | :wrench: |
 | security | Security | :lock: |
 
-### Phase 3: Generate Notes
+### Phase 4: Generate Notes
 
 Output format:
 
@@ -102,7 +103,7 @@ Output format:
 _Release notes generated with oh-my-customcodex_
 ```
 
-### Phase 4: Apply
+### Phase 5: Apply
 
 The generated notes can be:
 1. **Direct**: Passed to `gh release create --notes "{notes}"`

--- a/templates/.claude/skills/post-release-followup/SKILL.md
+++ b/templates/.claude/skills/post-release-followup/SKILL.md
@@ -96,7 +96,7 @@ Use AskUserQuestion (or equivalent user prompt) to get the choice.
 
 **Option C (모두 이슈 등록)**:
 - All Immediate + Trackable items → `gh issue create` with appropriate labels
-- Label: `professor` for auto-triage in next workflow run
+- Label: `triage-needed` for the next workflow run; reserve `professor` for manual analysis requests
 
 **Option D (개별 선택)**:
 - For each item, ask: `[{n}] {description} — 실행(E) / 이슈(I) / 건너뛰기(S)?`

--- a/templates/.claude/statusline.sh
+++ b/templates/.claude/statusline.sh
@@ -246,7 +246,7 @@ if [[ -n "$git_branch" ]] && command -v gh >/dev/null 2>&1; then
         pr_number="$cached_pr"
     else
         # Cache miss — query gh and update cache
-        pr_number="$(gh pr view --json number -q .number 2>/dev/null || echo "")"
+        pr_number="$(timeout 2 gh pr view --json number -q .number 2>/dev/null || echo "")"
         printf '%s\t%s\n' "$git_branch" "$pr_number" > "$cache_file"
     fi
 
@@ -360,21 +360,42 @@ if [[ -n "$wl_display" ]]; then
     wl_segment=" | ${wl_color}${wl_display}${COLOR_RESET}"
 fi
 
+# Build the RTK segment from the session-env bridge if available.
+rtk_segment=""
+env_status_file="/tmp/.codex-env-status-${PPID}"
+if [[ -f "$env_status_file" ]]; then
+    rtk_status=""
+    while IFS='=' read -r key value; do
+        if [[ "$key" == "rtk" ]]; then
+            rtk_status="$value"
+            break
+        fi
+    done < "$env_status_file"
+
+    if [[ "$rtk_status" == "available" ]]; then
+        rtk_segment=" | ${COLOR_CTX_OK}RTK:on${COLOR_RESET}"
+    elif [[ "$rtk_status" == "unavailable" ]]; then
+        rtk_segment=" | ${COLOR_CTX_WARN}RTK:off${COLOR_RESET}"
+    fi
+fi
+
 if [[ -n "$git_branch" ]]; then
-    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$branch_display" \
         "$pr_segment" \
         "$rl_segment" \
         "$wl_segment" \
+        "$rtk_segment" \
         "$ctx_display"
 else
-    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$pr_segment" \
         "$rl_segment" \
         "$wl_segment" \
+        "$rtk_segment" \
         "$ctx_display"
 fi

--- a/templates/guides/hook-data-flow/README.md
+++ b/templates/guides/hook-data-flow/README.md
@@ -26,22 +26,22 @@ The pipeline spans two hook events and three scripts:
 SubagentStart event
   └─ agent-start-recorder.sh
        reads:  stdin JSON (agent_type, model, description)
-       writes: /tmp/.claude-agent-starts-$PPID  (appends 1 JSON line)
+       writes: /tmp/.codex-agent-starts-$PPID  (appends 1 JSON line)
 
 SubagentStop event  [hooks execute in array order — ordering is critical]
   │
   ├─ [1] task-outcome-recorder.sh
   │       reads:  stdin JSON (agent_type, model, outcome)
-  │       reads:  /tmp/.claude-agent-starts-$PPID  (duration calc — entry still present)
-  │       writes: /tmp/.claude-task-outcomes-$PPID  (appends 1 JSON line with duration_seconds)
+  │       reads:  /tmp/.codex-agent-starts-$PPID  (duration calc — entry still present)
+  │       writes: /tmp/.codex-task-outcomes-$PPID  (appends 1 JSON line with duration_seconds)
   │       writes: stderr  (on failure only)
   │
   └─ [2] stall-detection-advisor.sh
           reads:  stdin JSON (agent_type, model, description)
-          reads:  /tmp/.claude-agent-starts-$PPID  (finds matching start entry for duration)
-          reads:  /tmp/.claude-agent-durations-$PPID  (peer durations for average calculation)
-          writes: /tmp/.claude-agent-durations-$PPID  (appends completed agent's duration)
-          writes: /tmp/.claude-agent-starts-$PPID  (removes consumed start entry)
+          reads:  /tmp/.codex-agent-starts-$PPID  (finds matching start entry for duration)
+          reads:  /tmp/.codex-agent-durations-$PPID  (peer durations for average calculation)
+          writes: /tmp/.codex-agent-durations-$PPID  (appends completed agent's duration)
+          writes: /tmp/.codex-agent-starts-$PPID  (removes consumed start entry)
           writes: stderr  (advisory block if stall detected — R021 advisory-only)
 ```
 
@@ -49,9 +49,9 @@ SubagentStop event  [hooks execute in array order — ordering is critical]
 
 At SubagentStop, after at least one peer has already completed:
 
-1. Calculate `avg_duration` from all entries in `.claude-agent-durations-$PPID`
+1. Calculate `avg_duration` from all entries in `.codex-agent-durations-$PPID`
 2. Set `stall_threshold = avg_duration * 2`
-3. Scan `.claude-agent-starts-$PPID` for agents not yet in the duration file (still running)
+3. Scan `.codex-agent-starts-$PPID` for agents not yet in the duration file (still running)
 4. For each still-running agent where `elapsed > stall_threshold`, emit advisory to stderr
 
 The current agent's duration is recorded *after* stall detection so it does not inflate the average for its own check.
@@ -73,9 +73,9 @@ The current agent's duration is recorded *after* stall detection so it does not 
 
 | File | Writer | Readers | Lifecycle |
 |------|--------|---------|-----------|
-| `/tmp/.claude-agent-starts-$PPID` | `agent-start-recorder.sh` (append) | `task-outcome-recorder.sh` (read), `stall-detection-advisor.sh` (read + remove entry) | Session-scoped via PPID; ring buffer 50 entries; entry removed after `stall-detection-advisor` consumes it |
-| `/tmp/.claude-task-outcomes-$PPID` | `task-outcome-recorder.sh` (append) | `feedback-collector.sh`, `eval-core-batch-save.sh` (at Stop) | Session-scoped via PPID; ring buffer 50 entries |
-| `/tmp/.claude-agent-durations-$PPID` | `stall-detection-advisor.sh` (append) | `stall-detection-advisor.sh` (read for average calculation) | Session-scoped via PPID; ring buffer 50 entries |
+| `/tmp/.codex-agent-starts-$PPID` | `agent-start-recorder.sh` (append) | `task-outcome-recorder.sh` (read), `stall-detection-advisor.sh` (read + remove entry) | Session-scoped via PPID; ring buffer 50 entries; entry removed after `stall-detection-advisor` consumes it |
+| `/tmp/.codex-task-outcomes-$PPID` | `task-outcome-recorder.sh` (append) | `feedback-collector.sh`, `eval-core-batch-save.sh` (at Stop) | Session-scoped via PPID; ring buffer 50 entries |
+| `/tmp/.codex-agent-durations-$PPID` | `stall-detection-advisor.sh` (append) | `stall-detection-advisor.sh` (read for average calculation) | Session-scoped via PPID; ring buffer 50 entries |
 
 ---
 
@@ -93,7 +93,7 @@ The SubagentStop hook array in `hooks.json` defines a strict ordering:
 
 **task-outcome-recorder MUST run before stall-detection-advisor.**
 
-Reason: `stall-detection-advisor.sh` removes the matching start entry from `.claude-agent-starts-$PPID` after reading it (to prevent re-matching on the next SubagentStop). If the order were reversed, `task-outcome-recorder.sh` would find no start entry for the agent and would always record `duration_seconds=0`.
+Reason: `stall-detection-advisor.sh` removes the matching start entry from `.codex-agent-starts-$PPID` after reading it (to prevent re-matching on the next SubagentStop). If the order were reversed, `task-outcome-recorder.sh` would find no start entry for the agent and would always record `duration_seconds=0`.
 
 If the order is swapped:
 - `task-outcome-recorder` records `duration_seconds=0` for all agents
@@ -107,10 +107,10 @@ If the order is swapped:
 ```
 Session start (PPID assigned)
   │
-  ├─ First SubagentStart  →  .claude-agent-starts-$PPID  created
+  ├─ First SubagentStart  →  .codex-agent-starts-$PPID  created
   │
-  ├─ First SubagentStop   →  .claude-task-outcomes-$PPID  created
-  │                          .claude-agent-durations-$PPID  created
+  ├─ First SubagentStop   →  .codex-task-outcomes-$PPID  created
+  │                          .codex-agent-durations-$PPID  created
   │
   ├─ Each SubagentStop    →  start entry consumed (removed by stall-detection-advisor)
   │                          duration entry appended

--- a/templates/guides/professor-triage/phases.md
+++ b/templates/guides/professor-triage/phases.md
@@ -1,0 +1,324 @@
+# professor-triage — Phase Implementation Detail
+
+Companion to `guides/professor-triage/README.md`. Detailed workflow for each phase.
+
+## Phase 1: Gather
+
+1. Parse arguments to determine target issues:
+   - If issue numbers provided: use those directly
+   - If `--label` provided: `gh issue list --label <label> --state <state> --json number`
+   - Default: `gh issue list --state open --json number` + exclude issues with `verify-done` label
+   - If `--since` provided: add `--search "created:>YYYY-MM-DD"` filter
+
+2. For each issue, fetch full details:
+```bash
+gh issue view NNN --json number,title,body,comments,labels,createdAt
+```
+
+3. For batches >20 issues, prefer `gh api graphql` for batch fetching to respect GitHub API rate limits (5000/hour authenticated).
+
+4. If filter returns 0 results: if `--label` was used, check label existence via `gh label list`. Report if label missing. If default filter, report "No open issues without verify-done label found."
+
+## Phase 2: Codebase Analysis
+
+For each issue, perform direct codebase analysis.
+
+### 2A: Context Extraction
+
+From issue title and body, extract:
+- File paths mentioned (regex: backtick-wrapped paths, `:\d+` line refs, `(L\d+)`, `(lines \d+-\d+)`)
+- Error messages or stack traces
+- Keywords (function names, class names, config keys, module names)
+- Component areas mentioned (e.g., "auth", "CI", "hooks")
+
+### 2B: Codebase Search
+
+Delegate to Explore agent(s):
+- Search for extracted keywords using Grep across the codebase
+- Find related files using Glob patterns derived from keywords
+- For explicitly mentioned files, verify existence and read relevant sections
+- For error messages, trace to source location
+- Map import/dependency relationships for affected files
+
+### 2C: Impact Assessment
+
+For each relevant file found:
+- Read current state of the code
+- Check recent changes: `git log --since=<issue_created_date> --oneline -- <file>`
+- Determine if the issue has already been addressed by recent commits
+- Assess blast radius (what depends on this code, what does this code depend on)
+
+### 2D: Structured Finding
+
+Produce per-issue analysis:
+
+| Field | Content |
+|-------|---------|
+| Affected files | List with status: `exists` ✅ / `missing` ❌ / `changed-since-issue` ⚠️ |
+| Architecture impact | Breaking changes, dependency effects, scope of change |
+| Implementation path | Concrete steps with file:line references from current codebase |
+| Risk level | P1 (critical/security/breaking) / P2 (moderate/compat) / P3 (nice-to-have) |
+| Size estimate | XS (<1h) / S (1-3h) / M (3-8h) / L (1-3d) / XL (>3d) |
+| Already resolved? | Yes / No / Partial — with git evidence (commit hash, PR number) |
+
+### Parallelization (R009/R018)
+
+- 1-3 issues → single Explore agent per issue (parallel per R009)
+- 4-10 issues → parallel Explore agents, max 4 concurrent (R009)
+- 10+ issues or 3+ Explore agents needed → Agent Teams per R018
+
+**Delegation**: All codebase search delegated to Explore agent(s) with `model: haiku`. Orchestrator collects and synthesizes results.
+
+## Phase 3: Cross-Analyze
+
+**R010 note**: This is a read-only analytical step — no file writes. Per R010 exception, the orchestrator may perform this directly. For batches >15 issues, delegate to a dedicated cross-analysis agent with model: opus.
+
+Perform deep cross-analysis with full context from all issues:
+
+1. **Common patterns** — Identify findings that appear across multiple issues (e.g., same file referenced, same recommendation theme)
+2. **Duplicate/merge candidates** — Detect issues tracking the same underlying change:
+   - Same release series (e.g., alpha.3/5/6)
+   - Same upstream dependency
+   - Same affected component
+3. **Conflicting findings** — Where findings disagree across issues, resolve based on:
+   - Codebase evidence (Phase 2 results)
+   - Specificity (concrete code-level finding > abstract observation)
+   - Recency (newer findings > older ones)
+4. **Priority matrix** — Unified priority ranking:
+   - P1: Breaking changes, security issues, blocking bugs
+   - P2: Documentation gaps, compatibility updates, medium-risk items
+   - P3: Nice-to-have improvements, future considerations
+5. **Action determination** — Per-issue decision:
+   - `Close (Already Resolved)`: Phase 2 found issue already fixed by recent commits
+   - `Close (Not Applicable)`: Issue is irrelevant (internal dependency tag, no impact)
+   - `Close (Duplicate of #NNN)`: Superseded by another issue in the batch
+   - `Open — action required`: Real work needed
+   - `Open — monitoring`: Waiting for external trigger (e.g., stable release)
+   - `New issue needed`: Cross-analysis discovered issue not yet tracked
+
+## Phase 4: Multi-Perspective Analysis & Output
+
+Generate multi-perspective analysis comments and artifacts for each analyzed issue.
+
+### Parallelization (R009)
+
+- Phase 4A + 4B: parallel (independent perspectives)
+- Phase 4C: after 4A + 4B complete (synthesis requires both inputs)
+- Phase 4D + 4E: parallel (independent outputs, both depend on 4C)
+- Phase 4F: after all above (verification gate)
+
+### Agent Selection Rationale
+
+Phases 4A, 4B, 4C, 4E use `general-purpose` (NOT `arch-documenter`).
+
+`arch-documenter` has `disallowedTools: [Bash]` → cannot execute `/tmp/*.sh` bypass pattern → falls back to Write tool → triggers Codex/Claude-compat sensitive-path guard on `.codex/outputs/`. `general-purpose` has Bash access and can use the `/tmp/*.sh` bypass. See #1043.
+
+### 4A: Senior Architect Analysis
+
+Delegate to general-purpose (model: sonnet). Post GitHub comment per issue:
+
+```
+## 🏛️ Senior Architect Analysis
+
+### 아키텍처 영향
+| 컴포넌트 | 영향 | 위험도 |
+|----------|------|--------|
+| {컴포넌트} | {설명} | {High/Medium/Low} |
+
+### 코드 수준 분석
+{Phase 2 코드베이스 분석의 구체적 file:line 참조}
+
+### 전략적 평가
+- **실현 가능성**: {근거가 포함된 평가}
+- **우선순위 권장**: {P1/P2/P3 및 근거}
+
+### 리스크 및 고려사항
+| 리스크 | 가능성 | 완화 방안 |
+|--------|--------|----------|
+| {리스크} | {High/Medium/Low} | {완화 방안} |
+
+**예상 작업량**: {XS/S/M/L/XL}
+
+---
+_🏛️ Senior Architect perspective — `/professor-triage` v2.3.0_
+```
+
+### 4B: Project Colleague Review
+
+Delegate to general-purpose (model: sonnet). Post GitHub comment per issue:
+
+```
+## 🤝 Project Colleague Review
+
+### 구현 아이디어
+{구체적 코드 위치 및 file:line 참조가 포함된 변경 제안}
+
+### 놓치기 쉬운 세부사항
+- {이름 충돌, 유효성 검사 우회, 경쟁 조건, 엣지 케이스}
+
+### 권장 다음 단계
+1. {구체적 file/function 참조가 포함된 실행 가능한 단계}
+2. {실행 가능한 단계}
+3. {실행 가능한 단계}
+
+---
+_🤝 Project Colleague perspective — `/professor-triage` v2.3.0_
+```
+
+**Note**: Do NOT include a "First Impressions" (첫인상) section — explicitly excluded per user feedback.
+
+### 4C: Professor Synthesis
+
+Delegate to general-purpose (model: opus). Requires 4A and 4B results as input. Post GitHub comment per issue:
+
+```
+## 🎓 Professor Synthesis
+
+### 코드베이스 검증
+| 주장 (Architect/Colleague) | 검증 | 근거 |
+|---------------------------|------|------|
+| {주장} | ✅/⚠️/❌ | {file:line 또는 git 근거} |
+
+### 합의 및 이견
+| 주제 | Architect | Colleague | 판정 |
+|------|-----------|-----------|------|
+| {주제} | {입장} | {입장} | {종합 판단} |
+
+### 우선순위 매트릭스
+| 차원 | 평가 |
+|------|------|
+| 긴급성 | {High/Medium/Low} |
+| 중요성 | {High/Medium/Low} |
+| 규모 | {XS/S/M/L/XL} |
+| 권장 순서 | {배치 내 N/M} |
+
+### 누락된 관점
+{Architect나 Colleague 모두 제기하지 않은 고려사항}
+
+### 실행 로드맵
+| 단계 | 작업 | 파일 | 의존성 |
+|------|------|------|--------|
+| 1 | {작업} | {파일} | — |
+| 2 | {작업} | {파일} | 단계 1 |
+
+### 최종 결론
+{확정적 권장 사항이 포함된 2-3문장 종합}
+
+---
+_🎓 Professor Synthesis — `/professor-triage` v2.3.0_
+```
+
+### 4D: Issue Triage Comment (MANDATORY)
+
+Every analyzed issue MUST receive a triage comment. Skipping breaks the triage audit trail. Delegate to mgr-gitnerd:
+
+```
+## 🔬 Professor Triage — Codebase Analysis Result
+
+**결정**: {Close (Already Resolved) | Close (Not Applicable) | Close (Duplicate of #NNN) | Open — action required | Open — monitoring}
+**근거**: {코드베이스 분석 기반 1-2줄 요약}
+**영향 파일**: {N}개 분석 — {N}✅ {N}⚠️ {N}❌
+**리스크**: {P1/P2/P3} | **규모**: {XS/S/M/L/XL}
+**전체 리포트**: {artifact path}
+
+---
+_`/professor-triage` v2.3.0에 의해 현재 코드베이스 대비 분석됨 — 관련 이슈 {N}개_
+```
+
+### 4E: Artifact Report
+
+Delegate to general-purpose. Path: `.codex/outputs/sessions/YYYY-MM-DD/professor-triage-HHmmss.md`
+
+**Sensitive-path compatibility note**: Write `.codex/outputs/` artifacts with the normal file-write path. Use `/tmp/professor-triage-<timestamp>.md` only as a legacy fallback when an older Claude Code runtime still prompts on `.claude/**` or `templates/.claude/**` compatibility paths, then verify the resulting diff.
+
+Artifact template:
+
+```
+# Professor Triage リポート — YYYY-MM-DD
+
+## 분석 대상
+| # | 제목 | 라벨 | 생성일 |
+|---|------|------|--------|
+
+## 이슈별 분석
+### #NNN — title
+- **영향 파일**: N개 분석 — N✅ N⚠️ N❌
+- **아키텍처 영향**: ...
+- **구현 경로**: ...
+- **리스크/우선순위**: P1/P2/P3
+- **규모**: XS/S/M/L/XL
+- **이미 해결됨?**: Yes/No/Partial — 근거
+- **권장 조치**: ...
+
+## 교차 분석
+### 공통 패턴
+### 중복/병합 후보
+### 상충 발견사항 해결
+### 우선순위 매트릭스
+
+## 다관점 요약
+### Architect 주요 사항
+### Colleague 주요 사항
+### Professor Synthesis 핵심 포인트
+
+## 실행된 조치
+| 이슈 | 조치 | 상태 |
+
+## 보류 중인 조치 (확인 필요)
+```
+
+### 4F: Comment Verification Gate
+
+Before proceeding to Phase 5, verify ALL analyzed issues received all 4 comment types:
+
+```bash
+# For each issue NNN in the batch:
+gh issue view NNN --json comments --jq '.comments | map(select(.body | contains("Professor Triage"))) | length'
+# Must be >= 1 for every issue. If any is 0, go back and post.
+
+gh issue view NNN --json comments --jq '.comments | map(select(.body | contains("Senior Architect"))) | length'
+gh issue view NNN --json comments --jq '.comments | map(select(.body | contains("Project Colleague"))) | length'
+gh issue view NNN --json comments --jq '.comments | map(select(.body | contains("Professor Synthesis"))) | length'
+# All must be >= 1.
+```
+
+## Phase 5: Act
+
+Delegate ALL GitHub operations to mgr-gitnerd.
+
+### Automatic (low-risk, reversible)
+
+| Condition | Action |
+|-----------|--------|
+| Phase 2 found issue already resolved (with commit evidence) | `gh issue close --reason "completed"` + comment with resolving commit |
+| Cross-analysis concludes "Not Applicable" / "no action needed" | `gh issue close --reason "not planned"` |
+| Cross-analysis detects same-series duplicates | Keep latest, close others + `duplicate` label |
+| All analysis complete | Add `verify-done` label |
+| Priority assigned | Add `P1`/`P2`/`P3` label |
+
+### Confirmation Required (high-risk)
+
+Present to user and wait for approval before executing:
+
+| Condition | Action | Reason |
+|-----------|--------|--------|
+| Reopen a closed issue | Propose reopen | Unintended notifications |
+| New issue creation needed | Present draft title/body | Noise prevention |
+| Epic/milestone linking | Propose link | Project structure change |
+| Issue body modification | Present edit draft | Respect original author intent |
+
+**Ensure `verify-done` label exists**: If not, create with `gh label create "verify-done" --color "0E8A16"`.
+
+## Phase Notes Summary
+
+| Phase | Owner | Model | R010 Exception? |
+|-------|-------|-------|----------------|
+| 1 | Orchestrator | — | Yes (read-only fetch) |
+| 2 | Explore agents | haiku | No (delegated) |
+| 3 | Orchestrator (opus for >15 issues) | sonnet/opus | Yes (read-only analysis) |
+| 4A/4B | general-purpose | sonnet | No (delegated) |
+| 4C | general-purpose | opus | No (delegated) |
+| 4D | mgr-gitnerd | — | No (delegated) |
+| 4E | general-purpose | — | No (delegated) |
+| 4F | Orchestrator | — | Yes (verification read-only) |
+| 5 | mgr-gitnerd | — | No (delegated) |

--- a/tests/unit/cli/projects.test.ts
+++ b/tests/unit/cli/projects.test.ts
@@ -524,6 +524,37 @@ describe('findProjects() — registry-based detection', () => {
 
     expect(results.find((p) => p.path === subProject)).toBeDefined();
   });
+
+  it('skips stale registry entries whose project paths no longer exist', async () => {
+    const existingDir = await mkDir(tempRoot, 'existing-registry-project');
+    const missingDir = join(tempRoot, 'deleted-registry-project');
+    const registryDir = join(tempRoot, '.oh-my-customcodex');
+    await mkdir(registryDir, { recursive: true });
+    await writeFile(
+      join(registryDir, 'projects.json'),
+      JSON.stringify({
+        projects: {
+          [existingDir]: {
+            version: '0.79.0',
+            installedAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+          [missingDir]: {
+            version: '0.79.0',
+            installedAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+      'utf-8'
+    );
+    _setRegistryDirForTesting(registryDir);
+
+    const results = await findProjects();
+
+    expect(results.find((p) => p.path === existingDir)).toBeDefined();
+    expect(results.find((p) => p.path === missingDir)).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -936,9 +967,9 @@ describe('projectsCommand() — shortenPath coverage', () => {
     const realHome = homedir();
     process.env.HOME = realHome;
 
-    // Create a project path under home dir to trigger the ~ shortening branch
-    // We don't actually create the directory — we fake the registry entry instead
+    // Create a project path under home dir to trigger the ~ shortening branch.
     const projectUnderHome = join(realHome, '.oh-my-customcodex-test-project-coverage');
+    await mkdir(projectUnderHome, { recursive: true });
     const registryDir = join(tempRoot, '.oh-my-customcodex');
     await mkdir(registryDir, { recursive: true });
     await writeFile(
@@ -968,6 +999,7 @@ describe('projectsCommand() — shortenPath coverage', () => {
       expect(output).toContain('~');
     } finally {
       consoleSpy.mockRestore();
+      await rm(projectUnderHome, { recursive: true, force: true });
       // Restore HOME to tempRoot for the afterEach cleanup to work correctly
       process.env.HOME = tempRoot;
     }

--- a/tests/unit/core/auto-tag-workflow.test.ts
+++ b/tests/unit/core/auto-tag-workflow.test.ts
@@ -314,13 +314,14 @@ describe('auto-tag.yml — tag creation', () => {
 // ---------------------------------------------------------------------------
 
 describe('auto-tag.yml — linked issue closure', () => {
-  it('should parse multiple issue references after one closing keyword', async () => {
+  it('should close multiple issue references from one closing keyword', async () => {
     const content = await readWorkflow();
-    expect(content).toContain('(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+');
+    expect(content).toContain("'(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+'");
     expect(content).toContain("grep -oE '#[0-9]+'");
+    expect(content).toContain("tr -d '#'");
   });
 
-  it('should keep closing issue numbers unique before invoking gh issue close', async () => {
+  it('should deduplicate linked issue numbers before closing', async () => {
     const content = await readWorkflow();
     expect(content).toContain('sort -u');
     expect(content).toContain('for ISSUE in $ISSUES');

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -789,6 +789,22 @@ describe('Template Validation', () => {
       expect(repoWorkflow).toBe(templateWorkflow);
     });
 
+    it('professor-triage detailed phase guide is included in templates', async () => {
+      const sourceGuide = await readFile(
+        join(PROJECT_ROOT, 'guides/professor-triage/phases.md'),
+        'utf-8'
+      );
+      const templateGuide = await readFile(
+        join(PROJECT_ROOT, 'templates/guides/professor-triage/phases.md'),
+        'utf-8'
+      );
+
+      expect(templateGuide).toBe(sourceGuide);
+      expect(templateGuide).toContain('Senior Architect Analysis');
+      expect(templateGuide).toContain('Project Colleague Review');
+      expect(templateGuide).toContain('Professor Synthesis');
+    });
+
     it('auto-dev workflow inventories release-monitor issues before declaring no work', async () => {
       const repoWorkflow = await readFile(join(PROJECT_ROOT, 'workflows/auto-dev.yaml'), 'utf-8');
       const skillWorkflow = await readFile(

--- a/tests/unit/core/updater.test.ts
+++ b/tests/unit/core/updater.test.ts
@@ -1009,6 +1009,67 @@ describe('updater', () => {
     });
   });
 
+  describe('statusLine settings backfill', () => {
+    it('should add refreshInterval to existing statusLine settings during full update', async () => {
+      await createConfig(MANIFEST_VERSION, {
+        rules: MANIFEST_VERSION,
+        agents: MANIFEST_VERSION,
+        skills: MANIFEST_VERSION,
+        guides: MANIFEST_VERSION,
+        hooks: MANIFEST_VERSION,
+        contexts: MANIFEST_VERSION,
+        ontology: MANIFEST_VERSION,
+      });
+
+      const layout = getProviderLayout();
+      await createDirStructure({
+        [`${layout.rootDir}/settings.local.json`]: JSON.stringify({
+          statusLine: {
+            type: 'command',
+            command: `${layout.rootDir}/custom-statusline.sh`,
+            padding: 2,
+          },
+          enableAllProjectMcpServers: true,
+        }),
+      });
+
+      const result = await update({ targetDir: tempDir });
+
+      const settings = JSON.parse(
+        await readFile(join(tempDir, layout.rootDir, 'settings.local.json'), 'utf-8')
+      );
+      expect(result.success).toBe(true);
+      expect(settings.statusLine.command).toBe(`${layout.rootDir}/custom-statusline.sh`);
+      expect(settings.statusLine.padding).toBe(2);
+      expect(settings.statusLine.refreshInterval).toBe(10);
+      expect(settings.enableAllProjectMcpServers).toBe(true);
+    });
+
+    it('should create statusLine settings during full update when settings.local.json is missing', async () => {
+      await createConfig(MANIFEST_VERSION, {
+        rules: MANIFEST_VERSION,
+        agents: MANIFEST_VERSION,
+        skills: MANIFEST_VERSION,
+        guides: MANIFEST_VERSION,
+        hooks: MANIFEST_VERSION,
+        contexts: MANIFEST_VERSION,
+        ontology: MANIFEST_VERSION,
+      });
+
+      const layout = getProviderLayout();
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({ targetDir: tempDir });
+
+      const settings = JSON.parse(
+        await readFile(join(tempDir, layout.rootDir, 'settings.local.json'), 'utf-8')
+      );
+      expect(result.success).toBe(true);
+      expect(settings.statusLine.command).toBe(`${layout.rootDir}/statusline.sh`);
+      expect(settings.statusLine.refreshInterval).toBe(10);
+    });
+  });
+
   describe('removeDeprecatedFiles (Bug #202)', () => {
     it('should remove deprecated files during full update', async () => {
       await createConfig('0.1.0');


### PR DESCRIPTION
## Summary
- Backfill `statusLine.refreshInterval` during full `omcustomcodex update` runs while preserving custom statusline commands and padding.
- Harden project discovery/update-all against stale registry paths and clean the registry before batch updates.
- Port SessionStart auto-update guidance to the `omcustomcodex` command boundary and add RTK/statusline visibility plus hook data-flow `.codex` temp-file corrections.
- Package the professor-triage phase guide in templates and add harness-synthesizer two-stage Base64/subprocess isolation guidance.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test tests/unit/core/auto-tag-workflow.test.ts tests/unit/core/template-validation.test.ts tests/unit/cli/projects.test.ts tests/unit/core/updater.test.ts tests/unit/cli/update.test.ts` (229 pass)
- Pre-commit was attempted earlier; it still fails in the known `core-update-registry-template-hooks` batch with 41 hook-script expectation failures unrelated to this follow-up.

## Notes
- This is a follow-up to merged PR #1290 on the same release branch. It keeps the v0.4.15 release branch shape and adds the hardening that landed after #1290 merged.