### PR TITLE
docs: release v0.5.3 upstream port backlog

### DIFF
--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -22,6 +22,36 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.
 
+## Diagnostic Hypothesis Verification
+
+When a failure diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until it is directly verified.
+
+Required steps:
+
+1. Capture the concrete symptom and the proposed root cause separately.
+2. Gather direct evidence for the root cause from the authoritative source: command output, CI logs, registry response, source file, or API result.
+3. Test or falsify at least one plausible alternative when the change affects shared release or verification infrastructure.
+4. Record the verified cause in the commit, issue comment, or release note before merging the permanent change.
+
+Examples:
+
+| Hypothesis | Required evidence before changing shared workflow |
+|------------|---------------------------------------------------|
+| "npm publish failed because provenance is incompatible" | Registry error details showing provenance rejection, not just an initial `E403` |
+| "CI cannot find a file because it is generated locally" | Clean checkout result proving the file is untracked or absent |
+| "A test is flaky enough to skip" | Repeated-run evidence plus a tracked fix issue; skip alone is not completion |
+
+## Test-Skip Is Not Completion
+
+Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO may be a temporary containment step, but it never satisfies completion by itself.
+
+Before a task can be declared done after a test skip or threshold reduction:
+
+1. The underlying failure must have a linked issue, owner, and reproduction command.
+2. The skipped scope must be named precisely, not hidden behind a broad suite skip.
+3. The release or PR summary must state that verification is reduced.
+4. A follow-up must restore the test or remove the threshold reduction before the related work is considered fully complete.
+
 ## Optional: Quantitative Evidence
 
 For agent, skill, or workflow changes, completion evidence MAY include `agent-eval-framework` metrics:

--- a/.codex/rules/MUST-sync-verification.md
+++ b/.codex/rules/MUST-sync-verification.md
@@ -32,12 +32,26 @@ Also run: mgr-claude-code-bible:verify (official spec compliance)
 
 | Check | Action |
 |-------|--------|
-| Missing pages | Source entities without wiki pages → run `/omcodex:wiki` |
-| Stale pages | Source modification date newer than wiki `updated` field → run `/omcodex:wiki ingest <path>` |
-| Broken cross-refs | Wiki links pointing to non-existent pages → run `/omcodex:wiki lint` |
-| index.md accuracy | Wiki index page count matches actual page count |
+| Missing pages | Source entities without wiki pages → run `/omcustomcodex:wiki` |
+| Stale pages | Source modification date newer than wiki `updated` field → run `/omcustomcodex:wiki ingest <path>` |
+| Broken cross-refs | Wiki links pointing to non-existent pages → run `/omcustomcodex:wiki lint` |
+| wiki/index.yaml accuracy | Wiki index page count and indexed file entries match actual page files |
 
 Wiki verification is also enforced by CI (`.github/workflows/wiki-sync.yml`).
