### PR TITLE
fix: preserve upstream v0.149.0 parity

### DIFF
--- a/.codex/hooks/hooks.json
+++ b/.codex/hooks/hooks.json
@@ -203,6 +203,16 @@
           }
         ],
         "description": "Auto-detect and fix previous session issues at start (#838)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/plugin-cache-check.sh"
+          }
+        ],
+        "description": "Advisory check for plugin cache directories missing node_modules (#1366)"
       }
     ],
     "UserPromptSubmit": [

--- a/.codex/hooks/scripts/plugin-cache-check.sh
+++ b/.codex/hooks/scripts/plugin-cache-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# plugin-cache-check.sh - SessionStart advisory hook.
+# Detects plugin cache packages with package.json but missing node_modules.
+# Always exits 0. Output advisory to stderr only.
+
+set -euo pipefail
+
+input=$(cat)
+
+cache_roots=()
+if [ -n "${CODEX_PLUGIN_CACHE:-}" ]; then
+  cache_roots+=("$CODEX_PLUGIN_CACHE")
+fi
+if [ -n "${CLAUDE_PLUGIN_CACHE:-}" ]; then
+  cache_roots+=("$CLAUDE_PLUGIN_CACHE")
+fi
+cache_roots+=("${HOME}/.codex/plugins/cache")
+cache_roots+=("${HOME}/.claude/shared-plugins/cache")
+
+missing=()
+for cache_root in "${cache_roots[@]}"; do
+  if [ ! -d "$cache_root" ]; then
+    continue
+  fi
+
+  while IFS= read -r package_json; do
+    package_dir=$(dirname "$package_json")
+    if [ ! -d "$package_dir/node_modules" ]; then
+      missing+=("$package_dir")
+    fi
+  done < <(find "$cache_root" -maxdepth 5 -name package.json 2>/dev/null)
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "[Advisory] Plugin cache missing node_modules (run \`(cd <dir> && bun install)\` per directory):" >&2
+  for dir in "${missing[@]}"; do
+    echo "  - $dir" >&2
+  done
+fi
+
+echo "$input"
+exit 0

--- a/.codex/rules/MUST-agent-teams.md
+++ b/.codex/rules/MUST-agent-teams.md
@@ -37,14 +37,18 @@ These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` a
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:
-Quick rule: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
+Quick rule: User explicitly preferred plain subagents this session? → use Agent Tool (R000 user instructions > R018). Otherwise: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
 
 <!-- DETAIL: Self-Check (Before Agent Tool)
 ╔══════════════════════════════════════════════════════════════════╗
 ║  BEFORE USING Agent TOOL FOR 2+ AGENTS:                          ║
 ║                                                                   ║
+║  0. Has user explicitly preferred plain subagents this session?  ║
+║     YES → Use Agent tool (R000 user instructions > R018)         ║
+║     NO  → Continue to #1                                          ║
+║                                                                   ║
 ║  1. Is Agent Teams available?                                    ║
-║     YES → check criteria #2-#4                                  ║
+║     YES → check criteria #2-#5                                  ║
 ║     NO  → Proceed with Agent tool                               ║
 ║                                                                   ║
 ║  2. Will 3+ agents be involved?                                  ║

--- a/.codex/rules/MUST-continuous-improvement.md
+++ b/.codex/rules/MUST-continuous-improvement.md
@@ -61,7 +61,7 @@ Before creating or modifying assets for an external repository or upstream contr
 
 Late discovery of contribution rules is a process defect. Record it as memory and an issue when the miss is repeatable or affected delivered work.
 
-## Anti-Patterns — 4 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first". See table via Read tool.
+## Anti-Patterns — 5 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first", "calibration during action-oriented tone". See table via Read tool.
 
 <!-- DETAIL: Anti-Patterns
 | Anti-Pattern | Why It's Wrong | Correct Action |
@@ -70,6 +70,7 @@ Late discovery of contribution rules is a process defect. Record it as memory an
 | "This is a one-time exception" | Exceptions become patterns | If the rule is wrong, fix it; if it's right, follow it |
 | "The rule doesn't cover this case" | Missing coverage = rule gap | Add the case to the rule immediately |
 | "Let me finish the task first" | Rule violations compound | Fix rule first (5 min), then continue (prevents N future violations) |
+| "Calibration/humility during action-oriented tone (auto mode, ㄱㄱ, 계속해)" | Self-questioning wastes time when user signals action; action-mode preempts meta-reflection | Defer calibration to post-task feedback memory; respond with short action confirmation |
 -->
 
 ## Timing — Rule updates MUST happen before continuing original task, in the same session.

--- a/.codex/rules/SHOULD-memory-integration.md
+++ b/.codex/rules/SHOULD-memory-integration.md
@@ -361,7 +361,7 @@ MCP tools (searchable memory backends, episodic-memory) are **orchestrator-scope
 
 ### Session-End Self-Check (MANDATORY)
 
-(1) sys-memory-keeper updated MEMORY.md? (2) searchable memory save attempted when a backend is available? Both are required before confirming session-end to the user. See full self-check via Read tool.
+(1) sys-memory-keeper updated MEMORY.md? (2) searchable memory save attempted when a backend is available? (3) If `omcustomcodex-feedback` skill is active, prompt user to trigger it? All three are required before confirming session-end to the user. See full self-check via Read tool.
 
 <!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
@@ -376,10 +376,15 @@ MCP tools (searchable memory backends, episodic-memory) are **orchestrator-scope
 ║     YES → Continue (even if it failed)                           ║
 ║     NO  → ToolSearch + save now                                  ║
 ║                                                                   ║
+║  3. Is omcustomcodex-feedback skill available in this project?   ║
+║     YES → Ask user: "이번 세션 피드백을 omcustomcodex-feedback로 ║
+║          기록하시겠습니까?" — accept skip                        ║
+║     NO  → Skip                                                    ║
+║                                                                   ║
 ║  Note: episodic-memory auto-indexes conversations after session  ║
 ║  ends. No manual action needed — do NOT search as "verification" ║
 ║                                                                   ║
-║  BOTH steps must be completed before confirming to user.         ║
+║  ALL applicable steps must be completed before confirming to user.║
 ║  "Attempted" means called the tool — failure is OK, skipping     ║
 ║  is NOT.                                                          ║
 ╚══════════════════════════════════════════════════════════════════╝

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.5.1",
-  "generatedAt": "2026-05-20T10:31:13.099Z",
+  "generatedAt": "2026-05-22T10:20:46.963Z",
   "templateVersion": "0.5.1",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-teams.md": {
-      "templateHash": "e20dca80f4775e9cd906fa369b95e83296584f4475ce26778d5aa4da9aac2381",
-      "size": 15401,
+      "templateHash": "3ec067bcc9915759e12a6f5506f7768168fa3b92d1f2619ceef1ea57c24838c4",
+      "size": 15818,
       "component": "rules"
     },
     ".codex/rules/MAY-optimization.md": {
@@ -75,8 +75,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-continuous-improvement.md": {
-      "templateHash": "7305e06be2cf2e725106866fcc50b2a5755ba90b8b774f5db9221eb1b515fd71",
-      "size": 3698,
+      "templateHash": "3d4303d1e345ae0bfc5edc47e55af9673acb0a5a57150f7e8d7d8a68ff6f8774",
+      "size": 4010,
       "component": "rules"
     },
     ".codex/rules/MUST-permissions.md": {
@@ -100,8 +100,8 @@
       "component": "rules"
     },
     ".codex/rules/SHOULD-memory-integration.md": {
-      "templateHash": "dc64b6cc83f5840297b48c85113a35ba5a25bf620ddcd2ad34c45395a7ad8dfa",
-      "size": 16952,
+      "templateHash": "ba72cd0c5f364716723c7dfc0a3377c9f09789d01e1b19506bf103bff83bbc78",
+      "size": 17424,
       "component": "rules"
     },
     ".codex/rules/MUST-enforcement-policy.md": {
@@ -384,6 +384,11 @@
       "size": 1346,
       "component": "hooks"
     },
+    ".codex/hooks/scripts/plugin-cache-check.sh": {
+      "templateHash": "8b8e817d63f972ad35f21bf110fa1738a5ad4ab49378d9bc82803793d7dfe550",
+      "size": 1110,
+      "component": "hooks"
+    },
     ".codex/hooks/scripts/rule-deletion-guard.sh": {
       "templateHash": "123af252561c798c552763d8728cb6207d346d56ccfa1d8844a721ade4f77d2f",
       "size": 2366,
@@ -580,8 +585,8 @@
       "component": "hooks"
     },
     ".codex/hooks/hooks.json": {
-      "templateHash": "c5f136478a7f3a5f8586332f15a0d217fc0a4321e3e295b567f255df9c22720c",
-      "size": 28225,
+      "templateHash": "16cf3ea5d22e7087143cf50ac25961f331f23d1b508a394210ed6f007f2e01f0",
+      "size": 28522,
       "component": "hooks"
     },
     ".codex/contexts/ecomode.md": {
@@ -665,8 +670,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "bbbc89bc55e519fb26e0560fc7ff0bb86d6c5966f9954a924bbd38496f9a455e",
-      "size": 11876,
+      "templateHash": "a57e9dd7b709112617d2e7d62a21e1c6e2b0927c123f5afec7372eb2ba73b174",
+      "size": 13760,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,21 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.146
+
+Published: 2026-05-21.
+
+Source: upstream oh-my-customcode #1205, Codex port #1364.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| `/simplify` was renamed to `/code-review` and accepts effort levels such as `/code-review high` | Native Claude command naming is now closer to review workflows, but this package still exposes its own `dev-review` skill. | No runtime rename. Keep user-facing docs clear that `dev-review` is the package skill and `/code-review` is the native Claude command. |
+| Auto mode no longer suppresses `AskUserQuestion` when the user or a skill explicitly relies on it | Ambiguity-gated compatibility workflows can ask explicit questions even in auto mode. | No Codex tool change. Keep `request_user_input`/question usage limited to genuinely branching cases. |
+| MCP `resources/list`, `resources/templates/list`, and `prompts/list` pagination was fixed | Large memory or ontology MCP servers are less likely to hide resources after page 1. | No package change; treat complete paginated MCP lists as more reliable evidence. |
+| `CLAUDE_CODE_SUBAGENT_MODEL` is forwarded to child processes in multi-agent sessions | Claude compatibility sessions with model env overrides now preserve child-process model intent. | No Codex model override. Codex-native child agents still follow repo model routing and inherited defaults. |
+| `/background` accepts skill-only or custom-slash-only input and background sessions preserve granted tool permissions | Long-running Claude compatibility sessions are less likely to stall on already granted permissions. | No Codex change. Keep permission expectations explicit in workflow prompts. |
+| Agent SDK streaming end-of-session exception was fixed | Agent SDK plugin experiments should be less noisy at stream completion. | Monitor only; no package change. |
+
 ## v2.1.145
 
 Published: 2026-05-19.

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -203,6 +203,16 @@
           }
         ],
         "description": "Auto-detect and fix previous session issues at start (#838)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/plugin-cache-check.sh"
+          }
+        ],
+        "description": "Advisory check for plugin cache directories missing node_modules (#1366)"
       }
     ],
     "UserPromptSubmit": [

--- a/templates/.claude/hooks/scripts/plugin-cache-check.sh
+++ b/templates/.claude/hooks/scripts/plugin-cache-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# plugin-cache-check.sh - SessionStart advisory hook.
+# Detects plugin cache packages with package.json but missing node_modules.
+# Always exits 0. Output advisory to stderr only.
+
+set -euo pipefail
+
+input=$(cat)
+
+cache_roots=()
+if [ -n "${CODEX_PLUGIN_CACHE:-}" ]; then
+  cache_roots+=("$CODEX_PLUGIN_CACHE")
+fi
+if [ -n "${CLAUDE_PLUGIN_CACHE:-}" ]; then
+  cache_roots+=("$CLAUDE_PLUGIN_CACHE")
+fi
+cache_roots+=("${HOME}/.codex/plugins/cache")
+cache_roots+=("${HOME}/.claude/shared-plugins/cache")
+
+missing=()
+for cache_root in "${cache_roots[@]}"; do
+  if [ ! -d "$cache_root" ]; then
+    continue
+  fi
+
+  while IFS= read -r package_json; do
+    package_dir=$(dirname "$package_json")
+    if [ ! -d "$package_dir/node_modules" ]; then
+      missing+=("$package_dir")
+    fi
+  done < <(find "$cache_root" -maxdepth 5 -name package.json 2>/dev/null)
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "[Advisory] Plugin cache missing node_modules (run \`(cd <dir> && bun install)\` per directory):" >&2
+  for dir in "${missing[@]}"; do
+    echo "  - $dir" >&2
+  done
+fi
+
+echo "$input"
+exit 0

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -37,14 +37,18 @@ These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` a
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:
-Quick rule: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
+Quick rule: User explicitly preferred plain subagents this session? → use Agent Tool (R000 user instructions > R018). Otherwise: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
 
 <!-- DETAIL: Self-Check (Before Agent Tool)
 ╔══════════════════════════════════════════════════════════════════╗
 ║  BEFORE USING Agent TOOL FOR 2+ AGENTS:                          ║
 ║                                                                   ║
+║  0. Has user explicitly preferred plain subagents this session?  ║
+║     YES → Use Agent tool (R000 user instructions > R018)         ║
+║     NO  → Continue to #1                                          ║
+║                                                                   ║
 ║  1. Is Agent Teams available?                                    ║
-║     YES → check criteria #2-#4                                  ║
+║     YES → check criteria #2-#5                                  ║
 ║     NO  → Proceed with Agent tool                               ║
 ║                                                                   ║
 ║  2. Will 3+ agents be involved?                                  ║

--- a/templates/.claude/rules/MUST-continuous-improvement.md
+++ b/templates/.claude/rules/MUST-continuous-improvement.md
@@ -61,7 +61,7 @@ Before creating or modifying assets for an external repository or upstream contr
 
 Late discovery of contribution rules is a process defect. Record it as memory and an issue when the miss is repeatable or affected delivered work.
 
-## Anti-Patterns — 4 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first". See table via Read tool.
+## Anti-Patterns — 5 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first", "calibration during action-oriented tone". See table via Read tool.
 
 <!-- DETAIL: Anti-Patterns
 | Anti-Pattern | Why It's Wrong | Correct Action |
@@ -70,6 +70,7 @@ Late discovery of contribution rules is a process defect. Record it as memory an
 | "This is a one-time exception" | Exceptions become patterns | If the rule is wrong, fix it; if it's right, follow it |
 | "The rule doesn't cover this case" | Missing coverage = rule gap | Add the case to the rule immediately |
 | "Let me finish the task first" | Rule violations compound | Fix rule first (5 min), then continue (prevents N future violations) |
+| "Calibration/humility during action-oriented tone (auto mode, ㄱㄱ, 계속해)" | Self-questioning wastes time when user signals action; action-mode preempts meta-reflection | Defer calibration to post-task feedback memory; respond with short action confirmation |
 -->
 
 ## Timing — Rule updates MUST happen before continuing original task, in the same session.

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -361,7 +361,7 @@ MCP tools (searchable memory backends, episodic-memory) are **orchestrator-scope
 
 ### Session-End Self-Check (MANDATORY)
 
-(1) sys-memory-keeper updated MEMORY.md? (2) searchable memory save attempted when a backend is available? Both are required before confirming session-end to the user. See full self-check via Read tool.
+(1) sys-memory-keeper updated MEMORY.md? (2) searchable memory save attempted when a backend is available? (3) If `omcustomcodex-feedback` skill is active, prompt user to trigger it? All three are required before confirming session-end to the user. See full self-check via Read tool.
 
 <!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
@@ -376,10 +376,15 @@ MCP tools (searchable memory backends, episodic-memory) are **orchestrator-scope
 ║     YES → Continue (even if it failed)                           ║
 ║     NO  → ToolSearch + save now                                  ║
 ║                                                                   ║
+║  3. Is omcustomcodex-feedback skill available in this project?   ║
+║     YES → Ask user: "이번 세션 피드백을 omcustomcodex-feedback로 ║
+║          기록하시겠습니까?" — accept skip                        ║
+║     NO  → Skip                                                    ║
+║                                                                   ║
 ║  Note: episodic-memory auto-indexes conversations after session  ║
 ║  ends. No manual action needed — do NOT search as "verification" ║
 ║                                                                   ║
-║  BOTH steps must be completed before confirming to user.         ║
+║  ALL applicable steps must be completed before confirming to user.║
 ║  "Attempted" means called the tool — failure is OK, skipping     ║
 ║  is NOT.                                                          ║
 ╚══════════════════════════════════════════════════════════════════╝

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,21 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.146
+
+Published: 2026-05-21.
+
+Source: upstream oh-my-customcode #1205, Codex port #1364.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| `/simplify` was renamed to `/code-review` and accepts effort levels such as `/code-review high` | Native Claude command naming is now closer to review workflows, but this package still exposes its own `dev-review` skill. | No runtime rename. Keep user-facing docs clear that `dev-review` is the package skill and `/code-review` is the native Claude command. |
+| Auto mode no longer suppresses `AskUserQuestion` when the user or a skill explicitly relies on it | Ambiguity-gated compatibility workflows can ask explicit questions even in auto mode. | No Codex tool change. Keep `request_user_input`/question usage limited to genuinely branching cases. |
+| MCP `resources/list`, `resources/templates/list`, and `prompts/list` pagination was fixed | Large memory or ontology MCP servers are less likely to hide resources after page 1. | No package change; treat complete paginated MCP lists as more reliable evidence. |
+| `CLAUDE_CODE_SUBAGENT_MODEL` is forwarded to child processes in multi-agent sessions | Claude compatibility sessions with model env overrides now preserve child-process model intent. | No Codex model override. Codex-native child agents still follow repo model routing and inherited defaults. |
+| `/background` accepts skill-only or custom-slash-only input and background sessions preserve granted tool permissions | Long-running Claude compatibility sessions are less likely to stall on already granted permissions. | No Codex change. Keep permission expectations explicit in workflow prompts. |
+| Agent SDK streaming end-of-session exception was fixed | Agent SDK plugin experiments should be less noisy at stream completion. | Monitor only; no package change. |
+
 ## v2.1.145
 
 Published: 2026-05-19.

--- a/tests/unit/core/hooks-scripts.test.ts
+++ b/tests/unit/core/hooks-scripts.test.ts
@@ -26,6 +26,7 @@ const SOURCE_SESSION_ENV_CHECK_SCRIPT = join(SOURCE_SCRIPTS_DIR, 'session-env-ch
 const STALE_TODO_SCANNER_SCRIPT = join(SCRIPTS_DIR, 'stale-todo-scanner.sh');
 const FEEDBACK_COLLECTOR_SCRIPT = join(SCRIPTS_DIR, 'feedback-collector.sh');
 const SKILL_EXTRACTOR_ANALYZER_SCRIPT = join(SCRIPTS_DIR, 'skill-extractor-analyzer.sh');
+const PLUGIN_CACHE_CHECK_SCRIPT = join(SCRIPTS_DIR, 'plugin-cache-check.sh');
 
 const STAGE_FILE = '/tmp/.codex-dev-stage';
 
@@ -1633,6 +1634,7 @@ describe('Script file validation', () => {
     'user-prompt-preprocessor.sh',
     'cwd-change-detector.sh',
     'file-change-validator.sh',
+    'plugin-cache-check.sh',
   ] as const;
 
   it('all expected scripts should exist in the templates directory', async () => {
@@ -1681,5 +1683,70 @@ describe('Script file validation', () => {
       expect(exitCode).toBe(0);
       expect(stderr).toBe('');
     }
+  });
+});
+
+describe('plugin-cache-check.sh', () => {
+  let tempHome: string;
+  let tempCache: string;
+
+  beforeEach(async () => {
+    tempHome = join(tmpdir(), `omx-plugin-cache-home-${Date.now()}-${Math.random()}`);
+    tempCache = join(tmpdir(), `omx-plugin-cache-${Date.now()}-${Math.random()}`);
+    await mkdir(tempHome, { recursive: true });
+    await mkdir(tempCache, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempHome, { recursive: true, force: true });
+    await rm(tempCache, { recursive: true, force: true });
+  });
+
+  it('passes stdin through and exits 0 when no plugin cache entries exist', async () => {
+    const input = JSON.stringify({ hook_event_name: 'SessionStart' });
+    const result = await runHookScript(PLUGIN_CACHE_CHECK_SCRIPT, input, {
+      HOME: tempHome,
+      CODEX_PLUGIN_CACHE: tempCache,
+      CLAUDE_PLUGIN_CACHE: join(tempHome, 'empty-claude-cache'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(input);
+    expect(result.stderr).toBe('');
+  });
+
+  it('warns about package directories missing node_modules without blocking the session', async () => {
+    const packageDir = join(tempCache, 'example-plugin');
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(join(packageDir, 'package.json'), '{"name":"example-plugin"}\n');
+
+    const input = JSON.stringify({ hook_event_name: 'SessionStart' });
+    const result = await runHookScript(PLUGIN_CACHE_CHECK_SCRIPT, input, {
+      HOME: tempHome,
+      CODEX_PLUGIN_CACHE: tempCache,
+      CLAUDE_PLUGIN_CACHE: join(tempHome, 'empty-claude-cache'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(input);
+    expect(result.stderr).toContain('Plugin cache missing node_modules');
+    expect(result.stderr).toContain(packageDir);
+  });
+
+  it('does not warn when node_modules exists beside package.json', async () => {
+    const packageDir = join(tempCache, 'installed-plugin');
+    await mkdir(join(packageDir, 'node_modules'), { recursive: true });
+    await writeFile(join(packageDir, 'package.json'), '{"name":"installed-plugin"}\n');
+
+    const input = JSON.stringify({ hook_event_name: 'SessionStart' });
+    const result = await runHookScript(PLUGIN_CACHE_CHECK_SCRIPT, input, {
+      HOME: tempHome,
+      CODEX_PLUGIN_CACHE: tempCache,
+      CLAUDE_PLUGIN_CACHE: join(tempHome, 'empty-claude-cache'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(input);
+    expect(result.stderr).toBe('');
   });
 });

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -594,7 +594,7 @@ describe('Template Validation', () => {
   });
 
   describe('Claude Code version compatibility guidance', () => {
-    it('mirrors the v2.1.139 through v2.1.145 compatibility guide into templates', async () => {
+    it('mirrors the v2.1.139 through v2.1.146 compatibility guide into templates', async () => {
       const projectRoot = resolve(import.meta.dir, '../../..');
       const guidePath = 'guides/claude-code/15-version-compatibility.md';
       const sourceGuide = await readFile(join(projectRoot, guidePath), 'utf-8');
@@ -609,6 +609,7 @@ describe('Template Validation', () => {
         'v2.1.143',
         'v2.1.144',
         'v2.1.145',
+        'v2.1.146',
       ]) {
         expect(templateGuide).toContain(version);
       }
@@ -619,6 +620,7 @@ describe('Template Validation', () => {
       expect(templateGuide).toContain('claude agents --json');
       expect(templateGuide).toContain('background_tasks');
       expect(templateGuide).toContain('session_crons');
+      expect(templateGuide).toContain('CLAUDE_CODE_SUBAGENT_MODEL');
     });
 
     it('mirrors statusline support for native GitHub and agent-count JSON', async () => {


### PR DESCRIPTION
## Summary
- Port Claude Code v2.1.146 compatibility guidance into source and template docs
- Add feedback-driven R018/R011/R016 rule updates with source/template parity
- Add a non-blocking SessionStart plugin cache advisory hook plus regression tests

Closes #1364
Closes #1365
Closes #1366

## Verification
- bun run lint
- bun run typecheck
- bun run build
- bun test tests/unit/core/template-validation.test.ts
- bun test tests/unit/core/hooks-scripts.test.ts
- bun test tests/sync-upstream-release-issues.test.js tests/integration/i18n.test.ts tests/integration/init-flow.test.ts tests/e2e/list.test.ts tests/e2e/doctor.test.ts
- bun test tests/ packages/eval-core/