### PR TITLE
fix: keep release sync from querying invalid issue refs

### DIFF
--- a/scripts/sync-upstream-release-issues.js
+++ b/scripts/sync-upstream-release-issues.js
@@ -12,14 +12,20 @@ export function extractReferencedIssueNumbers(text = '') {
   }
 
   const candidates = new Set();
+  const addCandidate = (rawIssueNumber) => {
+    const issueNumber = Number(rawIssueNumber);
+    if (Number.isSafeInteger(issueNumber) && issueNumber > 0) {
+      candidates.add(issueNumber);
+    }
+  };
   const sanitized = text.replace(/\bPR\s+#\d+\b/gi, '').replace(/\bpull request\s+#\d+\b/gi, '');
 
   for (const match of sanitized.matchAll(/#(\d+)\b/g)) {
-    candidates.add(Number(match[1]));
+    addCandidate(match[1]);
   }
 
   for (const match of sanitized.matchAll(/\/issues\/(\d+)\b/gi)) {
-    candidates.add(Number(match[1]));
+    addCandidate(match[1]);
   }
 
   return [...candidates].sort((left, right) => left - right);

--- a/tests/sync-upstream-release-issues.test.js
+++ b/tests/sync-upstream-release-issues.test.js
@@ -21,6 +21,17 @@ test('extractReferencedIssueNumbers deduplicates refs and ignores explicit PR re
   assert.deepEqual(extractReferencedIssueNumbers(releaseNotes), [264, 328, 329]);
 });
 
+test('extractReferencedIssueNumbers ignores invalid zero issue references', () => {
+  const releaseNotes = `
+## What's Changed
+- Placeholder reference should not be queried (#0)
+- Placeholder URL should not be queried: https://github.com/baekenough/oh-my-customcode/issues/0
+- Valid follow-up (#1203)
+`;
+
+  assert.deepEqual(extractReferencedIssueNumbers(releaseNotes), [1203]);
+});
+
 test('marker helpers round-trip marker values', () => {
   const marker = buildUpstreamIssueMarker('baekenough/oh-my-customcode', 264);
   assert.equal(marker, '<!-- upstream-release-issue: baekenough/oh-my-customcode#264 -->');


### PR DESCRIPTION
## Summary\n- Filter extracted upstream release issue references to positive safe integers before GitHub API lookup.\n- Add regression coverage for #0 and /issues/0 placeholders.\n\n## Root Cause\nThe scheduled Sync Upstream Release Issues workflow parsed a placeholder #0 from upstream release notes, then queried /issues/0 and failed with 404.\n\n## Verification\n- bun test tests/sync-upstream-release-issues.test.js\n- bun run lint\n- GITHUB_TOKEN=... TARGET_REPO=baekenough/oh-my-customcodex UPSTREAM_REPO=baekenough/oh-my-customcode RELEASE_TAG=v0.149.0 DRY_RUN=true node scripts/sync-upstream-release-issues.js\n- bun test tests/sync-upstream-release-issues.test.js tests/integration/i18n.test.ts tests/integration/init-flow.test.ts tests/e2e/list.test.ts tests/e2e/doctor.test.ts\n\n## Risk\nNarrow parser hygiene change. Non-dry-run issue creation was not executed locally.