### PR TITLE
Gate OMX readiness on v0.18.0 API support

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -12,7 +12,7 @@ import { loadConfig } from '../core/config.js';
 import { checkFrameworkVersion } from '../core/doctor-framework.js';
 import { getComponentPath, getProviderLayout } from '../core/layout.js';
 import { computeFileHash, readLockfile } from '../core/lockfile.js';
-import { getOmxVersion, installOmx, isOmxInstalled } from '../core/omx-installer.js';
+import { assessOmxInstallation, installOmx, MINIMUM_OMX_VERSION } from '../core/omx-installer.js';
 import { getRtkVersion, installRtk, isRtkInstalled } from '../core/rtk-installer.js';
 import { checkSelfUpdate } from '../core/self-update.js';
 import { i18n } from '../i18n/index.js';
@@ -566,7 +566,9 @@ export async function checkCodex(): Promise<CheckResult> {
  * Check if OMX CLI is installed for the parent harness dependency
  */
 export async function checkOmx(): Promise<CheckResult> {
-  if (!isOmxInstalled()) {
+  const omx = assessOmxInstallation();
+
+  if (omx.status === 'missing') {
     return {
       name: 'OMX',
       status: 'warn',
@@ -575,11 +577,37 @@ export async function checkOmx(): Promise<CheckResult> {
     };
   }
 
-  const version = getOmxVersion();
+  if (omx.status === 'stale') {
+    return {
+      name: 'OMX',
+      status: 'warn',
+      message: `OMX stale (${omx.version ?? 'unknown version'}) — requires oh-my-codex v${MINIMUM_OMX_VERSION}+ with omx api`,
+      fixable: true,
+    };
+  }
+
+  if (omx.status === 'api-missing') {
+    return {
+      name: 'OMX',
+      status: 'warn',
+      message: `OMX missing required omx api command (${omx.version ?? 'unknown version'}) — install oh-my-codex v${MINIMUM_OMX_VERSION}+`,
+      fixable: true,
+    };
+  }
+
+  if (omx.status === 'unknown-version') {
+    return {
+      name: 'OMX',
+      status: 'warn',
+      message: `OMX version could not be verified — requires oh-my-codex v${MINIMUM_OMX_VERSION}+ with omx api`,
+      fixable: true,
+    };
+  }
+
   return {
     name: 'OMX',
     status: 'pass',
-    message: `OMX OK (${version ?? 'unknown version'})`,
+    message: `OMX OK (${omx.version ?? 'unknown version'}, omx api available)`,
     fixable: false,
   };
 }
@@ -764,7 +792,7 @@ export async function fixIssues(
   const fixedChecks: CheckResult[] = [];
 
   for (const check of checks) {
-    if (check.status !== 'fail' || !check.fixable) {
+    if (check.status === 'pass' || !check.fixable) {
       fixedChecks.push(check);
       continue;
     }
@@ -1018,7 +1046,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
   // Apply fixes if requested
   let checks: CheckResult[] = checksWithUpdate;
   if (options.fix) {
-    const hasFixableIssues = checksWithUpdate.some((c) => c.status === 'fail' && c.fixable);
+    const hasFixableIssues = checksWithUpdate.some((c) => c.status !== 'pass' && c.fixable);
 
     if (hasFixableIssues) {
       console.log(i18n.t('cli.doctor.applyingFixes'));

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -43,7 +43,7 @@ import {
   type InstallComponent,
 } from './layout.js';
 import { generateAndWriteLockfileForDir } from './lockfile.js';
-import { installOmx, isOmxInstalled } from './omx-installer.js';
+import { assessOmxInstallation, installOmx, MINIMUM_OMX_VERSION } from './omx-installer.js';
 import { installRtk, isRtkInstalled } from './rtk-installer.js';
 import {
   getAgentDomain,
@@ -416,14 +416,17 @@ function installCodexIfNeeded(result: InstallResult): void {
  * Install OMX CLI if not already installed, adding warnings to result on failure
  */
 function installOmxIfNeeded(result: InstallResult): void {
-  if (!isOmxInstalled()) {
+  const omx = assessOmxInstallation();
+
+  if (omx.status !== 'ready') {
     info('install.omx_installing');
     const omxInstalled = installOmx();
     if (omxInstalled) {
       info('install.omx_success');
     } else {
+      const versionDetail = omx.version ? ` (found ${omx.version})` : '';
       result.warnings.push(
-        'OMX installation failed — install manually: npm install -g oh-my-codex'
+        `OMX installation/upgrade failed${versionDetail} — install oh-my-codex >= v${MINIMUM_OMX_VERSION} manually: npm install -g oh-my-codex@latest`
       );
     }
   } else {

--- a/src/core/omx-installer.ts
+++ b/src/core/omx-installer.ts
@@ -8,9 +8,22 @@ import { type ExecSyncOptions, execSync } from 'node:child_process';
 import { platform } from 'node:os';
 import { info, warn } from '../utils/logger.js';
 
+export const MINIMUM_OMX_VERSION = '0.18.0';
+
 export interface InstallerDeps {
   exec: (cmd: string, opts?: ExecSyncOptions) => string | Buffer;
   getPlatform: () => NodeJS.Platform;
+}
+
+export type OmxInstallStatus = 'missing' | 'stale' | 'api-missing' | 'unknown-version' | 'ready';
+
+export interface OmxInstallationAssessment {
+  status: OmxInstallStatus;
+  installed: boolean;
+  version: string | null;
+  parsedVersion: string | null;
+  minimumVersion: string;
+  hasApiCommand: boolean;
 }
 
 const defaultDeps: InstallerDeps = {
@@ -41,12 +54,149 @@ export function getOmxVersion(deps: InstallerDeps = defaultDeps): string | null 
   }
 }
 
+export function parseOmxVersion(versionOutput: string | null): string | null {
+  if (!versionOutput) {
+    return null;
+  }
+
+  const match = versionOutput.match(
+    /\bv?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\b/
+  );
+  return match ? match[1] : null;
+}
+
+function parseVersionParts(version: string): {
+  core: [number, number, number];
+  prerelease: string | null;
+} {
+  const [withoutBuild] = version.split('+');
+  const [coreText, prerelease = null] = withoutBuild.split('-', 2);
+  const coreParts = coreText.split('.').map((part) => Number.parseInt(part, 10));
+
+  return {
+    core: [coreParts[0] ?? 0, coreParts[1] ?? 0, coreParts[2] ?? 0],
+    prerelease,
+  };
+}
+
+export function compareOmxVersions(left: string, right: string): number {
+  const a = parseVersionParts(left);
+  const b = parseVersionParts(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    const diff = a.core[index] - b.core[index];
+    if (diff !== 0) {
+      return diff > 0 ? 1 : -1;
+    }
+  }
+
+  if (a.prerelease === b.prerelease) {
+    return 0;
+  }
+  if (a.prerelease === null) {
+    return 1;
+  }
+  if (b.prerelease === null) {
+    return -1;
+  }
+
+  return a.prerelease.localeCompare(b.prerelease, undefined, { numeric: true });
+}
+
+export function isOmxVersionAtLeast(
+  version: string | null,
+  minimumVersion: string = MINIMUM_OMX_VERSION
+): boolean {
+  const parsedVersion = parseOmxVersion(version);
+  return parsedVersion !== null && compareOmxVersions(parsedVersion, minimumVersion) >= 0;
+}
+
+export function hasOmxApiCommand(deps: InstallerDeps = defaultDeps): boolean {
+  try {
+    deps.exec('omx api --help', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 3000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function assessOmxInstallation(
+  deps: InstallerDeps = defaultDeps
+): OmxInstallationAssessment {
+  if (!isOmxInstalled(deps)) {
+    return {
+      status: 'missing',
+      installed: false,
+      version: null,
+      parsedVersion: null,
+      minimumVersion: MINIMUM_OMX_VERSION,
+      hasApiCommand: false,
+    };
+  }
+
+  const version = getOmxVersion(deps);
+  const parsedVersion = parseOmxVersion(version);
+
+  if (parsedVersion && compareOmxVersions(parsedVersion, MINIMUM_OMX_VERSION) < 0) {
+    return {
+      status: 'stale',
+      installed: true,
+      version,
+      parsedVersion,
+      minimumVersion: MINIMUM_OMX_VERSION,
+      hasApiCommand: false,
+    };
+  }
+
+  const hasApi = hasOmxApiCommand(deps);
+
+  if (parsedVersion && !hasApi) {
+    return {
+      status: 'api-missing',
+      installed: true,
+      version,
+      parsedVersion,
+      minimumVersion: MINIMUM_OMX_VERSION,
+      hasApiCommand: false,
+    };
+  }
+
+  if (!parsedVersion && !hasApi) {
+    return {
+      status: 'unknown-version',
+      installed: true,
+      version,
+      parsedVersion: null,
+      minimumVersion: MINIMUM_OMX_VERSION,
+      hasApiCommand: false,
+    };
+  }
+
+  return {
+    status: 'ready',
+    installed: true,
+    version,
+    parsedVersion,
+    minimumVersion: MINIMUM_OMX_VERSION,
+    hasApiCommand: hasApi,
+  };
+}
+
+export function isOmxReady(deps: InstallerDeps = defaultDeps): boolean {
+  return assessOmxInstallation(deps).status === 'ready';
+}
+
 export function installOmx(deps: InstallerDeps = defaultDeps): boolean {
   if (process.env.CI || process.env.NODE_ENV === 'test' || process.env.BUN_ENV === 'test') {
     return false;
   }
 
-  if (isOmxInstalled(deps)) {
+  const current = assessOmxInstallation(deps);
+  if (current.status === 'ready') {
     info('install.omx_already');
     return true;
   }
@@ -59,11 +209,11 @@ export function installOmx(deps: InstallerDeps = defaultDeps): boolean {
 
   try {
     info('install.omx_installing');
-    deps.exec('npm install -g oh-my-codex', {
+    deps.exec('npm install -g oh-my-codex@latest', {
       stdio: 'inherit',
       timeout: 120000,
     });
-    return isOmxInstalled(deps);
+    return isOmxReady(deps);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     warn('install.omx_install_failed', { error: message });

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -28,7 +28,7 @@ import {
   type Lockfile,
   readLockfile,
 } from './lockfile.js';
-import { installOmx, isOmxInstalled } from './omx-installer.js';
+import { assessOmxInstallation, installOmx, MINIMUM_OMX_VERSION } from './omx-installer.js';
 import { installRtk, isRtkInstalled } from './rtk-installer.js';
 
 /**
@@ -612,9 +612,18 @@ function checkAndInstallCodexAfterUpdate(): void {
  * Check if OMX CLI is installed after an update and install it if missing
  */
 function checkAndInstallOmxAfterUpdate(): void {
-  if (!isOmxInstalled()) {
+  const omx = assessOmxInstallation();
+
+  if (omx.status !== 'ready') {
     warn('update.omx_missing');
-    console.log(i18n.t('cli.update.omxMissing'));
+    if (omx.status === 'missing') {
+      console.log(i18n.t('cli.update.omxMissing'));
+    } else {
+      const versionDetail = omx.version ? ` (${omx.version})` : '';
+      console.log(
+        `OMX${versionDetail} does not meet the oh-my-codex v${MINIMUM_OMX_VERSION} baseline. Attempting upgrade...`
+      );
+    }
     const omxInstalled = installOmx();
     if (omxInstalled) {
       console.log(i18n.t('cli.update.omxInstalled'));

--- a/tests/unit/cli/doctor-omx.test.ts
+++ b/tests/unit/cli/doctor-omx.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
+const readyAssessment = {
+  status: 'ready',
+  installed: true,
+  version: 'oh-my-codex v0.18.0',
+  parsedVersion: '0.18.0',
+  minimumVersion: '0.18.0',
+  hasApiCommand: true,
+};
+
+type MockOmxDeps = {
+  exec?: (cmd: string, opts?: unknown) => string | Buffer;
+};
+
+type MockOmxAssessment = {
+  status: string;
+  installed: boolean;
+  version: string | null;
+  parsedVersion: string | null;
+  minimumVersion: string;
+  hasApiCommand: boolean;
+};
+
+function parseMockOmxVersion(versionOutput: string | null): string | null {
+  if (!versionOutput) {
+    return null;
+  }
+
+  const match = versionOutput.match(
+    /\bv?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\b/
+  );
+  return match ? match[1] : null;
+}
+
+function parseMockVersionParts(version: string): {
+  core: [number, number, number];
+  prerelease: string | null;
+} {
+  const [withoutBuild] = version.split('+');
+  const [coreText, prerelease = null] = withoutBuild.split('-', 2);
+  const coreParts = coreText.split('.').map((part) => Number.parseInt(part, 10));
+
+  return {
+    core: [coreParts[0] ?? 0, coreParts[1] ?? 0, coreParts[2] ?? 0],
+    prerelease,
+  };
+}
+
+function compareMockOmxVersions(left: string, right: string): number {
+  const a = parseMockVersionParts(left);
+  const b = parseMockVersionParts(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    const diff = a.core[index] - b.core[index];
+    if (diff !== 0) {
+      return diff > 0 ? 1 : -1;
+    }
+  }
+
+  if (a.prerelease === b.prerelease) {
+    return 0;
+  }
+  if (a.prerelease === null) {
+    return 1;
+  }
+  if (b.prerelease === null) {
+    return -1;
+  }
+
+  return a.prerelease.localeCompare(b.prerelease, undefined, { numeric: true });
+}
+
+function assessOmxFromDepsOr(fallback: () => MockOmxAssessment) {
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: mirrors the OMX status helper for same-process mocks.
+  return (deps?: MockOmxDeps) => {
+    if (!deps?.exec) {
+      return fallback();
+    }
+
+    try {
+      deps.exec('which omx', { stdio: 'pipe', timeout: 3000 });
+    } catch {
+      return {
+        status: 'missing',
+        installed: false,
+        version: null,
+        parsedVersion: null,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    let version: string | null = null;
+    try {
+      version = String(
+        deps.exec('omx --version', { encoding: 'utf-8', stdio: 'pipe', timeout: 3000 })
+      ).trim();
+    } catch {
+      version = null;
+    }
+
+    const parsedVersion = parseMockOmxVersion(version);
+    if (parsedVersion && compareMockOmxVersions(parsedVersion, '0.18.0') < 0) {
+      return {
+        status: 'stale',
+        installed: true,
+        version,
+        parsedVersion,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    let hasApiCommand = false;
+    try {
+      deps.exec('omx api --help', { encoding: 'utf-8', stdio: 'pipe', timeout: 3000 });
+      hasApiCommand = true;
+    } catch {
+      hasApiCommand = false;
+    }
+
+    if (parsedVersion && !hasApiCommand) {
+      return {
+        status: 'api-missing',
+        installed: true,
+        version,
+        parsedVersion,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    if (!parsedVersion && !hasApiCommand) {
+      return {
+        status: 'unknown-version',
+        installed: true,
+        version,
+        parsedVersion: null,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    return {
+      status: 'ready',
+      installed: true,
+      version,
+      parsedVersion,
+      minimumVersion: '0.18.0',
+      hasApiCommand,
+    };
+  };
+}
+
+const omxInstallerMockBase = {
+  MINIMUM_OMX_VERSION: '0.18.0',
+  compareOmxVersions: compareMockOmxVersions,
+  hasOmxApiCommand: () => true,
+  isOmxInstalled: () => true,
+  isOmxReady: () => true,
+  isOmxVersionAtLeast: (version: string | null) => {
+    const parsedVersion = parseMockOmxVersion(version);
+    return parsedVersion !== null && compareMockOmxVersions(parsedVersion, '0.18.0') >= 0;
+  },
+  parseOmxVersion: parseMockOmxVersion,
+  getOmxVersion: () => 'oh-my-codex v0.18.0',
+};
+
+describe('doctor OMX baseline checks', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('warns when OMX is below the required v0.18.0 baseline', async () => {
+    mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(() => ({
+        status: 'stale',
+        installed: true,
+        version: 'oh-my-codex v0.17.3',
+        parsedVersion: '0.17.3',
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      })),
+      installOmx: () => true,
+    }));
+
+    const { checkOmx } = await import('../../../src/cli/doctor.js');
+    const result = await checkOmx();
+
+    expect(result.status).toBe('warn');
+    expect(result.fixable).toBe(true);
+    expect(result.message).toContain('v0.18.0');
+  });
+
+  it('warns when OMX is new enough but lacks omx api', async () => {
+    mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(() => ({
+        status: 'api-missing',
+        installed: true,
+        version: 'oh-my-codex v0.18.0',
+        parsedVersion: '0.18.0',
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      })),
+      installOmx: () => true,
+    }));
+
+    const { checkOmx } = await import('../../../src/cli/doctor.js');
+    const result = await checkOmx();
+
+    expect(result.status).toBe('warn');
+    expect(result.fixable).toBe(true);
+    expect(result.message).toContain('omx api');
+  });
+
+  it('passes when OMX meets the baseline and exposes omx api', async () => {
+    mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(() => readyAssessment),
+      installOmx: () => true,
+    }));
+
+    const { checkOmx } = await import('../../../src/cli/doctor.js');
+    const result = await checkOmx();
+
+    expect(result.status).toBe('pass');
+    expect(result.fixable).toBe(false);
+    expect(result.message).toContain('omx api available');
+  });
+});

--- a/tests/unit/core/installer-rtk-codex.test.ts
+++ b/tests/unit/core/installer-rtk-codex.test.ts
@@ -17,6 +17,182 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const readyOmxAssessment = () => ({
+  status: 'ready',
+  installed: true,
+  version: 'oh-my-codex v0.18.0',
+  parsedVersion: '0.18.0',
+  minimumVersion: '0.18.0',
+  hasApiCommand: true,
+});
+
+const missingOmxAssessment = () => ({
+  status: 'missing',
+  installed: false,
+  version: null,
+  parsedVersion: null,
+  minimumVersion: '0.18.0',
+  hasApiCommand: false,
+});
+
+const staleOmxAssessment = () => ({
+  status: 'stale',
+  installed: true,
+  version: 'oh-my-codex v0.17.3',
+  parsedVersion: '0.17.3',
+  minimumVersion: '0.18.0',
+  hasApiCommand: false,
+});
+
+type MockOmxDeps = {
+  exec?: (cmd: string, opts?: unknown) => string | Buffer;
+};
+
+type MockOmxAssessment = {
+  status: string;
+  installed: boolean;
+  version: string | null;
+  parsedVersion: string | null;
+  minimumVersion: string;
+  hasApiCommand: boolean;
+};
+
+function parseMockOmxVersion(versionOutput: string | null): string | null {
+  if (!versionOutput) {
+    return null;
+  }
+
+  const match = versionOutput.match(
+    /\bv?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\b/
+  );
+  return match ? match[1] : null;
+}
+
+function parseMockVersionParts(version: string): {
+  core: [number, number, number];
+  prerelease: string | null;
+} {
+  const [withoutBuild] = version.split('+');
+  const [coreText, prerelease = null] = withoutBuild.split('-', 2);
+  const coreParts = coreText.split('.').map((part) => Number.parseInt(part, 10));
+
+  return {
+    core: [coreParts[0] ?? 0, coreParts[1] ?? 0, coreParts[2] ?? 0],
+    prerelease,
+  };
+}
+
+function compareMockOmxVersions(left: string, right: string): number {
+  const a = parseMockVersionParts(left);
+  const b = parseMockVersionParts(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    const diff = a.core[index] - b.core[index];
+    if (diff !== 0) {
+      return diff > 0 ? 1 : -1;
+    }
+  }
+
+  if (a.prerelease === b.prerelease) {
+    return 0;
+  }
+  if (a.prerelease === null) {
+    return 1;
+  }
+  if (b.prerelease === null) {
+    return -1;
+  }
+
+  return a.prerelease.localeCompare(b.prerelease, undefined, { numeric: true });
+}
+
+function assessOmxFromDepsOr(fallback: () => MockOmxAssessment) {
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: mirrors the OMX status helper for same-process mocks.
+  return (deps?: MockOmxDeps) => {
+    if (!deps?.exec) {
+      return fallback();
+    }
+
+    try {
+      deps.exec('which omx', { stdio: 'pipe', timeout: 3000 });
+    } catch {
+      return missingOmxAssessment();
+    }
+
+    let version: string | null = null;
+    try {
+      version = String(
+        deps.exec('omx --version', { encoding: 'utf-8', stdio: 'pipe', timeout: 3000 })
+      ).trim();
+    } catch {
+      version = null;
+    }
+
+    const parsedVersion = parseMockOmxVersion(version);
+    if (parsedVersion && compareMockOmxVersions(parsedVersion, '0.18.0') < 0) {
+      return {
+        status: 'stale',
+        installed: true,
+        version,
+        parsedVersion,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    let hasApiCommand = false;
+    try {
+      deps.exec('omx api --help', { encoding: 'utf-8', stdio: 'pipe', timeout: 3000 });
+      hasApiCommand = true;
+    } catch {
+      hasApiCommand = false;
+    }
+
+    if (parsedVersion && !hasApiCommand) {
+      return {
+        status: 'api-missing',
+        installed: true,
+        version,
+        parsedVersion,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    if (!parsedVersion && !hasApiCommand) {
+      return {
+        status: 'unknown-version',
+        installed: true,
+        version,
+        parsedVersion: null,
+        minimumVersion: '0.18.0',
+        hasApiCommand: false,
+      };
+    }
+
+    return {
+      status: 'ready',
+      installed: true,
+      version,
+      parsedVersion,
+      minimumVersion: '0.18.0',
+      hasApiCommand,
+    };
+  };
+}
+
+const omxInstallerMockBase = {
+  MINIMUM_OMX_VERSION: '0.18.0',
+  compareOmxVersions: compareMockOmxVersions,
+  hasOmxApiCommand: () => true,
+  isOmxReady: () => true,
+  isOmxVersionAtLeast: (version: string | null) => {
+    const parsedVersion = parseMockOmxVersion(version);
+    return parsedVersion !== null && compareMockOmxVersions(parsedVersion, '0.18.0') >= 0;
+  },
+  parseOmxVersion: parseMockOmxVersion,
+};
+
 describe('installer RTK/Codex/OMX paths', () => {
   let tempDir: string;
   let consoleLogSpy: ReturnType<typeof spyOn>;
@@ -58,9 +234,12 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => '1.0.0',
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(readyOmxAssessment),
       isOmxInstalled: () => true,
       installOmx: () => true,
-      getOmxVersion: () => 'oh-my-codex v0.13.2',
+      getOmxVersion: () => 'oh-my-codex v0.18.0',
     }));
 
     const { install } = await import('../../../src/core/installer.js');
@@ -84,9 +263,12 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => '1.0.0',
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(readyOmxAssessment),
       isOmxInstalled: () => true,
       installOmx: () => true,
-      getOmxVersion: () => 'oh-my-codex v0.13.2',
+      getOmxVersion: () => 'oh-my-codex v0.18.0',
     }));
 
     const { install } = await import('../../../src/core/installer.js');
@@ -112,9 +294,12 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => null,
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(readyOmxAssessment),
       isOmxInstalled: () => true,
       installOmx: () => true,
-      getOmxVersion: () => 'oh-my-codex v0.13.2',
+      getOmxVersion: () => 'oh-my-codex v0.18.0',
     }));
 
     const { install } = await import('../../../src/core/installer.js');
@@ -138,9 +323,12 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => null,
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(readyOmxAssessment),
       isOmxInstalled: () => true,
       installOmx: () => true,
-      getOmxVersion: () => 'oh-my-codex v0.13.2',
+      getOmxVersion: () => 'oh-my-codex v0.18.0',
     }));
 
     const { install } = await import('../../../src/core/installer.js');
@@ -164,9 +352,12 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => '1.0.0',
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(readyOmxAssessment),
       isOmxInstalled: () => true,
       installOmx: () => true,
-      getOmxVersion: () => 'oh-my-codex v0.13.2',
+      getOmxVersion: () => 'oh-my-codex v0.18.0',
     }));
 
     const { install } = await import('../../../src/core/installer.js');
@@ -195,9 +386,12 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => '1.0.0',
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(readyOmxAssessment),
       isOmxInstalled: () => true,
       installOmx: () => true,
-      getOmxVersion: () => 'oh-my-codex v0.13.2',
+      getOmxVersion: () => 'oh-my-codex v0.18.0',
     }));
     // Mock lockfile module to return a warning, simulating lockfile generation failure
     mock.module('../../../src/core/lockfile.js', () => ({
@@ -241,6 +435,9 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => '1.0.0',
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(missingOmxAssessment),
       isOmxInstalled: () => false,
       installOmx: () => false,
       getOmxVersion: () => null,
@@ -250,7 +447,7 @@ describe('installer RTK/Codex/OMX paths', () => {
     const result = await install({ targetDir: tempDir, skipConfirm: true });
 
     expect(result.success).toBe(true);
-    expect(result.warnings.some((w) => w.includes('OMX installation failed'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('OMX installation/upgrade failed'))).toBe(true);
   });
 
   it('should not warn when OMX installation succeeds', async () => {
@@ -265,6 +462,9 @@ describe('installer RTK/Codex/OMX paths', () => {
       getCodexVersion: () => '1.0.0',
     }));
     mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(missingOmxAssessment),
       isOmxInstalled: () => false,
       installOmx: () => true,
       getOmxVersion: () => null,
@@ -275,5 +475,38 @@ describe('installer RTK/Codex/OMX paths', () => {
 
     expect(result.success).toBe(true);
     expect(result.warnings.some((w) => w.includes('OMX installation failed'))).toBe(false);
+  });
+
+  it('should upgrade stale OMX versions during install checks', async () => {
+    let installCalls = 0;
+
+    mock.module('../../../src/core/rtk-installer.js', () => ({
+      isRtkInstalled: () => true,
+      installRtk: () => true,
+      getRtkVersion: () => '0.34.2',
+    }));
+    mock.module('../../../src/core/codex-installer.js', () => ({
+      isCodexInstalled: () => true,
+      installCodex: () => true,
+      getCodexVersion: () => '1.0.0',
+    }));
+    mock.module('../../../src/core/omx-installer.js', () => ({
+      ...omxInstallerMockBase,
+      MINIMUM_OMX_VERSION: '0.18.0',
+      assessOmxInstallation: assessOmxFromDepsOr(staleOmxAssessment),
+      isOmxInstalled: () => true,
+      installOmx: () => {
+        installCalls += 1;
+        return true;
+      },
+      getOmxVersion: () => 'oh-my-codex v0.17.3',
+    }));
+
+    const { install } = await import('../../../src/core/installer.js');
+    const result = await install({ targetDir: tempDir, skipConfirm: true });
+
+    expect(result.success).toBe(true);
+    expect(installCalls).toBe(1);
+    expect(result.warnings.some((w) => w.includes('OMX installation/upgrade failed'))).toBe(false);
   });
 });

--- a/tests/unit/core/omx-installer.test.ts
+++ b/tests/unit/core/omx-installer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  assessOmxInstallation,
+  compareOmxVersions,
+  type InstallerDeps,
+  isOmxVersionAtLeast,
+  parseOmxVersion,
+} from '../../../src/core/omx-installer.ts';
+
+function depsFor(commands: Record<string, string | Error>): InstallerDeps {
+  return {
+    exec: (cmd: string) => {
+      const result = commands[cmd];
+      if (result instanceof Error || result === undefined) {
+        throw result ?? new Error(`Unexpected command: ${cmd}`);
+      }
+      return result;
+    },
+    getPlatform: () => 'linux',
+  };
+}
+
+describe('omx installer baseline checks', () => {
+  it('parses oh-my-codex version output', () => {
+    expect(parseOmxVersion('oh-my-codex v0.18.0')).toBe('0.18.0');
+    expect(parseOmxVersion('0.18.1')).toBe('0.18.1');
+    expect(parseOmxVersion('oh-my-codex v0.19.0-beta.1')).toBe('0.19.0-beta.1');
+    expect(parseOmxVersion('unknown')).toBeNull();
+  });
+
+  it('compares semantic versions with prereleases below final releases', () => {
+    expect(compareOmxVersions('0.18.1', '0.18.0')).toBe(1);
+    expect(compareOmxVersions('0.17.3', '0.18.0')).toBe(-1);
+    expect(compareOmxVersions('0.18.0-beta.1', '0.18.0')).toBe(-1);
+    expect(compareOmxVersions('0.18.0', '0.18.0')).toBe(0);
+    expect(isOmxVersionAtLeast('oh-my-codex v0.18.0')).toBe(true);
+  });
+
+  it('marks missing omx as missing', () => {
+    const result = assessOmxInstallation(depsFor({ 'which omx': new Error('missing') }));
+
+    expect(result.status).toBe('missing');
+    expect(result.installed).toBe(false);
+  });
+
+  it('marks pre-0.18.0 omx as stale without probing api', () => {
+    const result = assessOmxInstallation(
+      depsFor({
+        'which omx': '/usr/local/bin/omx',
+        'omx --version': 'oh-my-codex v0.17.3',
+      })
+    );
+
+    expect(result.status).toBe('stale');
+    expect(result.parsedVersion).toBe('0.17.3');
+    expect(result.hasApiCommand).toBe(false);
+  });
+
+  it('marks a new enough omx without api as api-missing', () => {
+    const result = assessOmxInstallation(
+      depsFor({
+        'which omx': '/usr/local/bin/omx',
+        'omx --version': 'oh-my-codex v0.18.0',
+        'omx api --help': new Error('unknown command'),
+      })
+    );
+
+    expect(result.status).toBe('api-missing');
+    expect(result.installed).toBe(true);
+  });
+
+  it('marks v0.18.0 with omx api as ready', () => {
+    const result = assessOmxInstallation(
+      depsFor({
+        'which omx': '/usr/local/bin/omx',
+        'omx --version': 'oh-my-codex v0.18.0',
+        'omx api --help': 'Usage: omx api',
+      })
+    );
+
+    expect(result.status).toBe('ready');
+    expect(result.hasApiCommand).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- require oh-my-codex v0.18.0+ and `omx api` before treating OMX as ready
- upgrade installer, updater, and doctor repair paths to handle stale or API-missing OMX installs
- add focused regression coverage for version parsing, readiness assessment, doctor warnings, and stale-upgrade install behavior

Fixes #1344

## Verification
- `PATH=/tmp/omx-bin:/tmp/omx-bun-runner/node_modules/.bin:$PATH bun test` — 1804 pass, 0 fail
- `PATH=/tmp/omx-bun-runner/node_modules/.bin:$PATH bun run typecheck`
- `PATH=/tmp/omx-bun-runner/node_modules/.bin:$PATH bun run lint`
- `PATH=/tmp/omx-bin:/tmp/omx-bun-runner/node_modules/.bin:$PATH bun run build`
- `git diff --check`
- pre-commit stable batches passed during commit