### PR TITLE
feat: close remaining release-tracking gap with scholastic reviewer

### DIFF
--- a/.codex/agents/scholastic.md
+++ b/.codex/agents/scholastic.md
@@ -1,0 +1,60 @@
+---
+name: scholastic
+description: Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals
+model: sonnet
+domain: universal
+memory: project
+effort: high
+limitations:
+  - "read-only reviewer; does not implement code changes"
+  - "must distinguish ontology failures from empirical failures"
+tools:
+  - Read
+  - Grep
+  - Glob
+permissionMode: bypassPermissions
+---
+
+You are a reasoning assistant grounded in structured inquiry and Greek–scholastic traditions.
+
+## Capabilities
+
+- Define key terms in scholastic style to remove ambiguity
+- Flag inconsistent term usage and state a normalized definition
+- Validate ontology before logic or implementation details
+- Identify category mistakes and conflicts with concrete examples
+- Surface hidden assumptions, inconsistencies, and salvage-by-trivialization
+- Separate modalities in the text: kinds of possibility and necessity
+- Present structured arguments as premises → steps → conclusion
+- Propose minimal repairs when the ontology fails
+
+## Review Protocol
+
+1. **Define terms** — normalize key terms before judging the claim.
+2. **Validate ontology** — test whether the framework collapses the subject through a category mistake or conflict with real examples.
+3. **Classify failure** — when the ontology fails, label it as categorical or empirical and provide a concrete counterexample.
+4. **Analyze logic** — identify hidden assumptions, contradictions, and tautological rescues.
+5. **Separate modalities** — distinguish possibility, necessity, actuality, obligation, and capability claims.
+6. **Conclude structurally** — state premises, reasoning steps, and conclusion; distinguish hypotheses from established claims.
+7. **Repair minimally** — restate the problem under a sound ontology and re-run the argument when feasible.
+
+## Output Shape
+
+```markdown
+## Term Definitions
+- Term: normalized meaning and ambiguity notes
+
+## Ontology Check
+- Verdict: sound | categorical failure | empirical failure
+- Evidence: concrete example or counterexample
+
+## Argument Review
+- Premises
+- Reasoning steps
+- Hidden assumptions
+- Modality distinctions
+
+## Minimal Repair
+- Smallest ontology-safe change
+- Re-run conclusion if applicable
+```

--- a/.codex/ontology/agents.yaml
+++ b/.codex/ontology/agents.yaml
@@ -35,6 +35,9 @@ classes:
   ManagerAgent:
     agents: [mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible]
     description: "System management agents"
+  CoordinationAgent:
+    agents: [scholastic]
+    description: "Reasoning, critique, and coordination specialists"
   SystemAgent:
     agents: [sys-memory-keeper, sys-naggy, tracker-checkpoint]
     description: "System utility agents"
@@ -556,3 +559,15 @@ agents:
     summary: "Pipeline checkpoint tracker for resumable DAG and pipeline state"
     keywords: [pipeline, checkpoint, resume, dag, state, tracker]
     file_patterns: ["/tmp/.codex-pipeline-*.json", "/tmp/.codex-dag-*.json"]
+
+  scholastic:
+    class: CoordinationAgent
+    description: "Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals."
+    model: sonnet
+    memory: project
+    effort: high
+    skills: []
+    tools: [Read, Grep, Glob]
+    summary: "Scholastic reviewer for ontology checks, modality separation, and minimal argument repair"
+    keywords: [scholastic, ontology, category-mistake, modality, assumptions, critique, reasoning]
+    file_patterns: ["*.md", "*.txt"]

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.6",
-  "generatedAt": "2026-05-29T11:28:58.407Z",
-  "templateVersion": "0.5.6",
+  "generatorVersion": "0.5.7",
+  "generatedAt": "2026-05-29T11:56:17.449Z",
+  "templateVersion": "0.5.7",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -302,6 +302,11 @@
     ".codex/agents/qa-writer.md": {
       "templateHash": "41114d5cfa0dff10b0bac2aa48d8428f6390e0ec882d4ee347ab4ac0eea7d17e",
       "size": 908,
+      "component": "agents"
+    },
+    ".codex/agents/scholastic.md": {
+      "templateHash": "48b49c569a41877492a75d078b3b9d394787981b5ce611a9aab6599777ccfbde",
+      "size": 2291,
       "component": "agents"
     },
     ".codex/agents/db-supabase-expert.md": {
@@ -620,8 +625,8 @@
       "component": "contexts"
     },
     ".codex/ontology/agents.yaml": {
-      "templateHash": "764531b3847cdf4bcd23d475c29532217da127734504809a2db7506f57c30c16",
-      "size": 29233,
+      "templateHash": "5dacc675be95b5e629f142f94b0d1d53ec8357576afe522b734ebbaeab090b8e",
+      "size": 29901,
       "component": "ontology"
     },
     ".codex/ontology/skills.yaml": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## 1. System Overview
 
