### PR TITLE
fix: prevent upstream v0.156.x compatibility gaps from regressing

### DIFF
--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -41,6 +41,20 @@ Examples:
 | "CI cannot find a file because it is generated locally" | Clean checkout result proving the file is untracked or absent |
 | "A test is flaky enough to skip" | Repeated-run evidence plus a tracked fix issue; skip alone is not completion |
 
+### Variant: Parallel Read + Permanent-Change Dispatch
+
+Diagnostic reads and permanent-change dispatches are sequentially dependent. Do not batch diagnostic `Read`/log inspection with issue creation, fix delegation, workflow edits, rule edits, template edits, or release-process changes in the same parallel batch when the write depends on the diagnostic result.
+
+Parallel batches return results together, so a same-batch permanent dispatch proves the hypothesis was treated as confirmed before the evidence was read. R009 parallel execution applies only to independent work; diagnosis → permanent change is not independent.
+
+| Forbidden | Required |
+|-----------|----------|
+| File `Read` plus an issue or fix instruction based on that file in one parallel batch | Run the diagnostic read first, inspect the result, then dispatch permanent changes in a later step |
+| Log inspection in parallel with an issue stating "the cause is X" | Confirm the log evidence before creating or updating the issue |
+| Hypothesis-driven workflow/rule/template edits before the authoritative evidence returns | Treat the root cause as unverified until the evidence is available |
+
+Example: do not diagnose `triage-dispatch.yml` from memory, create an issue, and delegate a fix in the same parallel call before reading the workflow. If the read later shows a different root cause, the issue, PR, and commit trail become correction debt even when the eventual code direction is acceptable.
+
 ## Test-Skip Is Not Completion
 
 Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO may be a temporary containment step, but it never satisfies completion by itself.

--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -2,54 +2,56 @@ name: Issue Triage Dispatch
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
-  issues: read
+  issues: write
 
 jobs:
-  trigger-airflow:
+  triage:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
     steps:
-      - name: Get Airflow JWT token
-        id: token
+      - name: Ensure triaged label exists
         run: |
           set -euo pipefail
-          TOKEN=$(curl -fsS -X POST "${AIRFLOW_URL}/auth/token" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${AIRFLOW_USER}\",\"password\":\"${AIRFLOW_PASSWORD}\"}" \
-            | jq -r '.access_token')
-          if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
-            echo "Failed to obtain Airflow JWT token" >&2
-            exit 1
-          fi
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
-        env:
-          AIRFLOW_URL: ${{ secrets.AIRFLOW_URL }}
-          AIRFLOW_USER: ${{ secrets.AIRFLOW_USER }}
-          AIRFLOW_PASSWORD: ${{ secrets.AIRFLOW_PASSWORD }}
+          gh label create triaged \
+            --color "C5DEF5" \
+            --description "Issue acknowledged by triage dispatch" \
+            --repo "${{ github.repository }}" \
+            2>/dev/null || true
 
-      - name: Trigger issue_triage DAG
-        env:
-          AIRFLOW_URL: ${{ secrets.AIRFLOW_URL }}
-          AIRFLOW_TOKEN: ${{ steps.token.outputs.token }}
-          REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_URL: ${{ github.event.issue.html_url }}
+      - name: Record issue type
         run: |
           set -euo pipefail
