### PR TITLE
fix: skip missing upstream release issue refs

### DIFF
--- a/scripts/sync-upstream-release-issues.js
+++ b/scripts/sync-upstream-release-issues.js
@@ -6,6 +6,16 @@ const USER_AGENT = 'oh-my-customcodex-release-sync';
 const MAX_RELEASE_NOTES_LENGTH = 6000;
 const MAX_ISSUE_BODY_LENGTH = 12000;
 
+class GitHubRequestError extends Error {
+  constructor({ method, path, status, statusText, responseBody }) {
+    super(`GitHub API ${method} ${path} failed: ${status} ${statusText}\n${responseBody}`);
+    this.name = 'GitHubRequestError';
+    this.method = method;
+    this.path = path;
+    this.status = status;
+  }
+}
+
 export function extractReferencedIssueNumbers(text = '') {
   if (!text.trim()) {
     return [];
@@ -110,12 +120,25 @@ async function githubRequest(path, { token, method = 'GET', body, apiBase = DEFA
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(
-      `GitHub API ${method} ${path} failed: ${response.status} ${response.statusText}\n${errorText}`
-    );
+    throw new GitHubRequestError({
+      method,
+      path,
+      status: response.status,
+      statusText: response.statusText,
+      responseBody: errorText,
+    });
   }
 
   return response.status === 204 ? null : response.json();
+}
+
+function isMissingUpstreamIssue(error, upstreamRepo, issueNumber) {
+  return (
+    error instanceof GitHubRequestError &&
+    error.method === 'GET' &&
+    error.status === 404 &&
+    error.path === `/repos/${upstreamRepo}/issues/${issueNumber}`
+  );
 }
 
 async function githubTextRequest(path, { token, apiBase = DEFAULT_API_BASE }) {
@@ -326,12 +349,23 @@ async function processRelease({
   const totals = { created: 0, planned: 0, skipped: 0 };
 
   for (const issueNumber of candidateIssueNumbers) {
-    const issue = await fetchIssue({
-      upstreamRepo,
-      issueNumber,
-      token,
-      apiBase,
-    });
+    let issue;
+    try {
+      issue = await fetchIssue({
+        upstreamRepo,
+        issueNumber,
+        token,
+        apiBase,
+      });
+    } catch (error) {
+      if (isMissingUpstreamIssue(error, upstreamRepo, issueNumber)) {
+        totals.skipped += 1;
+        logger.log(`Skipping #${issueNumber}: upstream issue was not found.`);
+        continue;
+      }
+
+      throw error;
+    }
 
     if (issue.pull_request) {
       totals.skipped += 1;

--- a/tests/sync-upstream-release-issues.test.js
+++ b/tests/sync-upstream-release-issues.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import http from 'node:http';
 import test from 'node:test';
 
 import {
@@ -7,6 +8,7 @@ import {
   extractChangelogSection,
   extractReferencedIssueNumbers,
   extractUpstreamIssueMarker,
+  run,
 } from '../scripts/sync-upstream-release-issues.js';
 
 test('extractReferencedIssueNumbers deduplicates refs and ignores explicit PR refs', () => {
@@ -82,4 +84,112 @@ test('buildTargetIssuePayload embeds upstream marker and release context', () =>
   assert.match(payload.body, /upstream-release-issue: baekenough\/oh-my-customcode#264/);
   assert.match(payload.body, /Release: \[v0\.34\.0]/);
   assert.match(payload.body, /Need to rename command namespace to omcustom\./);
+});
+
+test('run skips missing upstream issue references instead of failing the sync', async (t) => {
+  const createdIssues = [];
+  const requests = [];
+  const writeJson = (response, payload, status = 200) => {
+    response.writeHead(status, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify(payload));
+  };
+  const routes = new Map([
+    [
+      'GET /repos/upstream/project/releases/tags/v1.0.0',
+      (_request, response) =>
+        writeJson(response, {
+          tag_name: 'v1.0.0',
+          name: 'v1.0.0',
+          body: 'Valid work (#123) and stale placeholder (#999).',
+          html_url: 'https://github.com/upstream/project/releases/tag/v1.0.0',
+          draft: false,
+        }),
+    ],
+    ['GET /repos/target/project/issues', (_request, response) => writeJson(response, [])],
+    [
+      'GET /repos/upstream/project/contents/CHANGELOG.md',
+      (_request, response) => {
+        response.setHeader('Content-Type', 'text/plain');
+        response.end('');
+      },
+    ],
+    [
+      'GET /repos/upstream/project/issues/123',
+      (_request, response) =>
+        writeJson(response, {
+          number: 123,
+          title: 'Valid upstream issue',
+          html_url: 'https://github.com/upstream/project/issues/123',
+          state: 'closed',
+          body: 'Ship the valid issue.',
+          labels: [],
+        }),
+    ],
+    [
+      'GET /repos/upstream/project/issues/999',
+      (_request, response) => writeJson(response, { message: 'Not Found' }, 404),
+    ],
+    [
+      'POST /repos/target/project/issues',
+      async (request, response) => {
+        let body = '';
+        for await (const chunk of request) {
+          body += chunk;
+        }
+
+        const payload = JSON.parse(body);
+        createdIssues.push(payload);
+        writeJson(
+          response,
+          {
+            number: 77,
+            html_url: 'https://github.com/target/project/issues/77',
+          },
+          201
+        );
+      },
+    ],
+  ]);
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://localhost');
+    const routeKey = `${request.method} ${url.pathname}`;
+    requests.push(routeKey);
+
+    const route = routes.get(routeKey);
+    if (route) {
+      await route(request, response);
+      return;
+    }
+
+    writeJson(response, { message: 'unexpected route' }, 404);
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+
+  const { port } = server.address();
+  const logs = [];
+  const result = await run({
+    apiBase: `http://127.0.0.1:${port}`,
+    env: {
+      GITHUB_TOKEN: 'test-token',
+      TARGET_REPO: 'target/project',
+      UPSTREAM_REPO: 'upstream/project',
+      RELEASE_TAG: 'v1.0.0',
+      DRY_RUN: 'false',
+    },
+    logger: {
+      log: (message) => logs.push(message),
+    },
+  });
+
+  assert.deepEqual(result, { created: 1, planned: 0, skipped: 1, scannedReleases: 1 });
+  assert.equal(createdIssues.length, 1);
+  assert.match(createdIssues[0].title, /Port #123/);
+  assert.deepEqual(
+    requests.filter((request) => request.includes('/repos/upstream/project/issues/999')),
+    ['GET /repos/upstream/project/issues/999']
+  );
+  assert.ok(logs.includes('Skipping #999: upstream issue was not found.'));
 });


### PR DESCRIPTION
## Summary\n- Treat a missing upstream issue 404 as a skipped release-note reference instead of failing the whole sync.\n- Keep auth/rate-limit/outage and other API errors fatal.\n- Add a mock GitHub API regression test for one valid issue plus one missing positive issue reference.\n\n## Why\nThe previous fix blocks invalid zero refs. This hardens the next plausible failure mode: release notes can contain prose-local positive numbers that parse like issue refs but do not exist upstream.\n\n## Verification\n- bun test tests/sync-upstream-release-issues.test.js\n- bun run lint\n- GITHUB_TOKEN=... TARGET_REPO=baekenough/oh-my-customcodex UPSTREAM_REPO=baekenough/oh-my-customcode RELEASE_TAG=v0.149.0 DRY_RUN=true node scripts/sync-upstream-release-issues.js\n\n## Risk\nNarrow behavior change for GET /issues/<n> 404 only. Other GitHub API failures still throw.