-oh-my-customcodex is the Codex + OMX native child package of oh-my-customcode. It preserves the parent harness model, workflow intent, and package structure while retargeting the execution surface from Claude Code native to GPT Codex + OMX. The current shipped template surface includes 49 pre-built subagents, 118 skills, 22 governing rules, and a comprehensive hook system. The core philosophy remains: **"No expert? CREATE one, connect knowledge, and USE it."**
+oh-my-customcodex is the Codex + OMX native child package of oh-my-customcode. It preserves the parent harness model, workflow intent, and package structure while retargeting the execution surface from Claude Code native to GPT Codex + OMX. The current shipped template surface includes 50 pre-built subagents, 118 skills, 22 governing rules, and a comprehensive hook system. The core philosophy remains: **"No expert? CREATE one, connect knowledge, and USE it."**
 
 The harness operates on three engineering pillars — **Context Engineering** (what goes into the prompt), **Architectural Constraints** (rules that shape agent behavior), and **Entropy Management** (hooks, verification, and observability that keep the system coherent at scale).
 
@@ -68,7 +68,7 @@ The takeover pattern — reverse-compiling an existing codebase into structured 
 | R020 | MUST | Completion Verification | Task-type-specific verification before declaring [Done] |
 | R021 | MUST | Enforcement Policy | Advisory-first enforcement model, promotion criteria |
 
-### 3.2 Agent Taxonomy (49 agents)
+### 3.2 Agent Taxonomy (50 agents)
 
 | Category | Count | Agents |
 |----------|-------|--------|
@@ -85,7 +85,8 @@ The takeover pattern — reverse-compiling an existing codebase into structured 
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli-expert, wiki-curator |
-| **Total** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **Total** | **50** | |
 
 Each agent is defined in the source tree (`.codex/agents/{name}.md`) and compiled into the installed Codex runtime surface. YAML frontmatter specifies model, tools, skills, memory scope, and optional features (soul identity, escalation policy, isolation mode).
 

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -4,7 +4,7 @@
 
 ## 1. 시스템 개요
 
-oh-my-customcodex는 oh-my-customcode의 child package로, parent 하네스의 구조와 워크플로를 유지한 채 실행 표면만 GPT Codex + OMX로 옮긴 포트입니다. 현재 shipped template surface는 49개의 서브에이전트, 118개의 스킬, 22개의 거버넌스 규칙, 훅 시스템으로 구성됩니다. 핵심 철학은 그대로 유지됩니다: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."**
+oh-my-customcodex는 oh-my-customcode의 child package로, parent 하네스의 구조와 워크플로를 유지한 채 실행 표면만 GPT Codex + OMX로 옮긴 포트입니다. 현재 shipped template surface는 50개의 서브에이전트, 118개의 스킬, 22개의 거버넌스 규칙, 훅 시스템으로 구성됩니다. 핵심 철학은 그대로 유지됩니다: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."**
 
 현재 패키지 식별자: npm `oh-my-customcodex`, GitHub Packages `@baekenough/oh-my-customcodex`, CLI `omcodex`
 
@@ -58,7 +58,7 @@ oh-my-customcode parent가 정의한 컴파일 메타포를 oh-my-customcodex도
 | R020 | MUST | 완료 검증 | 작업 완료 선언 전 task-type-specific 검증 |
 | R021 | MUST | Enforcement Policy | Advisory-first 시행 모델, 강화 승격 기준 |
 
-### 3.2 에이전트 분류 (49개)
+### 3.2 에이전트 분류 (50개)
 
 | 카테고리 | 수량 | 에이전트 |
 |----------|------|----------|
@@ -75,7 +75,8 @@ oh-my-customcode parent가 정의한 컴파일 메타포를 oh-my-customcodex도
 | 매니저 | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | 시스템 | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | 보조 | 2 | slack-cli-expert, wiki-curator |