-          LOGICAL_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          DAG_RUN_ID="github-${REPO//\//-}-${ISSUE_NUMBER}-$(date -u +%s)"
-          PAYLOAD=$(jq -n \
-            --arg dag_run_id "$DAG_RUN_ID" \
-            --arg logical_date "$LOGICAL_DATE" \
-            --arg repo "$REPO" \
-            --argjson issue_number "$ISSUE_NUMBER" \
-            --arg issue_url "$ISSUE_URL" \
-            '{dag_run_id: $dag_run_id, logical_date: $logical_date, conf: {repo: $repo, issue_number: $issue_number, issue_url: $issue_url}}')
-          echo "Triggering DAG with payload: $PAYLOAD"
-          curl -fsS -X POST "${AIRFLOW_URL}/api/v2/dags/issue_triage/dagRuns" \
-            -H "Authorization: Bearer ${AIRFLOW_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
+          # Real triage is performed by the in-session professor-triage skill.
+          # This workflow only acknowledges new or labeled issues; no external CLI is required.
+          echo "Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+          echo "Triage acknowledgment will be posted only when the issue is not already triaged."
+
+      - name: Post triage acknowledgment
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+
+          # Check whether the issue is already triaged to avoid duplicate
+          # comments on repeated 'labeled' events or pre-labeled opened issues.
+          if gh issue view "$ISSUE_NUMBER" \
+               --repo "$REPO" \
+               --json labels \
+               --jq '.labels[].name' \
+             | grep -qx "triaged"; then
+            echo "Issue #${ISSUE_NUMBER} already triaged — skipping comment and label."
+            exit 0
+          fi
+
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --body "Thanks for filing this issue! It has been acknowledged by our triage dispatch and will be reviewed shortly. Detailed triage is performed by the professor-triage skill during active development sessions."
+
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --add-label "triaged"

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.5",
-  "generatedAt": "2026-05-29T08:12:31.040Z",
-  "templateVersion": "0.5.5",
+  "generatorVersion": "0.5.6",
+  "generatedAt": "2026-05-29T11:28:58.407Z",
+  "templateVersion": "0.5.6",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "db8aef04c857eb3503f5dd361f95b5927838b95b33d01451fd8dd91f48a61a10",
-      "size": 8925,
+      "templateHash": "4f7266c62ec564a933043811b2c6cd3db98ce873c5f498772e0e45b68e113f32",
+      "size": 10400,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {
@@ -675,8 +675,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "a811c81ba5cd4203fa8e9fff1ed030f0b8611b98c7c03dd12b33a2f57feb3469",
-      "size": 20087,
+      "templateHash": "b73cf8acdd71a498d8d39d6681ed29a15159543e4b3f59709861eb03212db000",
+      "size": 23915,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-05-29
+
+### Added
+- Document Claude Code v2.1.152-v2.1.156 compatibility across source guides, install templates, and wiki parity for #1417, #1418, #1419, #1420, and #1421.
+- Document the Agent tool malformed parsing platform workaround for long or special-character-heavy delegation prompts for #1416.
+- Add the R020 Parallel Read + Permanent-Change Dispatch guard to prevent hypothesis-dependent permanent changes from being batched with diagnostic reads for #1423.
+
+### Changed
+- Replace the stale external Airflow DAG issue triage workflow with an in-repo triage acknowledgment workflow for #1422.
+
 ## [0.5.5] - 2026-05-29
 
 ### Added

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,67 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.156
+
+Published: 2026-05-29.
+
+Source: upstream oh-my-customcode #1245, Codex port #1420.
+
+Note: v2.1.155 had no public release.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Fixed Opus 4.8 thinking-block API errors | Claude compatibility sessions using the v2.1.154 Opus 4.8 surface are more stable. Codex-native model routing is unchanged. | No package change. Prefer v2.1.156 over v2.1.154 when testing Claude Opus 4.8 compatibility. |
+
+## v2.1.154
+
+Published: 2026-05-28.
+
+Source: upstream oh-my-customcode #1244, Codex port #1419.
+
+Note: v2.1.155 had no public release.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Opus 4.8 and the `opus48` alias were introduced | Relevant to Claude-template agent model notes only; Codex-native child agents still follow the OMX model contract. | Document as compatibility vocabulary. Do not replace Codex model routing with Claude alias behavior. |
+| Dynamic Workflows reached general availability | Conceptually overlaps with OMX workflows, but remains a Claude-native orchestration surface. | Keep OMX `$pipeline`, `$team`, and Codex subagents primary. Mention Dynamic Workflows only in Claude compatibility guidance. |
+| Lean system prompt defaults and Fast Mode override deprecation were announced | Claude compatibility sessions may see changed prompt weight and deprecation of `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` after 2026-06-01. | No template change; avoid relying on the deprecated override for new guidance. |
+
+## v2.1.153
+
+Published: 2026-05-28.
+
+Source: upstream oh-my-customcode #1243, Codex port #1418.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Statusline environment now includes `COLUMNS` and `LINES` | Claude-template statusline scripts can size output with terminal dimensions when available. | No Codex statusline change required; keep fallbacks for missing env values. |
+| Marketplace plugin sources support `skipLfs` | Helpful for Claude plugin installs that should avoid Git LFS assets. | Document as Claude marketplace compatibility only. |
+| `claude agents` autocomplete improved | Improves Claude CLI UX without changing packaged agent definitions. | No package change. |
+
+## v2.1.152
+
+Published: 2026-05-27.
+
+Source: upstream oh-my-customcode #1242, Codex port #1417.
+
+Note: v2.1.151 had no public release.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Skill frontmatter supports `disallowed-tools` | Useful Claude-template metadata for constraining tools; Codex rule surfaces still enforce `.codex/**` policy. | No package migration. Preserve explicit tool-policy rules instead of relying solely on Claude frontmatter. |
+| `/reload-skills` and `SessionStart reloadSkills` reload skill state | Helps Claude compatibility sessions pick up skill edits without restart. | No Codex runtime change; keep installed templates deterministic and test mirrored files. |
+
+## Known Platform Issues
+
+### Agent tool malformed parsing on long / special-character prompts
+
+Source: upstream oh-my-customcode #1241, Codex port #1416.
+
+| Issue | Impact on oh-my-customcodex | Workaround |
+|-------|------------------------------|------------|
+| Agent tool malformed parsing can occur when delegation prompts are very long or contain heavy special characters such as backticks, repeated colons, or shell-variable syntax. | This is a Claude Code platform serialization issue, not an oh-my-customcodex defect. Codex-native subagent dispatch is unaffected. | Keep Claude `Agent` prompts shorter, move large evidence into files, avoid dense shell quoting in delegation text, and retry with a smaller prompt when `malformed` appears. |
+
 ## v2.1.150
 
 Published: 2026-05-23.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.5",
+  "version": "0.5.6",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -41,6 +41,20 @@ Examples:
 | "CI cannot find a file because it is generated locally" | Clean checkout result proving the file is untracked or absent |
 | "A test is flaky enough to skip" | Repeated-run evidence plus a tracked fix issue; skip alone is not completion |
 
+### Variant: Parallel Read + Permanent-Change Dispatch
+
+Diagnostic reads and permanent-change dispatches are sequentially dependent. Do not batch diagnostic `Read`/log inspection with issue creation, fix delegation, workflow edits, rule edits, template edits, or release-process changes in the same parallel batch when the write depends on the diagnostic result.
+
+Parallel batches return results together, so a same-batch permanent dispatch proves the hypothesis was treated as confirmed before the evidence was read. R009 parallel execution applies only to independent work; diagnosis → permanent change is not independent.
+
+| Forbidden | Required |
+|-----------|----------|
+| File `Read` plus an issue or fix instruction based on that file in one parallel batch | Run the diagnostic read first, inspect the result, then dispatch permanent changes in a later step |
+| Log inspection in parallel with an issue stating "the cause is X" | Confirm the log evidence before creating or updating the issue |
+| Hypothesis-driven workflow/rule/template edits before the authoritative evidence returns | Treat the root cause as unverified until the evidence is available |
+
+Example: do not diagnose `triage-dispatch.yml` from memory, create an issue, and delegate a fix in the same parallel call before reading the workflow. If the read later shows a different root cause, the issue, PR, and commit trail become correction debt even when the eventual code direction is acceptable.
+
 ## Test-Skip Is Not Completion
 
 Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO may be a temporary containment step, but it never satisfies completion by itself.

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,67 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.156
+
+Published: 2026-05-29.
+
+Source: upstream oh-my-customcode #1245, Codex port #1420.
+
+Note: v2.1.155 had no public release.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Fixed Opus 4.8 thinking-block API errors | Claude compatibility sessions using the v2.1.154 Opus 4.8 surface are more stable. Codex-native model routing is unchanged. | No package change. Prefer v2.1.156 over v2.1.154 when testing Claude Opus 4.8 compatibility. |
+
+## v2.1.154
+
+Published: 2026-05-28.
+
+Source: upstream oh-my-customcode #1244, Codex port #1419.
+
+Note: v2.1.155 had no public release.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Opus 4.8 and the `opus48` alias were introduced | Relevant to Claude-template agent model notes only; Codex-native child agents still follow the OMX model contract. | Document as compatibility vocabulary. Do not replace Codex model routing with Claude alias behavior. |
+| Dynamic Workflows reached general availability | Conceptually overlaps with OMX workflows, but remains a Claude-native orchestration surface. | Keep OMX `$pipeline`, `$team`, and Codex subagents primary. Mention Dynamic Workflows only in Claude compatibility guidance. |
+| Lean system prompt defaults and Fast Mode override deprecation were announced | Claude compatibility sessions may see changed prompt weight and deprecation of `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` after 2026-06-01. | No template change; avoid relying on the deprecated override for new guidance. |
+
+## v2.1.153
+
+Published: 2026-05-28.
+
+Source: upstream oh-my-customcode #1243, Codex port #1418.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Statusline environment now includes `COLUMNS` and `LINES` | Claude-template statusline scripts can size output with terminal dimensions when available. | No Codex statusline change required; keep fallbacks for missing env values. |
+| Marketplace plugin sources support `skipLfs` | Helpful for Claude plugin installs that should avoid Git LFS assets. | Document as Claude marketplace compatibility only. |
+| `claude agents` autocomplete improved | Improves Claude CLI UX without changing packaged agent definitions. | No package change. |
+
+## v2.1.152
+
+Published: 2026-05-27.
+
+Source: upstream oh-my-customcode #1242, Codex port #1417.
+
+Note: v2.1.151 had no public release.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Skill frontmatter supports `disallowed-tools` | Useful Claude-template metadata for constraining tools; Codex rule surfaces still enforce `.codex/**` policy. | No package migration. Preserve explicit tool-policy rules instead of relying solely on Claude frontmatter. |
+| `/reload-skills` and `SessionStart reloadSkills` reload skill state | Helps Claude compatibility sessions pick up skill edits without restart. | No Codex runtime change; keep installed templates deterministic and test mirrored files. |
+
+## Known Platform Issues
+
+### Agent tool malformed parsing on long / special-character prompts
+
+Source: upstream oh-my-customcode #1241, Codex port #1416.
+
+| Issue | Impact on oh-my-customcodex | Workaround |
+|-------|------------------------------|------------|
+| Agent tool malformed parsing can occur when delegation prompts are very long or contain heavy special characters such as backticks, repeated colons, or shell-variable syntax. | This is a Claude Code platform serialization issue, not an oh-my-customcodex defect. Codex-native subagent dispatch is unaffected. | Keep Claude `Agent` prompts shorter, move large evidence into files, avoid dense shell quoting in delegation text, and retry with a smaller prompt when `malformed` appears. |
+
 ## v2.1.150
 
 Published: 2026-05-23.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.5",
+  "version": "0.5.6",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -612,7 +612,7 @@ describe('Template Validation', () => {
   });
 
   describe('Claude Code version compatibility guidance', () => {
-    it('mirrors the v2.1.139 through v2.1.150 compatibility guide into templates', async () => {
+    it('mirrors the v2.1.139 through v2.1.156 compatibility guide into templates', async () => {
       const projectRoot = resolve(import.meta.dir, '../../..');
       const guidePath = 'guides/claude-code/15-version-compatibility.md';
       const sourceGuide = await readFile(join(projectRoot, guidePath), 'utf-8');
@@ -632,6 +632,10 @@ describe('Template Validation', () => {
         'v2.1.148',
         'v2.1.149',
         'v2.1.150',
+        'v2.1.152',
+        'v2.1.153',
+        'v2.1.154',
+        'v2.1.156',
       ]) {
         expect(templateGuide).toContain(version);
       }
@@ -648,6 +652,13 @@ describe('Template Validation', () => {
       expect(templateGuide).toContain('allowAllClaudeAiMcps');
       expect(templateGuide).toContain('Internal infrastructure improvements only');
       expect(templateGuide).toContain('Do not add a dead `simplify` route');
+      expect(templateGuide).toContain('disallowed-tools');
+      expect(templateGuide).toContain('reloadSkills');
+      expect(templateGuide).toContain('COLUMNS');
+      expect(templateGuide).toContain('skipLfs');
+      expect(templateGuide).toContain('Opus 4.8');
+      expect(templateGuide).toContain('Dynamic Workflows');
+      expect(templateGuide).toContain('Agent tool malformed parsing');
     });
 
     it('mirrors statusline support for native GitHub and agent-count JSON', async () => {
@@ -742,6 +753,7 @@ describe('Template Validation', () => {
       expect(r020).toContain('Interrupt Priority Re-Ordering');
       expect(r020).toContain('Diagnostic Hypothesis Verification');
       expect(r020).toContain('Test-Skip Is Not Completion');
+      expect(r020).toContain('Parallel Read + Permanent-Change Dispatch');
 
       const r017 = await readFile(
         join(projectRoot, '.codex/rules/MUST-sync-verification.md'),

--- a/wiki/guides/claude-code.md
+++ b/wiki/guides/claude-code.md
@@ -1,7 +1,7 @@
 ---
 title: "Claude Code Guide"
 type: guide
-updated: 2026-05-24
+updated: 2026-05-29
 sources:
   - guides/claude-code/01-overview.md
   - guides/claude-code/15-version-compatibility.md
@@ -33,6 +33,47 @@ Covers Claude's advanced API features for building Claude Code-compatible applic
 ## Version Compatibility
 
 oh-my-customcodex keeps Claude compatibility guidance for installed templates while `.codex/**` and OMX remain the primary runtime surface.
+
+### v2.1.156 (2026-05-29)
+
+Source: upstream oh-my-customcode #1245, Codex port #1420.
+
+- Fixed Opus 4.8 thinking-block API errors; prefer v2.1.156 over v2.1.154 for Claude Opus 4.8 compatibility testing.
+- No Codex runtime change is required; `.codex/**` and OMX model routing remain primary.
+- v2.1.155 had no public release.
+
+### v2.1.154 (2026-05-28)
+
+Source: upstream oh-my-customcode #1244, Codex port #1419.
+
+- Opus 4.8 and the `opus48` alias are Claude-template compatibility vocabulary, not Codex model-routing changes.
+- Dynamic Workflows reached GA; keep OMX `$pipeline`, `$team`, and Codex subagents as the primary orchestration surfaces.
+- Lean system prompt defaults changed and `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` was deprecated for new guidance.
+- v2.1.155 had no public release.
+
+### v2.1.153 (2026-05-28)
+
+Source: upstream oh-my-customcode #1243, Codex port #1418.
+
+- Statusline scripts can use `COLUMNS` and `LINES` when Claude provides terminal dimensions, while preserving fallbacks.
+- Marketplace plugin source config supports `skipLfs`; document it as Claude marketplace compatibility only.
+- `claude agents` autocomplete improved without changing packaged agent definitions.
+
+### v2.1.152 (2026-05-27)
+
+Source: upstream oh-my-customcode #1242, Codex port #1417.
+
+- Skill frontmatter supports `disallowed-tools`; Codex rule surfaces still enforce `.codex/**` policy.
+- `/reload-skills` and `SessionStart reloadSkills` reload Claude skill state without changing Codex runtime behavior.
+- v2.1.151 had no public release.
+
+### Known Platform Issues: Agent tool malformed parsing
+
+Source: upstream oh-my-customcode #1241, Codex port #1416.
+
+- Long or special-character-heavy Claude `Agent` delegation prompts can intermittently report `malformed` because of platform serialization.
+- This is not an oh-my-customcodex defect and does not affect Codex-native subagent dispatch.
+- Workaround: keep delegation prompts shorter, move large evidence into files, avoid dense shell quoting/backticks/repeated colons in the prompt, and retry with a smaller prompt.
 
 ### v2.1.150 (2026-05-23)
 

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -1,7 +1,7 @@
 ---
 title: "R020: Completion Verification Rules"
 type: rule
-updated: 2026-05-24
+updated: 2026-05-29
 sources:
   - .codex/rules/MUST-completion-verification.md
 related:
@@ -67,6 +67,12 @@ False completion declarations erode trust and cause downstream failures. "Ran th
 When a diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until directly verified. Record the symptom, proposed root cause, direct evidence, and at least one plausible alternative before merging the permanent change.
 
 This specifically guards release workflows from repeating the pattern where an initial `E403` or clean-checkout failure is attributed to the wrong root cause without registry, CI, or source evidence.
+
+### Variant: Parallel Read + Permanent-Change Dispatch
+
+Do not batch diagnostic `Read` or log inspection with permanent issue/fix dispatch in the same parallel batch when the write depends on the diagnostic result. A file read, CI log check, or source inspection must complete before creating issues, delegating fixes, or editing workflows/rules/templates based on that evidence.
+
+R009 parallel execution applies only to independent tasks. Diagnostic evidence and the permanent change that depends on it are sequential, not independent. This prevents stale or speculative issue, PR, and commit records when the later read reveals a different root cause.
 
 ## Test-Skip Is Not Completion
 


### PR DESCRIPTION
## Summary
- Port the upstream v0.156.x Claude compatibility release unit into Codex-native source guides, install templates, wiki guidance, and generated lock metadata.
- Add the R020 Parallel Read + Permanent-Change Dispatch safeguard across rule/template/wiki surfaces.
- Replace the stale external Airflow triage workflow with an in-repo GitHub issue acknowledgment workflow.
- Bump release metadata to v0.5.6 and document the release unit in the changelog.

## Validation
- `bun install --frozen-lockfile` (passed; worktree hook setup warning is non-fatal because linked worktrees use a `.git` file)
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test` — 1833 pass / 0 fail
- `bun test tests/unit/core/template-validation.test.ts` — 48 pass / 0 fail / 532 expects
- `bash .github/scripts/verify-version-sync.sh`
- `bash .github/scripts/verify-template-sync.sh`
- `bash .github/scripts/verify-wiki-sync.sh`
- `git diff --check`

## Auto-dev scope
Closes #1416
Closes #1417
Closes #1418
Closes #1419
Closes #1420
Closes #1421
Closes #1422
Closes #1423

Remaining open issues #1402-#1415 are intentionally left for subsequent auto-dev release units or explicit skip decisions.