+
+### Structural Migration Verification
+
+Directory restructuring, template flattening, branch-strategy changes, generated-file relocation, and package-surface moves require a clean-checkout migration audit before they are considered complete.
+
+Required checks:
+
+1. Run the relevant verification from a clean checkout or isolated worktree, not only from a developer tree with untracked files.
+2. Confirm old paths are no longer referenced by CI, docs validators, template validators, install/init output, and release workflows.
+3. Confirm new paths are tracked by git and present in packaged templates or generated output where users will rely on them.
+4. Verify allowlists, `.gitignore`, and template sync checks do not hide missing files.
+5. Add or update regression tests that fail on the old path assumption.
+
+This section is specifically intended to catch migrations where local untracked files or stale CI path references make a release appear healthy while a clean checkout fails.
 
 ### Phase 4: Fix all discovered issues
 

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.2",
-  "generatedAt": "2026-05-24T03:37:03.227Z",
-  "templateVersion": "0.5.2",
+  "generatorVersion": "0.5.3",
+  "generatedAt": "2026-05-24T12:07:20.381Z",
+  "templateVersion": "0.5.3",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-sync-verification.md": {
-      "templateHash": "aa6bf18a9b1d490a5e2f71a29324588c37dc356d9a871c6c84cf869257ba7b1c",
-      "size": 6499,
+      "templateHash": "cf4c6f6723b77b7c67e2db45e3a5c7eb178d65bf2b06802f48a4728b24575a12",
+      "size": 7533,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-teams.md": {
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "fd80101ed04272eac20dbd7654c08e9b871c843c6b0662aeb63ccd4bd43bb154",
-      "size": 7045,
+      "templateHash": "db8aef04c857eb3503f5dd361f95b5927838b95b33d01451fd8dd91f48a61a10",
+      "size": 8925,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {
@@ -670,8 +670,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "a57e9dd7b709112617d2e7d62a21e1c6e2b0927c123f5afec7372eb2ba73b174",
-      "size": 13760,
+      "templateHash": "a811c81ba5cd4203fa8e9fff1ed030f0b8611b98c7c03dd12b33a2f57feb3469",
+      "size": 20087,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-05-24
+
+### Added
+- Record Claude Code v2.1.147-v2.1.150 compatibility decisions in source, templates, and wiki docs, including Workflow gating, `/simplify` to `/code-review` naming, Bash exit-127 triage, `/usage` diagnostics, worktree sandbox fixes, and the v2.1.150 no-op review.
+
+### Changed
+- Strengthen R020 with explicit Diagnostic Hypothesis Verification and Test-Skip Is Not Completion guidance, mirrored into Claude templates and wiki rules.
+- Strengthen R017 structural migration verification for clean-checkout path audits and `wiki/index.yaml` entry accuracy.
+- Refresh `wiki/index.yaml` so every wiki markdown page has a matching index entry and stale `omcustomcodex-*` skill paths point at the actual `omcodex-*` pages.
+
+### Fixed
+- Confirm no stale Codex-native `simplify` route is present while documenting the valid `dev-review` and `dev-refactor` split.
+- Confirm the referenced leftover `.claude/worktrees/agent-abf7468961dceb1fe` directory is absent from the current worktree and Git worktree list.
+
 ## [0.5.2] - 2026-05-24
 
 ### Added

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,62 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.150
+
+Published: 2026-05-23.
+
+Source: upstream oh-my-customcode #1220, Codex port #1380.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Internal infrastructure improvements only | No user-facing Claude compatibility behavior changed for templates, agents, skills, hooks, or rules. | No package change. Record the no-op review so release-monitor ports can be closed with evidence instead of staying open. |
+
+## v2.1.149
+
+Published: 2026-05-22.
+
+Source: upstream oh-my-customcode #1219, Codex port #1379.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| `/usage` now breaks limit usage down by skills, subagents, plugins, and MCP servers | Useful diagnostic vocabulary for Claude compatibility sessions; Codex-native reporting still comes from OMX status, trace, and local CLI surfaces. | No runtime change. Keep cost and status reports source-specific instead of treating Claude `/usage` output as Codex evidence. |
+| `/diff` detail view supports keyboard scrolling and Markdown renders GFM task-list checkboxes | Improves Claude terminal UX for reviews and release notes. | No template change. Continue writing normal Markdown task lists; Claude now renders them more faithfully. |
+| Enterprise `allowAllClaudeAiMcps` can load claude.ai cloud MCP connectors next to managed MCP config | Only affects managed Claude enterprise workspaces. | Document as Claude-template compatibility only; Codex MCP routing remains configured through Codex/OMX config. |
+| PowerShell `cd` aliases, wildcard prefix rules, and stale directory-variable tracking were hardened | Permission-analysis fixes reduce Claude compatibility sandbox escapes. | No Codex shell-policy change. Do not copy PowerShell-specific assumptions into Codex Bash approvals. |
+| Git worktree sandbox allowlists now cover only the shared `.git` directory, not the whole main repo | Aligns with this repo's preference for isolated worktrees during auto-dev sweeps. | Keep release and issue-sweep work in clean worktrees and verify dirty-tree boundaries explicitly. |
+| Bash `find` no longer exhausts macOS file/vnode tables on large trees | Large repository scans are safer for Claude compatibility sessions. | Still prefer `rg`/targeted `find` in Codex sessions and keep scans bounded. |
+| `/ultraplan` and remote sessions no longer fail when there are no real uncommitted changes | Reduces false blockers for clean-tree planning. | No package change; continue verifying `git status` before declaring clean boundaries. |
+| `otelHeadersHelper` reports path-with-spaces failures in `/doctor` and debug logs | Helps diagnose local telemetry setup drift. | Keep hook and doctor guidance path-safe, especially under workspace paths that may contain spaces. |
+
+## v2.1.148
+
+Published: 2026-05-22.
+
+Source: upstream oh-my-customcode #1218, Codex port #1378.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Fixed a v2.1.147 regression where the Bash tool returned exit code 127 for every command for some users | Claude compatibility sessions on affected versions may have produced false command-not-found failures. | Treat suspicious all-command `127` reports from Claude v2.1.147 as environment/version evidence to verify before changing repo code. No Codex runtime change. |
+
+## v2.1.147
+
+Published: 2026-05-21.
+
+Source: upstream oh-my-customcode #1216 and #1222, Codex ports #1376 and #1381.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Added the `Workflow` tool for deterministic multi-agent orchestration, gated by `CLAUDE_CODE_WORKFLOWS=1` | This overlaps conceptually with OMX `$pipeline`, but it is a Claude-native tool surface. | Do not replace Codex/OMX pipeline routing with Claude Workflow. Mention the env gate when documenting Claude-template sessions. |
+| Pinned background sessions stay alive when idle, restart in place for updates, and are shed after non-pinned sessions under memory pressure | Claude compatibility background agents are more durable. | Keep Codex-native child-agent and OMX session lifecycle separate; pinned Claude sessions are not proof of active OMX work. |
+| `/simplify` was renamed to `/code-review`; it now reports correctness bugs at chosen effort levels and the old cleanup-and-fix behavior was removed | Potential naming confusion with this package's `dev-review` and `dev-refactor` skills. | Keep package commands as `dev-review` for best-practice review and `dev-refactor` for cleanup/refactor. Do not add a dead `simplify` route. |
+| REPL and Workflow sandboxes were hardened against prototype-pollution and thenable-based escapes | Security hardening applies to Claude runtime internals. | No package code change; keep security reviews focused on repo-owned hooks, scripts, and generated templates. |
+| Auto-updater retries transient network failures and reports specific error categories plus current version on update failure | Helps distinguish transient update problems from package regressions. | For publish/update triage, verify registry token, workflow logs, and current version before making permanent workflow edits. |
+| Large diff rendering and prompt-history duplicate handling improved | UX-only for Claude compatibility sessions. | No template change. |
+| Enterprise login restrictions are enforced against third-party-provider and API-key sessions | Managed Claude environments behave more consistently. | No Codex auth change. Treat enterprise login policy as external environment state. |
+| Headless/SDK unknown slash commands now show an error instead of silently doing nothing | Broken generated commands should be easier to detect. | Keep template command names explicit and test packaged command references. |
+| Plugin agents declaring multiple `Agent(...)` tool types no longer drop all but the last one | Compatibility templates with multi-agent tool declarations are safer. | Continue using canonical, explicit agent names in package docs and frontmatter. |
+| Hook `if` conditions such as `PowerShell(git push*)` were fixed to match as intended | Claude hook compatibility improved. | Keep Codex hook routing Bash-first unless a hook is explicitly PowerShell-specific. |
+
 ## v2.1.146
 
 Published: 2026-05-21.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.2",
+  "version": "0.5.3",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -22,6 +22,36 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.
 
+## Diagnostic Hypothesis Verification
+
+When a failure diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until it is directly verified.
+
+Required steps:
+
+1. Capture the concrete symptom and the proposed root cause separately.
+2. Gather direct evidence for the root cause from the authoritative source: command output, CI logs, registry response, source file, or API result.
+3. Test or falsify at least one plausible alternative when the change affects shared release or verification infrastructure.
+4. Record the verified cause in the commit, issue comment, or release note before merging the permanent change.
+
+Examples:
+
+| Hypothesis | Required evidence before changing shared workflow |
+|------------|---------------------------------------------------|
+| "npm publish failed because provenance is incompatible" | Registry error details showing provenance rejection, not just an initial `E403` |
+| "CI cannot find a file because it is generated locally" | Clean checkout result proving the file is untracked or absent |
+| "A test is flaky enough to skip" | Repeated-run evidence plus a tracked fix issue; skip alone is not completion |
+
+## Test-Skip Is Not Completion
+
+Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO may be a temporary containment step, but it never satisfies completion by itself.
+
+Before a task can be declared done after a test skip or threshold reduction:
+
+1. The underlying failure must have a linked issue, owner, and reproduction command.
+2. The skipped scope must be named precisely, not hidden behind a broad suite skip.
+3. The release or PR summary must state that verification is reduced.
+4. A follow-up must restore the test or remove the threshold reduction before the related work is considered fully complete.
+
 ## Optional: Quantitative Evidence
 
 For agent, skill, or workflow changes, completion evidence MAY include `agent-eval-framework` metrics:

--- a/templates/.claude/rules/MUST-sync-verification.md
+++ b/templates/.claude/rules/MUST-sync-verification.md
@@ -35,9 +35,23 @@ Also run: mgr-claude-code-bible:verify (official spec compliance)
 | Missing pages | Source entities without wiki pages → run `/omcustomcodex:wiki` |
 | Stale pages | Source modification date newer than wiki `updated` field → run `/omcustomcodex:wiki ingest <path>` |
 | Broken cross-refs | Wiki links pointing to non-existent pages → run `/omcustomcodex:wiki lint` |
-| index.md accuracy | Wiki index page count matches actual page count |
+| wiki/index.yaml accuracy | Wiki index page count and indexed file entries match actual page files |
 
 Wiki verification is also enforced by CI (`.github/workflows/wiki-sync.yml`).
+
+### Structural Migration Verification
+
+Directory restructuring, template flattening, branch-strategy changes, generated-file relocation, and package-surface moves require a clean-checkout migration audit before they are considered complete.
+
+Required checks:
+
+1. Run the relevant verification from a clean checkout or isolated worktree, not only from a developer tree with untracked files.
+2. Confirm old paths are no longer referenced by CI, docs validators, template validators, install/init output, and release workflows.
+3. Confirm new paths are tracked by git and present in packaged templates or generated output where users will rely on them.
+4. Verify allowlists, `.gitignore`, and template sync checks do not hide missing files.
+5. Add or update regression tests that fail on the old path assumption.
+
+This section is specifically intended to catch migrations where local untracked files or stale CI path references make a release appear healthy while a clean checkout fails.
 
 ### Phase 4: Fix all discovered issues
 

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,62 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.150
+
+Published: 2026-05-23.
+
+Source: upstream oh-my-customcode #1220, Codex port #1380.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Internal infrastructure improvements only | No user-facing Claude compatibility behavior changed for templates, agents, skills, hooks, or rules. | No package change. Record the no-op review so release-monitor ports can be closed with evidence instead of staying open. |
+
+## v2.1.149
+
+Published: 2026-05-22.
+
+Source: upstream oh-my-customcode #1219, Codex port #1379.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| `/usage` now breaks limit usage down by skills, subagents, plugins, and MCP servers | Useful diagnostic vocabulary for Claude compatibility sessions; Codex-native reporting still comes from OMX status, trace, and local CLI surfaces. | No runtime change. Keep cost and status reports source-specific instead of treating Claude `/usage` output as Codex evidence. |
+| `/diff` detail view supports keyboard scrolling and Markdown renders GFM task-list checkboxes | Improves Claude terminal UX for reviews and release notes. | No template change. Continue writing normal Markdown task lists; Claude now renders them more faithfully. |
+| Enterprise `allowAllClaudeAiMcps` can load claude.ai cloud MCP connectors next to managed MCP config | Only affects managed Claude enterprise workspaces. | Document as Claude-template compatibility only; Codex MCP routing remains configured through Codex/OMX config. |
+| PowerShell `cd` aliases, wildcard prefix rules, and stale directory-variable tracking were hardened | Permission-analysis fixes reduce Claude compatibility sandbox escapes. | No Codex shell-policy change. Do not copy PowerShell-specific assumptions into Codex Bash approvals. |
+| Git worktree sandbox allowlists now cover only the shared `.git` directory, not the whole main repo | Aligns with this repo's preference for isolated worktrees during auto-dev sweeps. | Keep release and issue-sweep work in clean worktrees and verify dirty-tree boundaries explicitly. |
+| Bash `find` no longer exhausts macOS file/vnode tables on large trees | Large repository scans are safer for Claude compatibility sessions. | Still prefer `rg`/targeted `find` in Codex sessions and keep scans bounded. |
+| `/ultraplan` and remote sessions no longer fail when there are no real uncommitted changes | Reduces false blockers for clean-tree planning. | No package change; continue verifying `git status` before declaring clean boundaries. |
+| `otelHeadersHelper` reports path-with-spaces failures in `/doctor` and debug logs | Helps diagnose local telemetry setup drift. | Keep hook and doctor guidance path-safe, especially under workspace paths that may contain spaces. |
+
+## v2.1.148
+
+Published: 2026-05-22.
+
+Source: upstream oh-my-customcode #1218, Codex port #1378.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Fixed a v2.1.147 regression where the Bash tool returned exit code 127 for every command for some users | Claude compatibility sessions on affected versions may have produced false command-not-found failures. | Treat suspicious all-command `127` reports from Claude v2.1.147 as environment/version evidence to verify before changing repo code. No Codex runtime change. |
+
+## v2.1.147
+
+Published: 2026-05-21.
+
+Source: upstream oh-my-customcode #1216 and #1222, Codex ports #1376 and #1381.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Added the `Workflow` tool for deterministic multi-agent orchestration, gated by `CLAUDE_CODE_WORKFLOWS=1` | This overlaps conceptually with OMX `$pipeline`, but it is a Claude-native tool surface. | Do not replace Codex/OMX pipeline routing with Claude Workflow. Mention the env gate when documenting Claude-template sessions. |
+| Pinned background sessions stay alive when idle, restart in place for updates, and are shed after non-pinned sessions under memory pressure | Claude compatibility background agents are more durable. | Keep Codex-native child-agent and OMX session lifecycle separate; pinned Claude sessions are not proof of active OMX work. |
+| `/simplify` was renamed to `/code-review`; it now reports correctness bugs at chosen effort levels and the old cleanup-and-fix behavior was removed | Potential naming confusion with this package's `dev-review` and `dev-refactor` skills. | Keep package commands as `dev-review` for best-practice review and `dev-refactor` for cleanup/refactor. Do not add a dead `simplify` route. |
+| REPL and Workflow sandboxes were hardened against prototype-pollution and thenable-based escapes | Security hardening applies to Claude runtime internals. | No package code change; keep security reviews focused on repo-owned hooks, scripts, and generated templates. |
+| Auto-updater retries transient network failures and reports specific error categories plus current version on update failure | Helps distinguish transient update problems from package regressions. | For publish/update triage, verify registry token, workflow logs, and current version before making permanent workflow edits. |
+| Large diff rendering and prompt-history duplicate handling improved | UX-only for Claude compatibility sessions. | No template change. |
+| Enterprise login restrictions are enforced against third-party-provider and API-key sessions | Managed Claude environments behave more consistently. | No Codex auth change. Treat enterprise login policy as external environment state. |
+| Headless/SDK unknown slash commands now show an error instead of silently doing nothing | Broken generated commands should be easier to detect. | Keep template command names explicit and test packaged command references. |
+| Plugin agents declaring multiple `Agent(...)` tool types no longer drop all but the last one | Compatibility templates with multi-agent tool declarations are safer. | Continue using canonical, explicit agent names in package docs and frontmatter. |
+| Hook `if` conditions such as `PowerShell(git push*)` were fixed to match as intended | Claude hook compatibility improved. | Keep Codex hook routing Bash-first unless a hook is explicitly PowerShell-specific. |
+
 ## v2.1.146
 
 Published: 2026-05-21.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.5.2",
+  "version": "0.5.3",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-05-20T00:00:00.000Z",
+  "lastUpdated": "2026-05-24T00:00:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -127,6 +127,24 @@ async function countMdFiles(fullPath: string): Promise<number> {
   return entries.filter((e) => e.isFile() && e.name.endsWith('.md')).length;
 }
 