-| **합계** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **합계** | **50** | |
 
 ### 3.3 스킬 카탈로그 (118개)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-05-29
+
+### Added
+- Add the Scholastic ontology reviewer agent from Yeachan-Heo/oh-my-codex v0.18.3 for #1410, mirrored into source/templates, ontology metadata, reference docs, wiki docs, and template validation coverage.
+- Record v0.5.7 auto-dev triage dispositions for #1402-#1415, explicitly deferring upstream runtime features that lack a repo-owned implementation surface.
+
+### Changed
+- Bump release metadata from 0.5.6 to 0.5.7 and refresh packaged agent counts for the 50-agent surface.
+
 ## [0.5.6] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-49 agents. 123 skills. 22 rules. One command.
+50 agents. 123 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcustomcodex init
@@ -112,7 +112,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-### Agents (49)
+### Agents (50)
 
 | Category | Count | Agents |
 |----------|-------|--------|
@@ -129,6 +129,7 @@ Agent(arch-documenter):haiku      ┘
 | Managers | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli, wiki-curator |
+| Review/Reasoning | 1 | scholastic |
 
 Each agent declares its tools, model, memory scope, and limitations in YAML frontmatter. Tool budgets are enforced per agent type for accuracy.
 
@@ -279,7 +280,7 @@ omcustomcodex serve-stop            # Stop Web UI
 your-project/
 ├── AGENTS.md                   # Entry point
 ├── .codex/
-│   ├── agents/                 # 49 agent definitions
+│   ├── agents/                 # 50 agent definitions
 │   ├── rules/                  # 22 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-49개 에이전트. 123개 스킬. 22개 규칙. 명령어 하나.
+50개 에이전트. 123개 스킬. 22개 규칙. 명령어 하나.
 
 > **v0.1.7** — token-efficiency-audit 스킬, 토큰 효율 3계층 가이드, cc-token-saver/CLI flags cross-reference 추가
 
@@ -127,7 +127,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 에이전트 (49개)
+## 에이전트 (50개)
 
 | 카테고리 | 수 | 에이전트 |
 |---------|-----|---------|
@@ -144,6 +144,7 @@ Agent(arch-documenter):haiku      ┘
 | 매니저 | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | 시스템 | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | 보조 | 2 | slack-cli, wiki-curator |
+| 추론 검토 | 1 | scholastic |
 
 각 에이전트는 YAML 프론트매터에 도구, 모델, 메모리 스코프, 한계를 선언합니다. 에이전트 유형별 도구 예산이 정확도를 위해 강제됩니다.
 
@@ -291,7 +292,7 @@ omcustomcodex serve-stop            # Web UI 중지
 your-project/
 ├── AGENTS.md                   # 진입점
 ├── .codex/
-│   ├── agents/                 # 49개 에이전트 정의
+│   ├── agents/                 # 50개 에이전트 정의
 │   ├── rules/                  # 22개 거버넌스 규칙 (R000-R022)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -17,6 +17,7 @@ Reference snapshot for the oh-my-customcodex agent catalog. The live shipped sur
 | SW Architect | Architecture and documentation | Architecture and documentation |
 | Infra Engineer | Infrastructure and DevOps | Infrastructure and DevOps |
 | QA Team | Quality assurance roles | Quality assurance |
+| Review/Reasoning | Ontology-first critique | Reasoning validation and argument review |
 
 ## Orchestrator Agents
 
@@ -333,6 +334,19 @@ System agents provide core functionality.
 - Test automation
 - Test frameworks
 - Bug reporting
+
+
+## Review / Reasoning Agents
+
+### scholastic
+
+**Role**: Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals.
+
+- Defines terms before evaluating an argument
+- Checks whether a claim fails categorically or empirically
+- Separates possibility, necessity, actuality, obligation, and capability claims
+- Produces structured premise → reasoning → conclusion reviews
+- Proposes the smallest ontology-safe repair when a claim fails
 
 ## Tutor Agents
 

--- a/docs/superpowers/plans/2026-05-29-v0.5.7-auto-dev.md
+++ b/docs/superpowers/plans/2026-05-29-v0.5.7-auto-dev.md
@@ -1,0 +1,35 @@
+# v0.5.7 Auto-Dev Release Triage
+
+Date: 2026-05-29
+Branch: `release/v0.5.7-auto-dev`
+Scope: remaining open upstream release tracking issues #1402-#1415.
+
+## Implemented
+
+- **#1410 — Yeachan-Heo/oh-my-codex v0.18.3**: implemented the portable Scholastic reviewer/catalog slice from upstream v0.18.3.
+  - Added `scholastic` as a first-class read-only ontology reviewer under `.codex/agents/` and `templates/.claude/agents/`.
+  - Registered `scholastic` in the local ontology catalog and documented it in `docs/reference/agents.md`, README/template counts, and wiki pages.
+  - Added regression coverage so template validation fails if the Scholastic source/template mirror or reference docs drift.
+
+## Skipped / Deferred With Repo-Grounded Rationale
+
+These issues are intentionally recorded rather than implemented as fake runtime features. This repo is the `oh-my-customcodex` packaging/docs/template surface; upstream runtime or product features should only be ported when this codebase has a matching implementation surface.
+
+- **#1402 — openai/codex rust-v0.131.0**: deferred. The issue tracks upstream Codex TUI/session controls, service-tier display, permissions, workspace roots, and markdown table behavior. Those are Codex runtime features, not implemented by this package's templates or CLI list/init/update surfaces.
+- **#1403 — openai/codex rust-v0.132.0**: deferred. The release focuses on Python SDK authentication and turn APIs. This repo does not vendor or wrap the upstream Python SDK authentication surface.
+- **#1404 — openai/codex rust-v0.133.0**: deferred. Goals and `codex remote-control` are upstream Codex runtime features. Local guidance already reserves native `/goal` for Codex and uses `/omcustomcodex:goal` for this harness; adding runtime storage here would duplicate Codex behavior.
+- **#1405 — openai/codex rust-v0.134.0**: deferred. Local conversation-history search and `--profile` primary selector behavior belong to Codex CLI/TUI. This package should not fake those capabilities in docs or templates.
+- **#1406 — openai/codex rust-v0.135.0**: deferred. `codex doctor`, `/status`, and remote connection details are upstream diagnostics. The local `omcustomcodex doctor` surface is separate and should only change for verified local checks.
+- **#1407 — Yeachan-Heo/oh-my-codex v0.18.0**: deferred. The release centers on OMX API gateway, SparkShell/operator runtime, notify/Stop-hook/tmux/HUD/Windows MCP fixes. This branch is not adding new runtime daemons or API gateway behavior without a local implementation contract.
+- **#1408 — Yeachan-Heo/oh-my-codex v0.18.1**: deferred. The issue is a release-readiness patch for upstream 0.18 runtime work. No standalone portable docs/catalog item was identified for this release unit.
+- **#1409 — Yeachan-Heo/oh-my-codex v0.18.2**: deferred. Prometheus Strict planner surfaces are already represented in this session's runtime guidance/model table, but this codebase has no matching source/template agent files in the current branch; adding stubs would be misleading.
+- **#1411 — Yeachan-Heo/oh-my-codex v0.18.4**: deferred. Ultragoal recovery, `omx explore` deprecation, Team/HUD, and hook safety changes are upstream runtime behavior. Local AGENTS/runtime guidance already marks `omx explore` deprecated; no fake runtime feature is added.
+- **#1412 — Yeachan-Heo/oh-my-codex v0.18.5**: deferred. Durable Ultragoal/HUD completion visibility is upstream runtime state handling, outside this package's shipped template docs for this release unit.
+- **#1413 — Yeachan-Heo/oh-my-codex v0.18.6**: deferred. HUD rendering compaction and Ultragoal context display are runtime UI concerns; no local source/template file owns that behavior.
+- **#1414 — baekenough/oh-my-customcode v0.139.0**: deferred. Phase α CRG MCP / Compound AI Workflow / R023 belongs to the parent `oh-my-customcode` release line. Porting requires separate scoped design and source mapping before implementation.
+- **#1415 — baekenough/oh-my-customcode v0.142.0**: deferred. Parent release notes are auto-generated and lack a concrete portable change target in this repo. Defer until a source-mapped requirement exists.
+
+## Release Metadata
+
+- Version bumped from `0.5.6` to `0.5.7` in `package.json`, `templates/manifest.json`, and regenerated `.omcodex.lock.json`.
+- Manifest agent count increased from 49 to 50.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.6",
+  "version": "0.5.7",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -121,8 +121,23 @@ function parseYamlMetadata(content: string): Record<string, string> {
  * Official format: {root}/agents/{prefix}-{name}.md
  * Prefixes: lang-, be-, fe-, tool-, db-, arch-, infra-, qa-, mgr-, sys-, tutor-
  */
+function translateListMessage(
+  key: string,
+  options: Record<string, string | number>,
+  fallback: string
+): string {
+  const translated = i18n.t(key, options);
+  return translated && translated !== key ? translated : fallback;
+}
+
 function extractAgentTypeFromFilename(filename: string): string {
   const name = basename(filename, '.md');
+  const exactNameMap: Record<string, string> = {
+    scholastic: 'coordination',
+  };
+
+  if (exactNameMap[name]) return exactNameMap[name];
+
   const prefixMap: Record<string, string> = {
     lang: 'language',
     be: 'backend',
@@ -543,13 +558,19 @@ export async function getRules(
  */
 export function formatAsTable(components: ComponentInfo[], type: ListType): void {
   if (components.length === 0) {
-    console.log(i18n.t('cli.list.empty', { type }));
+    console.log(translateListMessage('cli.list.empty', { type }, `No ${type} found.`));
     return;
   }
 
   // Print header
   console.log('');
-  console.log(i18n.t('cli.list.header', { type, count: components.length }));
+  console.log(
+    translateListMessage(
+      'cli.list.header',
+      { type, count: components.length },
+      `${type} (${components.length} installed)`
+    )
+  );
   console.log('\u2500'.repeat(80));
 
   // Calculate column widths
@@ -574,7 +595,13 @@ export function formatAsTable(components: ComponentInfo[], type: ListType): void
   }
 
   console.log('\u2500'.repeat(80));
-  console.log(i18n.t('cli.list.total', { count: components.length, type }));
+  console.log(
+    translateListMessage(
+      'cli.list.total',
+      { count: components.length, type },
+      `Total: ${components.length} ${type}`
+    )
+  );
   console.log('');
 }
 
@@ -585,7 +612,7 @@ export function formatAsTable(components: ComponentInfo[], type: ListType): void
  */
 export function formatAsSimple(components: ComponentInfo[], type: ListType): void {
   if (components.length === 0) {
-    console.log(i18n.t('cli.list.empty', { type }));
+    console.log(translateListMessage('cli.list.empty', { type }, `No ${type} found.`));
     return;
   }
 

--- a/templates/.claude/agents/scholastic.md
+++ b/templates/.claude/agents/scholastic.md
@@ -1,0 +1,60 @@
+---
+name: scholastic
+description: Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals
+model: sonnet
+domain: universal
+memory: project
+effort: high
+limitations:
+  - "read-only reviewer; does not implement code changes"
+  - "must distinguish ontology failures from empirical failures"
+tools:
+  - Read
+  - Grep
+  - Glob
+permissionMode: bypassPermissions
+---
+
+You are a reasoning assistant grounded in structured inquiry and Greek–scholastic traditions.
+
+## Capabilities
+
+- Define key terms in scholastic style to remove ambiguity
+- Flag inconsistent term usage and state a normalized definition
+- Validate ontology before logic or implementation details
+- Identify category mistakes and conflicts with concrete examples
+- Surface hidden assumptions, inconsistencies, and salvage-by-trivialization
+- Separate modalities in the text: kinds of possibility and necessity
+- Present structured arguments as premises → steps → conclusion
+- Propose minimal repairs when the ontology fails
+
+## Review Protocol
+
+1. **Define terms** — normalize key terms before judging the claim.
+2. **Validate ontology** — test whether the framework collapses the subject through a category mistake or conflict with real examples.
+3. **Classify failure** — when the ontology fails, label it as categorical or empirical and provide a concrete counterexample.
+4. **Analyze logic** — identify hidden assumptions, contradictions, and tautological rescues.
+5. **Separate modalities** — distinguish possibility, necessity, actuality, obligation, and capability claims.
+6. **Conclude structurally** — state premises, reasoning steps, and conclusion; distinguish hypotheses from established claims.
+7. **Repair minimally** — restate the problem under a sound ontology and re-run the argument when feasible.
+
+## Output Shape
+
+```markdown
+## Term Definitions
+- Term: normalized meaning and ambiguity notes
+
+## Ontology Check
+- Verdict: sound | categorical failure | empirical failure
+- Evidence: concrete example or counterexample
+
+## Argument Review
+- Premises
+- Reasoning steps
+- Hidden assumptions
+- Modality distinctions
+
+## Minimal Repair
+- Smallest ontology-safe change
+- Re-run conclusion if applicable
+```

--- a/templates/.claude/ontology/agents.yaml
+++ b/templates/.claude/ontology/agents.yaml
@@ -35,6 +35,9 @@ classes:
   ManagerAgent:
     agents: [mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible]
     description: "System management agents"
+  CoordinationAgent:
+    agents: [scholastic]
+    description: "Reasoning, critique, and coordination specialists"
   SystemAgent:
     agents: [sys-memory-keeper, sys-naggy]
     description: "System utility agents"
@@ -544,3 +547,15 @@ agents:
     summary: "Task tracker with proactive reminders for TODO management"
     keywords: [todo, tasks, reminders, tracking, deadlines, project-momentum]
     file_patterns: ["TODO.md", "*.todo"]
+
+  scholastic:
+    class: CoordinationAgent
+    description: "Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals."
+    model: sonnet
+    memory: project
+    effort: high
+    skills: []
+    tools: [Read, Grep, Glob]
+    summary: "Scholastic reviewer for ontology checks, modality separation, and minimal argument repair"
+    keywords: [scholastic, ontology, category-mistake, modality, assumptions, critique, reasoning]
+    file_patterns: ["*.md", "*.txt"]

--- a/templates/AGENTS.md.en
+++ b/templates/AGENTS.md.en
@@ -129,7 +129,7 @@ NO EXCEPTIONS. NO EXCUSES.
 project/
 +-- AGENTS.md                    # Entry point
 +-- .codex/
-|   +-- agents/                  # Subagent definitions (49 files)
+|   +-- agents/                  # Subagent definitions (50 files)
 |   +-- rules/                   # Global rules (R000-R020)
 |   +-- hooks/                   # Hook scripts (security, validation, HUD)
 |   +-- contexts/                # Context files (ecomode)
@@ -176,7 +176,8 @@ This is the core oh-my-customcodex philosophy: **"No expert? CREATE one, connect
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli-expert, wiki-curator |
-| **Total** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **Total** | **50** | |
 
 ## Agent Teams (MUST when enabled)
 

--- a/templates/AGENTS.md.ko
+++ b/templates/AGENTS.md.ko
@@ -129,7 +129,7 @@ oh-my-customcodex로 구동됩니다.
 project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
-|   +-- agents/                  # 서브에이전트 정의 (49 파일)
+|   +-- agents/                  # 서브에이전트 정의 (50 파일)
 |   +-- rules/                   # 전역 규칙 (R000-R020)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
@@ -176,7 +176,8 @@ project/
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli-expert, wiki-curator |
-| **총계** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **총계** | **50** | |
 
 ## Agent Teams (MUST when enabled)
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -114,7 +114,7 @@ oh-my-customcodex로 구동됩니다.
 project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
-|   +-- agents/                  # 서브에이전트 정의 (49 파일)
+|   +-- agents/                  # 서브에이전트 정의 (50 파일)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
@@ -176,7 +176,8 @@ oh-my-customcodex는 소프트웨어 컴파일과 동일한 구조를 따릅니�
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli-expert, wiki-curator |
-| **총계** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **총계** | **50** | |
 
 ## Agent Teams (MUST when enabled)
 

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -132,7 +132,7 @@ NO EXCEPTIONS. NO EXCUSES.
 project/
 +-- AGENTS.md                    # Entry point
 +-- .codex/
-|   +-- agents/                  # Subagent definitions (49 files)
+|   +-- agents/                  # Subagent definitions (50 files)
 |   +-- skills/                  # Skills (123 directories)
 |   +-- rules/                   # Global rules (22 files)
 |   +-- hooks/                   # Hook scripts (security, validation, HUD)
@@ -178,7 +178,8 @@ This is the core oh-my-customcodex philosophy: **"No expert? CREATE one, connect
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli-expert, wiki-curator |
-| **Total** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **Total** | **50** | |
 
 ## Agent Teams (MUST when enabled)
 

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -132,7 +132,7 @@ oh-my-customcodex로 구동됩니다.
 project/
 +-- AGENTS.md                    # 진입점
 +-- .codex/
-|   +-- agents/                  # 서브에이전트 정의 (49 파일)
+|   +-- agents/                  # 서브에이전트 정의 (50 파일)
 |   +-- skills/                  # 스킬 (123 디렉토리)
 |   +-- rules/                   # 전역 규칙 (22 파일)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
@@ -178,7 +178,8 @@ project/
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 3 | sys-memory-keeper, sys-naggy, tracker-checkpoint |
 | Auxiliary | 2 | slack-cli-expert, wiki-curator |
-| **총계** | **49** | |
+| Review/Reasoning | 1 | scholastic |
+| **총계** | **50** | |
 
 ## Agent Teams (MUST when enabled)
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -45,7 +45,7 @@ templates/
 +-- manifest.json                     # packaged component metadata
 +-- workflows/                        # project-level pipeline definitions
 +-- .claude/
-|   +-- agents/                       # agent definitions (49 files)
+|   +-- agents/                       # agent definitions (50 files)
 |   +-- skills/                       # skill modules (123 SKILL.md files)
 |   +-- rules/                        # global rules (22 files)
 |   +-- hooks/                        # hook registry and scripts (40 scripts)
@@ -59,7 +59,7 @@ templates/
 
 The counts below should stay aligned with `templates/manifest.json`, README component headings, and CI template validation.
 
-### Agents (49)
+### Agents (50)
 
 `templates/.claude/agents/*.md`
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.6",
+  "version": "0.5.7",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
@@ -17,7 +17,7 @@
       "name": "agents",
       "path": ".codex/agents",
       "description": "AI agent definitions (flat .md files with prefixes)",
-      "files": 49
+      "files": 50
     },
     {
       "name": "skills",

--- a/tests/unit/cli/list.test.ts
+++ b/tests/unit/cli/list.test.ts
@@ -102,6 +102,18 @@ describe('list command', () => {
       expect(agents[0].type).toBe('backend');
     });
 
+    it('should classify exact-name coordination reviewers', async () => {
+      const agentsDir = join(tempDir, '.codex', 'agents');
+      await mkdir(agentsDir, { recursive: true });
+      await writeFile(join(agentsDir, 'scholastic.md'), '# Scholastic Reviewer');
+
+      const agents = await getAgents(tempDir);
+
+      expect(agents).toHaveLength(1);
+      expect(agents[0].name).toBe('scholastic');
+      expect(agents[0].type).toBe('coordination');
+    });
+
     it('should extract description from blockquote in markdown', async () => {
       const agentsDir = join(tempDir, '.codex', 'agents');
       await mkdir(agentsDir, { recursive: true });

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -444,6 +444,21 @@ describe('Template Validation', () => {
   });
 
   describe('Agent frontmatter', () => {
+    it('packages Scholastic as a mirrored ontology reviewer agent', async () => {
+      const projectRoot = resolve(import.meta.dir, '../../..');
+      const agentPath = '.codex/agents/scholastic.md';
+      const templateAgentPath = '.claude/agents/scholastic.md';
+      const sourceAgent = await readFile(join(projectRoot, agentPath), 'utf-8');
+      const templateAgent = await readFile(join(TEMPLATES_DIR, templateAgentPath), 'utf-8');
+      const reference = await readFile(join(projectRoot, 'docs/reference/agents.md'), 'utf-8');
+
+      expect(templateAgent).toBe(sourceAgent);
+      expect(sourceAgent).toContain('name: scholastic');
+      expect(sourceAgent).toContain('Ontology-first reasoning reviewer');
+      expect(reference).toContain('### scholastic');
+      expect(reference).toContain('category mistakes');
+    });
+
     it('every agent .md file should have valid YAML frontmatter', async () => {
       const agentsDir = join(TEMPLATES_DIR, '.claude/agents');
       const agentFiles = (await readdir(agentsDir, { withFileTypes: true }))

--- a/wiki/Agents.md
+++ b/wiki/Agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-oh-my-customcodex includes **33 specialized agents** organized by category.
+oh-my-customcodex includes **50 specialized agents** organized by category.
 
 | Category | Count | Agents |
 |----------|-------|--------|
@@ -14,6 +14,7 @@ oh-my-customcodex includes **33 specialized agents** organized by category.
 | **Architecture** | 2 | arch-documenter, arch-speckit-agent |
 | **Infrastructure** | 2 | infra-docker-expert, infra-aws-expert |
 | **QA** | 3 | qa-planner, qa-writer, qa-engineer |
+| **Review/Reasoning** | 1 | scholastic |
 
 ---
 

--- a/wiki/agents/scholastic.md
+++ b/wiki/agents/scholastic.md
@@ -1,0 +1,41 @@
+---
+title: scholastic
+type: agent
+updated: 2026-05-29
+sources:
+  - .codex/agents/scholastic.md
+related:
+  - [[wiki/architecture/agent-taxonomy]]
+  - [[wiki/agents/arch-speckit-agent]]
+  - [[wiki/agents/qa-planner]]
+---
+
+# scholastic
+
+Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals.
+
+## Overview
+
+`scholastic` reviews arguments before implementation or planning decisions harden. It defines key terms, checks whether a claim collapses through a category mistake, separates categorical failures from empirical failures, and only then evaluates logic. It is intentionally read-only: the agent should diagnose reasoning quality, provide concrete counterexamples, and propose the smallest ontology-safe repair rather than rewriting code or inventing runtime features.
+
+## Key Details
+
+- **Model**: sonnet
+- **Domain**: universal
+- **Tools**: Read, Grep, Glob
+- **Memory**: project
+- **Effort**: high
+- **Limitations**: read-only reviewer; must distinguish ontology failures from empirical failures
+
+## Review Pattern
+
+1. Define key terms and normalize ambiguous usage.
+2. Validate ontology against concrete examples.
+3. Label failures as categorical or empirical.
+4. Surface hidden assumptions and modality shifts.
+5. Present premises, reasoning steps, and conclusion.
+6. Propose the minimal safe repair when the ontology fails.
+
+## Sources
+
+- `.codex/agents/scholastic.md` — agent definition

--- a/wiki/architecture/agent-taxonomy.md
+++ b/wiki/architecture/agent-taxonomy.md
@@ -14,7 +14,7 @@ related:
 
 # Agent Taxonomy
 
-49 agents are organized into 13 functional categories. Each agent is a specialist "build artifact" that composes skills into a focused domain expert with a specific model, toolset, and memory scope.
+50 agents are organized into 14 functional categories. Each agent is a specialist "build artifact" that composes skills into a focused domain expert with a specific model, toolset, and memory scope.
 
 ## Overview
 

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-05-29"
-  total_pages: 258
+  total_pages: 259
   total_sources: 247
 
 pages:
@@ -57,7 +57,7 @@ pages:
   architecture:
     - file: architecture/agent-taxonomy.md
       title: "Agent Taxonomy"
-      summary: "49 agents are organized into 13 functional categories. Each agent is a specialist"
+      summary: "50 agents are organized into 14 functional categories. Each agent is a specialist"
     - file: architecture/orchestration.md
       title: "Orchestration Model"
       summary: "The main Claude Code conversation is the sole orchestrator. It never writes files"
@@ -195,6 +195,9 @@ pages:
     - file: agents/sec-codeql-expert.md
       title: "sec-codeql-expert"
       summary: "Security-focused code analyst using CodeQL for vulnerability detection, call graph"
+    - file: agents/scholastic.md
+      title: "scholastic"
+      summary: "Ontology-first reasoning reviewer for category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal repairs"
     - file: agents/slack-cli-expert.md
       title: "slack-cli-expert"
       summary: "Expert Slack CLI developer for building, deploying, and managing Slack apps"


### PR DESCRIPTION
## Summary
- Add the portable Scholastic ontology reviewer from the v0.18.3 upstream release slice, mirrored across source agents, install templates, ontology metadata, reference docs, wiki docs, and list classification.
- Record repo-grounded skip/defer decisions for remaining release-tracking issues #1402-#1409 and #1411-#1415 instead of creating unsupported runtime stubs.
- Bump package/template metadata to v0.5.7 and regenerate `.omcodex.lock.json` for the 50-agent packaged surface.

## Validation
- `bun test tests/unit/cli/list.test.ts tests/unit/core/template-validation.test.ts` — 138 pass / 0 fail / 777 expects
- `bun test` — 1835 pass / 0 fail / 5117 expects
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bash .github/scripts/verify-version-sync.sh`
- `bash .github/scripts/verify-template-sync.sh`
- `bash .github/scripts/verify-wiki-sync.sh`
- `git diff --check`

## Auto-dev scope
Implemented:
- #1410

Skipped/deferred with repo-grounded rationale in `docs/superpowers/plans/2026-05-29-v0.5.7-auto-dev.md`:
- #1402 #1403 #1404 #1405 #1406 #1407 #1408 #1409 #1411 #1412 #1413 #1414 #1415

Closes #1402
Closes #1403
Closes #1404
Closes #1405
Closes #1406
Closes #1407
Closes #1408
Closes #1409
Closes #1410
Closes #1411
Closes #1412
Closes #1413
Closes #1414
Closes #1415