+async function listMarkdownFiles(fullPath: string, prefix = ''): Promise<string[]> {
+  const entries = await readdir(fullPath, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const absolutePath = join(fullPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await listMarkdownFiles(absolutePath, relativePath)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(relativePath);
+    }
+  }
+
+  return files;
+}
+
 async function countActualFiles(componentPath: string, componentName: string): Promise<number> {
   let fullPath = join(TEMPLATES_DIR, componentPath);
 
@@ -594,7 +612,7 @@ describe('Template Validation', () => {
   });
 
   describe('Claude Code version compatibility guidance', () => {
-    it('mirrors the v2.1.139 through v2.1.146 compatibility guide into templates', async () => {
+    it('mirrors the v2.1.139 through v2.1.150 compatibility guide into templates', async () => {
       const projectRoot = resolve(import.meta.dir, '../../..');
       const guidePath = 'guides/claude-code/15-version-compatibility.md';
       const sourceGuide = await readFile(join(projectRoot, guidePath), 'utf-8');
@@ -610,6 +628,10 @@ describe('Template Validation', () => {
         'v2.1.144',
         'v2.1.145',
         'v2.1.146',
+        'v2.1.147',
+        'v2.1.148',
+        'v2.1.149',
+        'v2.1.150',
       ]) {
         expect(templateGuide).toContain(version);
       }
@@ -621,6 +643,11 @@ describe('Template Validation', () => {
       expect(templateGuide).toContain('background_tasks');
       expect(templateGuide).toContain('session_crons');
       expect(templateGuide).toContain('CLAUDE_CODE_SUBAGENT_MODEL');
+      expect(templateGuide).toContain('CLAUDE_CODE_WORKFLOWS=1');
+      expect(templateGuide).toContain('exit code 127');
+      expect(templateGuide).toContain('allowAllClaudeAiMcps');
+      expect(templateGuide).toContain('Internal infrastructure improvements only');
+      expect(templateGuide).toContain('Do not add a dead `simplify` route');
     });
 
     it('mirrors statusline support for native GitHub and agent-count JSON', async () => {
@@ -680,6 +707,7 @@ describe('Template Validation', () => {
         'MUST-intent-transparency.md',
         'MUST-continuous-improvement.md',
         'MUST-completion-verification.md',
+        'MUST-sync-verification.md',
       ];
 
       for (const ruleName of mirroredRules) {
@@ -712,6 +740,15 @@ describe('Template Validation', () => {
       expect(outputStyle).toContain('합쇼체');
       expect(r010).toContain('Agent Capability Pre-Check');
       expect(r020).toContain('Interrupt Priority Re-Ordering');
+      expect(r020).toContain('Diagnostic Hypothesis Verification');
+      expect(r020).toContain('Test-Skip Is Not Completion');
+
+      const r017 = await readFile(
+        join(projectRoot, '.codex/rules/MUST-sync-verification.md'),
+        'utf-8'
+      );
+      expect(r017).toContain('Structural Migration Verification');
+      expect(r017).toContain('clean checkout or isolated worktree');
     });
 
     it('keeps qa-engineer evidence requirements mirrored into templates', async () => {
@@ -781,6 +818,22 @@ describe('Template Validation', () => {
       }
       return count;
     }
+
+    it('keeps wiki/index.yaml file entries aligned with wiki markdown pages', async () => {
+      const wikiDir = join(PROJECT_ROOT, 'wiki');
+      const indexYaml = await readFile(join(wikiDir, 'index.yaml'), 'utf-8');
+      const markdownFiles = (await listMarkdownFiles(wikiDir))
+        .filter((file) => file !== 'index.md' && file !== 'log.md')
+        .sort();
+      const indexedFiles = Array.from(indexYaml.matchAll(/^\s+- file: (.+)$/gm))
+        .map((match) => match[1])
+        .sort();
+      const totalPagesMatch = indexYaml.match(/^\s+total_pages:\s+(\d+)$/m);
+
+      expect(totalPagesMatch).not.toBeNull();
+      expect(Number(totalPagesMatch?.[1])).toBe(markdownFiles.length);
+      expect(indexedFiles).toEqual(markdownFiles);
+    });
 
     it('uses AGENTS.md as the repo entry file and documents the visible status block', async () => {
       const agentsMd = await readFile(join(PROJECT_ROOT, 'AGENTS.md'), 'utf-8');

--- a/wiki/guides/claude-code.md
+++ b/wiki/guides/claude-code.md
@@ -1,7 +1,7 @@
 ---
 title: "Claude Code Guide"
 type: guide
-updated: 2026-05-20
+updated: 2026-05-24
 sources:
   - guides/claude-code/01-overview.md
   - guides/claude-code/15-version-compatibility.md
@@ -33,6 +33,46 @@ Covers Claude's advanced API features for building Claude Code-compatible applic
 ## Version Compatibility
 
 oh-my-customcodex keeps Claude compatibility guidance for installed templates while `.codex/**` and OMX remain the primary runtime surface.
+
+### v2.1.150 (2026-05-23)
+
+Source: upstream oh-my-customcode #1220, Codex port #1380.
+
+- Internal infrastructure improvements only; no Codex package or Claude-template runtime change was required.
+- The no-op review is recorded so release-monitor ports can close with explicit evidence.
+
+### v2.1.149 (2026-05-22)
+
+Source: upstream oh-my-customcode #1219, Codex port #1379.
+
+- `/usage` now breaks limit usage down by skills, subagents, plugins, and MCP servers; Codex reports still come from OMX status, trace, and local CLI evidence.
+- Git worktree sandbox allowlists now cover only shared `.git` state, reinforcing clean worktree boundaries for auto-dev sweeps.
+- Bash `find` and no-change planning regressions were fixed upstream, but Codex sessions should still prefer bounded `rg`/targeted scans and explicit `git status` checks.
+- Enterprise `allowAllClaudeAiMcps`, PowerShell permission fixes, diff scrolling, GFM checkboxes, and telemetry path diagnostics are documented as Claude compatibility surfaces.
+
+### v2.1.148 (2026-05-22)
+
+Source: upstream oh-my-customcode #1218, Codex port #1378.
+
+- Claude Code fixed the v2.1.147 Bash regression that returned exit code 127 for every command for some users.
+- Suspicious all-command `127` failures from Claude v2.1.147 should be treated as version/environment evidence before changing repository code.
+
+### v2.1.147 (2026-05-21)
+
+Source: upstream oh-my-customcode #1216 and #1222, Codex ports #1376 and #1381.
+
+- `Workflow` is a Claude-native deterministic multi-agent tool gated by `CLAUDE_CODE_WORKFLOWS=1`; it does not replace OMX `$pipeline`.
+- Pinned background sessions are more durable, but pinned Claude sessions are not evidence of active OMX work.
+- `/simplify` was renamed to `/code-review`; this package keeps `dev-review` for best-practice review and `dev-refactor` for cleanup/refactor, with no dead `simplify` route.
+- Auto-updater diagnostics, unknown slash-command errors, multi-`Agent(...)` plugin handling, sandbox hardening, and hook condition fixes are recorded as Claude-template compatibility notes.
+
+### v2.1.146 (2026-05-21)
+
+Source: upstream oh-my-customcode #1205, Codex port #1364.
+
+- `/simplify` was renamed to `/code-review` and accepts effort levels such as `/code-review high`.
+- The package still exposes `dev-review` as its own review skill; native `/code-review` is a Claude command, not a package skill rename.
+- MCP pagination, model env forwarding, background permission preservation, and Agent SDK stream completion fixes are documented as compatibility-only changes.
 
 ### v2.1.145 (2026-05-19)
 

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -7,6 +7,53 @@ meta:
   total_sources: 247
 
 pages:
+  navigation:
+    - file: Agents.md
+      title: "Agents"
+      summary: "GitHub Wiki navigation page for agent documentation."
+    - file: Built-in-Commands.md
+      title: "Built-in Commands"
+      summary: "GitHub Wiki navigation page for built-in command documentation."
+    - file: CLI-Reference.md
+      title: "CLI Reference"
+      summary: "GitHub Wiki reference page for command-line usage."
+    - file: Contributing.md
+      title: "Contributing"
+      summary: "GitHub Wiki contribution guide."
+    - file: Customization.md
+      title: "Customization"
+      summary: "GitHub Wiki guide for customizing the harness."
+    - file: Development.md
+      title: "Development"
+      summary: "GitHub Wiki development workflow guide."
+    - file: Guides.md
+      title: "Guides"
+      summary: "GitHub Wiki navigation page for guide documentation."
+    - file: Home.md
+      title: "Home"
+      summary: "GitHub Wiki home page."
+    - file: Project-Structure.md
+      title: "Project Structure"
+      summary: "GitHub Wiki project structure overview."
+    - file: Quick-Start.md
+      title: "Quick Start"
+      summary: "GitHub Wiki quick start guide."
+    - file: Rules.md
+      title: "Rules"
+      summary: "GitHub Wiki navigation page for rule documentation."
+    - file: Skills.md
+      title: "Skills"
+      summary: "GitHub Wiki navigation page for skill documentation."
+    - file: Sub-Agent-Model.md
+      title: "Sub-Agent Model"
+      summary: "GitHub Wiki explanation of the sub-agent model."
+    - file: _Footer.md
+      title: "Footer"
+      summary: "GitHub Wiki footer navigation."
+    - file: _Sidebar.md
+      title: "Sidebar"
+      summary: "GitHub Wiki sidebar navigation."
+
   architecture:
     - file: architecture/agent-taxonomy.md
       title: "Agent Taxonomy"
@@ -177,6 +224,9 @@ pages:
     - file: skills/action-validator.md
       title: "Action Validator"
       summary: "Pre-action boundary checking — validates agent tool calls against declared capabilities"
+    - file: skills/agent-eval-framework.md
+      title: "Agent Eval Framework"
+      summary: "Quantitative agent evaluation using correctness, step ratio, tool-call ratio, and latency ratio."
     - file: skills/adaptive-harness.md
       title: "Adaptive Harness"
       summary: "Auto-detect project context and optimize the oh-my-customcodex harness — deactivate unused agents/skills, suggest missing experts"
@@ -294,6 +344,9 @@ pages:
     - file: skills/help.md
       title: "Help"
       summary: "Show help information for commands, agents, and skills."
+    - file: skills/idea.md
+      title: "Idea"
+      summary: "Analyze natural-language ideas against the current codebase and produce issue-ready specs."
     - file: skills/impeccable-design.md
       title: "Impeccable Design"
       summary: "AI design language for production-ready UI systems."
@@ -357,25 +410,25 @@ pages:
     - file: skills/npm-version.md
       title: "NPM Version"
       summary: "Semantic version management for npm packages."
-    - file: skills/omcustomcodex-auto-improve.md
+    - file: skills/omcodex-auto-improve.md
       title: "Omcustom Auto-Improve"
       summary: "Apply verified improvement suggestions from the improve-report to the codebase"
-    - file: skills/omcustomcodex-feedback.md
+    - file: skills/omcodex-feedback.md
       title: "Omcustom Feedback"
       summary: "Submit user feedback as a GitHub Issue for tracking and improvement."
-    - file: skills/omcustomcodex-improve-report.md
+    - file: skills/omcodex-improve-report.md
       title: "Omcustom Improve Report"
       summary: "Read-only report of improvement status based on eval-core findings."
-    - file: skills/omcustomcodex-loop.md
+    - file: skills/omcodex-loop.md
       title: "Omcustom Loop"
       summary: "Prevent session idle during background agent execution by keeping the session active"
-    - file: skills/omcustomcodex-release-notes.md
+    - file: skills/omcodex-release-notes.md
       title: "Omcustom Release Notes"
       summary: "Generate structured release notes from git history and closed issues."
-    - file: skills/omcustomcodex-takeover.md
+    - file: skills/omcodex-takeover.md
       title: "Omcustom Takeover"
       summary: "Extract canonical spec from existing agents/skills — reverse-engineer the intended"
-    - file: skills/omcustomcodex-web.md
+    - file: skills/omcodex-web.md
       title: "Omcustom Web"
       summary: "Control and inspect the built-in Claude Code Web UI."
     - file: skills/optimize-analyze.md
@@ -441,6 +494,9 @@ pages:
     - file: skills/result-aggregation.md
       title: "Result Aggregation"
       summary: "Aggregate parallel agent results into a unified, deduplicated summary."
+    - file: skills/roundtable-debate.md
+      title: "Roundtable Debate"
+      summary: "Structured multi-agent debate for decisions where preserving dissent matters."
     - file: skills/rtk-exec.md
       title: "RTK Exec"
       summary: "Execute CLI commands through RTK proxy for token compression."
@@ -613,6 +669,9 @@ pages:
     - file: guides/agent-teams.md
       title: "Agent Teams Guide"
       summary: "Agent Teams shutdown, cleanup, and tmux fallback recovery guidance for Codex/OMX sessions"
+    - file: guides/agent-eval.md
+      title: "Agent Eval"
+      summary: "Correctness-first four-metric evaluation guidance for agent runs."
     - file: guides/alembic.md
       title: "Alembic Guide"
       summary: "Reference documentation for Alembic, the database migration framework for SQLAlchemy"
@@ -630,7 +689,7 @@ pages:
       summary: "External plugin for token cost optimization and session continuity — conflict resolution with R012/R013/R009/R010"
     - file: guides/claude-code.md
       title: "Claude Code Guide"
-      summary: "Claude Code compatibility guide with v2.1.143-v2.1.145 statusline, agent JSON, and background task impact"
+      summary: "Claude Code compatibility guide with v2.1.147-v2.1.150 Workflow, usage, sandbox, and no-op release impact"
     - file: guides/dbt.md
       title: "dbt Guide"
       summary: "Reference documentation for dbt (data build tool) SQL modeling and analytics engineering"
@@ -694,6 +753,9 @@ pages:
     - file: guides/middleware-patterns.md
       title: "Middleware Patterns Guide"
       summary: "Lifecycle middleware vocabulary mapped to Codex + OMX hooks, skills, and rules"
+    - file: guides/multi-agent-debate-patterns.md
+      title: "Multi-Agent Debate Patterns"
+      summary: "Guidance for consensus-seeking review and dissent-preserving multi-agent debate."
     - file: guides/postgres.md
       title: "PostgreSQL Guide"
       summary: "Reference documentation for pure PostgreSQL database administration, query optimization"
@@ -739,6 +801,9 @@ pages:
     - file: guides/worktree-lifecycle.md
       title: "Worktree Lifecycle Automation Guide"
       summary: "Three shell aliases (agent-spin, agent-merge, agent-clean) automating the full git worktree lifecycle for AI agent workflows"
+    - file: guides/multi-provider-exec.md
+      title: "Multi-Provider Exec Guide"
+      summary: "Unified reference for executing prompts through external LLM provider exec skills."
     - file: guides/multi-model-routing.md
       title: "Multi-Model Routing Guide"
       summary: "Role-based model selection strategy mapping task types to haiku/sonnet/opus tiers with escalation and project override patterns"

--- a/wiki/rules/r017.md
+++ b/wiki/rules/r017.md
@@ -1,9 +1,9 @@
 ---
 title: "R017: Sync Verification Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-05-24
 sources:
-  - .claude/rules/MUST-sync-verification.md
+  - .codex/rules/MUST-sync-verification.md
 related:
   - [[r006]]
   - [[r010]]
@@ -31,14 +31,20 @@ Structural changes can silently break routing tables, orphan skill references, o
 |-------|--------|-------|
 | Phase 1: Manager | 5 rounds | mgr-supplier:audit, mgr-updater:docs, frontmatter validity, count matching |
 | Phase 2: Deep Review | 3 rounds | Workflow alignment, reference integrity, R006/R009/R010 philosophy |
-| Phase 3 | — | Fix all discovered issues |
-| Phase 4 | — | Commit via `mgr-gitnerd` |
-| Phase 5 | — | Push via `mgr-gitnerd` (only after sauron passes) |
+| Phase 3: Wiki Sync | — | Missing pages, stale pages, broken links, `wiki/index.yaml` count and entry accuracy |
+| Phase 4 | — | Fix all discovered issues |
+| Phase 5 | — | Commit via `mgr-gitnerd` |
+| Phase 6 | — | Push via `mgr-gitnerd` (only after sauron passes) |
+
+**Structural migration verification:**
+
+Directory restructuring, template flattening, branch-strategy changes, generated-file relocation, and package-surface moves require a clean-checkout or isolated-worktree audit. The audit confirms old paths are gone from CI/docs/template validators, new paths are tracked and packaged, allowlists and `.gitignore` do not hide missing files, and regression tests fail on the old path assumption.
 
 **Quick verification commands:**
 - Agent count: `ls .codex/agents/*.md | wc -l`
-- Skill count: `find .claude/skills -name "SKILL.md" | wc -l`
+- Skill count: `find .codex/skills -name "SKILL.md" | wc -l`
 - Guide count: `find guides -mindepth 1 -maxdepth 1 -type d | wc -l`
+- Wiki index entries: compare `wiki/index.yaml` `file:` entries against actual `wiki/**/*.md` pages
 
 **When required:** Any change to agents, agent frontmatter, skills, guides, routing patterns, or rules.
 
@@ -52,8 +58,8 @@ Prompt-based self-check + `mgr-sauron:watch` verification flow. No hard-block ho
 
 - **Enforced by**: `mgr-sauron`, `mgr-supplier`, `mgr-updater`, `mgr-gitnerd`
 - **Related rules**: [[r006]], [[r010]], [[r016]], [[r020]]
-- **Affects**: All structural changes across `.codex/agents/`, `.codex/skills/`, `guides/`
+- **Affects**: All structural changes across `.codex/agents/`, `.codex/skills/`, `guides/`, `templates/`, and `wiki/`
 
 ## Sources
 
-- `.claude/rules/MUST-sync-verification.md` — rule definition
+- `.codex/rules/MUST-sync-verification.md` — rule definition

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -1,9 +1,9 @@
 ---
 title: "R020: Completion Verification Rules"
 type: rule
-updated: 2026-05-20
+updated: 2026-05-24
 sources:
-  - .claude/rules/MUST-completion-verification.md
+  - .codex/rules/MUST-completion-verification.md
 related:
   - [[r003]]
   - [[r010]]
@@ -61,6 +61,16 @@ False completion declarations erode trust and cause downstream failures. "Ran th
 | "Auto-publish ran" | External workflow not confirmed | Check `gh run list` for triggered jobs |
 | "Subagent reported pre-existing" | Not verified against baseline | Compare develop branch directly |
 | "Continued old plan after user interrupt" | Newest instruction has priority | Re-rank work and update completion contract before closing |
+
+## Diagnostic Hypothesis Verification
+
+When a diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until directly verified. Record the symptom, proposed root cause, direct evidence, and at least one plausible alternative before merging the permanent change.
+
+This specifically guards release workflows from repeating the pattern where an initial `E403` or clean-checkout failure is attributed to the wrong root cause without registry, CI, or source evidence.
+
+## Test-Skip Is Not Completion
+
+Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO can be temporary containment only. Completion still requires a linked issue, owner, reproduction command, precise skipped scope, and a follow-up that restores the skipped coverage.
 
 ## Interrupt Priority Re-Ordering
 


### PR DESCRIPTION
## Summary
- port Claude Code v2.1.147-v2.1.150 compatibility decisions into source docs, templates, tests, and wiki pages
- strengthen R020 diagnostic/test-skip completion rules and R017 structural migration/wiki index verification
- bump package/template version to 0.5.3 and refresh .omcodex.lock.json
- verify no stale Codex-native simplify route or leftover .claude/worktrees/agent-abf7468961dceb1fe residue remains

## Issues
Closes #1376 #1377 #1378 #1379 #1380 #1381 #1382 #1383

## Verification
- bun test tests/unit/core/template-validation.test.ts
- bun run build
- bun run lint
- bun run typecheck
- bun test tests/ packages/eval-core/

## Notes
- Work was isolated in /tmp/oh-my-customcodex-auto-dev-20260524-210104 because the main checkout is dirty.
