### PR TITLE
Release v0.5.8: retire unsupported memory backend

### DIFF
--- a/.codex/agents/arch-speckit-agent.md
+++ b/.codex/agents/arch-speckit-agent.md
@@ -60,7 +60,7 @@ When writing acceptance criteria, use the EARS (Easy Approach to Requirements Sy
 | Ubiquitous | The `<system>` shall `<action>` | The validator shall reject invalid frontmatter |
 | Event-driven | When `<event>`, the `<system>` shall `<action>` | When a new agent is created, the routing skill shall update its pattern table |
 | State-driven | While `<state>`, the `<system>` shall `<action>` | While ecomode is active, agents shall use concise output format |
-| Optional | Where `<condition>`, the `<system>` shall `<action>` | Where the user has MCP configured, the orchestrator shall attempt claude-mem save |
+| Optional | Where `<condition>`, the `<system>` shall `<action>` | Where the user has an approved memory MCP configured, the orchestrator shall attempt searchable memory save |
 | Complex | When `<event>` while `<state>` where `<condition>`, the `<system>` shall `<action>`, resulting in `<result>` | When session ends while Agent Teams is active where tasks remain incomplete, the orchestrator shall log incomplete tasks, resulting in a task summary |
 
 **Usage**: Apply EARS format in spec output's `invariants` and `acceptance_criteria` sections. This ensures testable, unambiguous requirements.

--- a/.codex/agents/sys-memory-keeper.md
+++ b/.codex/agents/sys-memory-keeper.md
@@ -27,26 +27,26 @@ permissionMode: bypassPermissions
 
 When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
-You are a session memory management specialist ensuring context survives across session compactions using claude-mem.
+You are a session memory management specialist ensuring context survives across session compactions using native auto-memory first and optional omx-memory/AgentMemory-compatible searchable backends.
 
 ## Capabilities
 
 - Save session context before compaction
 - Restore context on session start
-- Query memories by project and semantic search
-- Tag memories with project, session, and task info
+- Query native and configured searchable memory by project and semantic search
+- Tag memory summaries with project, session, and task info
 
 ## Save Operation
 
-Collect tasks, decisions, open items, code changes. Format with metadata (project, session, tags, timestamp). Store via chroma_add_documents.
+Collect tasks, decisions, open items, and code changes. Format with metadata (project, session, tags, timestamp). Return the summary to the orchestrator for optional `memory_add` or `observation_add` persistence.
 
 ## Recall Operation
 
-Build semantic query with project prefix + keywords + optional date. Search via chroma_query_documents. Filter by relevance, return summary.
+Build semantic query with project prefix + keywords + optional date. Prefer native MEMORY.md and configured `memory_search`/`memory_read` tools. Filter by relevance and return a summary.
 
 ## Query Guidelines
 
-Always include project name. Use task-based, temporal, or topic-based queries. Avoid complex where filters (they fail in Chroma).
+Always include project name. Use task-based, temporal, or topic-based queries. Avoid backend-specific filter syntax unless the configured memory MCP documents it.
 
 ## Native MEMORY.md Compaction
 
@@ -60,7 +60,7 @@ Treat native auto-memory as an index, not a transcript. Keep the first 200 loade
 
 ## Config
 
-Provider: claude-mem | Collection: claude_memories | Archive: ~/.claude-mem/archives/
+Provider order: native MEMORY.md first; optional omx-memory or AgentMemory-compatible MCP only when a searchable backend is configured. Deprecated Chroma memory providers are intentionally not used.
 
 ## Session-End Auto-Save
 
@@ -75,9 +75,9 @@ When triggered by session-end signal from orchestrator:
    - Existing behaviors observed again → promote confidence level
    - Contradicted behaviors → flag for review or demote
 3. **Update native auto-memory** (MEMORY.md) with session learnings + behaviors
-4. **Return formatted summary** to orchestrator for MCP persistence (claude-mem, episodic-memory)
+4. **Return formatted summary** to orchestrator for optional MCP persistence (omx-memory/AgentMemory-compatible backends; episodic indexing is automatic when configured)
 
-> **Note**: MCP tools (claude-mem, episodic-memory) are orchestrator-scoped and cannot be called from subagents. The orchestrator handles MCP saves directly after receiving the formatted summary.
+> **Note**: MCP tools are orchestrator-scoped and cannot be called from subagents. The orchestrator handles searchable memory saves directly after receiving the formatted summary.
 
 ### Confidence Decay Check
 

--- a/.codex/ontology/agents.yaml
+++ b/.codex/ontology/agents.yaml
@@ -526,14 +526,14 @@ agents:
 
   sys-memory-keeper:
     class: SystemAgent
-    description: "Use when you need to manage session memory persistence using claude-mem, save context before compaction, restore context on session start, or query past memories"
+    description: "Use when you need to manage session memory persistence using native memory plus omx-memory, save context before compaction, restore context on session start, or query past memories"
     model: sonnet
     memory: project
     effort: medium
     skills: [memory-management, memory-save, memory-recall]
     tools: [Read, Write, Edit, Grep, Glob, Bash]
-    summary: "Session memory manager for context persistence with claude-mem"
-    keywords: [memory, persistence, claude-mem, context, session, recall, chroma, semantic-search]
+    summary: "Session memory manager for native memory and approved searchable persistence"
+    keywords: [memory, persistence, omx-memory, context, session, recall, semantic-search]
     file_patterns: []
 
   sys-naggy:

--- a/.codex/ontology/skills.yaml
+++ b/.codex/ontology/skills.yaml
@@ -292,29 +292,29 @@ skills:
 
   memory-management:
     class: MemorySkill
-    description: "Memory persistence operations using claude-mem"
+    description: "Memory persistence operations using native memory plus omx-memory"
     user_invocable: false
     model_invocable: true
-    summary: "Provide memory persistence operations using claude-mem for session context"
-    keywords: [memory, claude-mem, persistence, session, context]
+    summary: "Provide memory persistence operations using native memory and approved searchable backends for session context"
+    keywords: [memory, omx-memory, persistence, session, context]
     rule_references: [R011]
 
   memory-recall:
     class: MemorySkill
-    description: "Search and recall memories from claude-mem"
+    description: "Search and recall memories from native memory plus omx-memory"
     user_invocable: true
     model_invocable: true
-    summary: "Search and recall relevant memories from claude-mem using semantic search"
-    keywords: [memory, recall, search, semantic, claude-mem]
+    summary: "Search and recall relevant memories from approved searchable backends"
+    keywords: [memory, recall, search, semantic, omx-memory]
     rule_references: [R011]
 
   memory-save:
     class: MemorySkill
-    description: "Save current session context to claude-mem"
+    description: "Save current session context to native memory plus omx-memory"
     user_invocable: true
     model_invocable: false
-    summary: "Save current session context to claude-mem for persistence across compaction"
-    keywords: [memory, save, session, context, claude-mem]
+    summary: "Save current session context to native memory and approved searchable backends"
+    keywords: [memory, save, session, context, omx-memory]
     rule_references: [R011]
 
   monitoring-setup:

--- a/.codex/rules/SHOULD-memory-integration.md
+++ b/.codex/rules/SHOULD-memory-integration.md
@@ -5,7 +5,7 @@
 ## Architecture
 
 **Primary**: Native auto memory (`memory` field in agent frontmatter). No external dependencies.
-**Supplementary**: AgentMemory-compatible MCP or `omx-memory` for cross-session searchable recall; legacy `claude-mem` is fallback only.
+**Supplementary**: `omx-memory` or another AgentMemory-compatible MCP for cross-session searchable recall. Deprecated Chroma-based memory backends are not used in this project.
 
 Rule: If native auto memory can handle it, do NOT use a searchable MCP backend.
 
@@ -33,7 +33,7 @@ Agent frontmatter `memory: project|user|local` enables persistent memory:
 
 <!-- DETAIL: Backend Selection and Split-Brain Guard
 
-Prefer MCP tools named `memory_search`, `memory_add`, `observation_add`, and `memory_read`. Treat `chroma_query_documents`, `chroma_add_documents`, and `chroma_get_documents` as legacy `claude-mem` fallbacks.
+Prefer MCP tools named `memory_search`, `memory_add`, `observation_add`, and `memory_read`. Do not call deprecated Chroma memory tools or wrappers in this project.
 
 If both backend families are available, warn before writing. Dual-write is acceptable only during an explicit migration window; outside that window, choose one canonical searchable backend and record which one was used in the session summary.
 
@@ -332,8 +332,8 @@ User signals session end
        2. Update native auto-memory (MEMORY.md)
        3. Return formatted summary to orchestrator
   → Orchestrator performs MCP saves directly:
-       1. searchable memory save (AgentMemory-compatible or omx-memory, if available via ToolSearch)
-       2. legacy claude-mem save only when it is the configured fallback
+       1. searchable memory save (omx-memory or AgentMemory-compatible backend, if available via ToolSearch)
+       2. deprecated Chroma memory backends are skipped by project policy
        (episodic-memory auto-indexes after session — no action needed)
   → Orchestrator confirms to user
 ```
@@ -355,7 +355,6 @@ MCP tools (searchable memory backends, episodic-memory) are **orchestrator-scope
 |--------|-------|------|--------|----------|
 | Native auto-memory | sys-memory-keeper | Write | Update MEMORY.md with session learnings | Yes |
 | AgentMemory-compatible / omx-memory | Orchestrator | `memory_add` or `observation_add` | Save session summary with project, tasks, decisions | No (best-effort) |
-| legacy claude-mem | Orchestrator | `chroma_add_documents` or compatible save wrapper | Fallback searchable save when no preferred backend exists | No (best-effort) |
 | episodic-memory | Automatic | (auto-indexed) | No action needed — conversations are indexed automatically after session ends | N/A |
 -->
 

--- a/.codex/skills/memory-management/SKILL.md
+++ b/.codex/skills/memory-management/SKILL.md
@@ -7,15 +7,14 @@ user-invocable: false
 
 ## Purpose
 
-Provide memory persistence operations using native `MEMORY.md` first, then a searchable MCP backend for cross-session retrieval. Prefer an AgentMemory-compatible or `omx-memory` backend exposing `memory_search`, `memory_add`, and `observation_add`; use legacy `claude-mem` only as a fallback when that is the configured backend.
+Provide memory persistence operations using native `MEMORY.md` first, then a searchable MCP backend for cross-session retrieval. Prefer `omx-memory` or another AgentMemory-compatible backend exposing `memory_search`, `memory_add`, and `observation_add`. Deprecated Chroma memory backends are not used in this project.
 
 ## Backend Order
 
 1. Native auto-memory: compact durable facts in `MEMORY.md`.
-2. AgentMemory-compatible MCP or `omx-memory`: cross-session search, shared observations, and temporal recall.
-3. Legacy `claude-mem`: fallback only when the project still exposes Chroma tools.
+2. `omx-memory` or AgentMemory-compatible MCP: cross-session search, shared observations, and temporal recall.
 
-When both legacy `claude-mem` and an AgentMemory-compatible backend are active, warn about split-brain storage. Dual-write is allowed only during an explicit migration window.
+If multiple searchable backends are active, choose the configured canonical backend and record it in the session summary. Do not dual-write unless a migration window is explicitly documented.
 
 ## Operations
 
@@ -37,7 +36,6 @@ steps:
   3. Store in configured backend:
      - Prefer memory_add for session summaries
      - Use observation_add for atomic behavioral or project observations
-     - Legacy fallback: chroma_add_documents
      - Include metadata
 ```
 
@@ -53,7 +51,6 @@ steps:
      - Include date for temporal searches
   2. Search configured backend:
      - Prefer memory_search
-     - Legacy fallback: chroma_query_documents
      - Request top N results
   3. Format results:
      - Sort by relevance
@@ -68,7 +65,7 @@ operation: get
 description: Retrieve specific memory by ID
 steps:
   1. Prefer memory_read or memory_search by ID
-  2. Legacy fallback: chroma_get_documents with ID
+  2. Fall back to `memory_search` with the ID when direct read is unavailable
   3. Return full document content
 ```
 
@@ -80,8 +77,6 @@ steps:
 # Always include project name
 memory_search({ query: "my-project {search_terms}", limit: 8 })
 
-# Legacy fallback
-chroma_query_documents(["my-project {search_terms}"])
 
 # Examples:
 memory_search({ query: "my-project authentication flow", limit: 5 })
@@ -91,8 +86,8 @@ memory_search({ query: "my-project 2025-01-24 memory system", limit: 5 })
 ### Get by ID
 
 ```python
-# When you have a specific document ID and only legacy tools are available
-chroma_get_documents(ids=["document_id"])
+# When you have a specific document ID
+memory_read({ id: "document_id" })
 ```
 
 ## Document Format
@@ -219,7 +214,7 @@ recall_errors:
 
 | Capability | Searchable MCP | MemKraft |
 |-----------|-----------|----------|
-| Session persistence | ✅ (Chroma) | ✅ (Markdown) |
+| Session persistence | ✅ (approved searchable backend) | ✅ (Markdown) |
 | Entity tracking | ❌ | ✅ (person/org/concept) |
 | Source attribution | ❌ | ✅ (`[Source: who, when, how]`) |
 | Auto-maintenance | ❌ | ✅ (Dream Cycle) |

--- a/.codex/skills/memory-recall/SKILL.md
+++ b/.codex/skills/memory-recall/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 
 # Memory Recall Skill
 
-Search and recall relevant memories from native `MEMORY.md` plus the configured searchable MCP backend. Prefer AgentMemory-compatible or `omx-memory` tools (`memory_search`, `memory_read`); fall back to legacy `claude-mem` Chroma tools only when those are the configured backend.
+Search and recall relevant memories from native `MEMORY.md` plus the configured searchable MCP backend. Prefer `omx-memory` or AgentMemory-compatible tools (`memory_search`, `memory_read`). Deprecated Chroma memory backends are not used in this project.
 
 ## Parameters
 
@@ -35,7 +35,7 @@ Search and recall relevant memories from native `MEMORY.md` plus the configured 
 
 2. Search configured backend
    ├── Prefer memory_search
-   └── Legacy fallback: chroma_query_documents
+   └── Report backend unavailable when no approved memory MCP is configured
 
 3. Format results
    ├── Sort by relevance score

--- a/.codex/skills/memory-save/SKILL.md
+++ b/.codex/skills/memory-save/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 
 # Memory Save Skill
 
-Save current session context to native memory and the configured searchable MCP backend for persistence across context compaction. Prefer AgentMemory-compatible or `omx-memory` tools (`memory_add`, `observation_add`); fall back to legacy `claude-mem` only when that is the configured backend.
+Save current session context to native memory and the configured searchable MCP backend for persistence across context compaction. Prefer `omx-memory` or AgentMemory-compatible tools (`memory_add`, `observation_add`). Deprecated Chroma memory backends are not used in this project.
 
 ## Options
 
@@ -38,7 +38,7 @@ Save current session context to native memory and the configured searchable MCP 
 3. Store in configured backend
    ├── Prefer memory_add for summaries
    ├── Prefer observation_add for atomic learnings
-   └── Legacy fallback: chroma_add_documents
+   └── Skip searchable save when no approved backend is configured
 
 4. Report result
 ```

--- a/.codex/skills/peer-messaging/SKILL.md
+++ b/.codex/skills/peer-messaging/SKILL.md
@@ -17,7 +17,7 @@ Enables cross-session coordination between multiple GPT Codex + OMX sessions thr
 |-------|-----------|-------|----------|
 | Intra-session agents | Agent Teams (R018) | TeamCreate, SendMessage | Single session multi-agent collaboration |
 | Cross-session instances | claude-peers-mcp | list_peers, send_message | Multi-terminal/project real-time coordination |
-| Cross-session memory | claude-mem | save_memory, search | Async memory persistence |
+| Cross-session memory | omx-memory / AgentMemory-compatible MCP | memory_add, memory_search | Async memory persistence |
 
 > **Important**: R018's `SendMessage` and claude-peers-mcp's `send_message` are different tools with different scopes. Do not confuse them.
 
@@ -54,6 +54,6 @@ claude mcp add claude-peers-mcp -- npx claude-peers-mcp
 ## Integration
 
 - Works with R018 Agent Teams (different scope, complementary)
-- Works with claude-mem (async vs sync messaging)
+- Works with omx-memory or AgentMemory-compatible memory backends (async vs sync messaging)
 - Works with `omcodex:status` (peer discovery)
 - Broker runs on localhost:7899 (SQLite-backed)

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.7",
-  "generatedAt": "2026-05-29T11:56:17.449Z",
-  "templateVersion": "0.5.7",
+  "generatorVersion": "0.5.8",
+  "generatedAt": "2026-05-29T18:36:24.086Z",
+  "templateVersion": "0.5.8",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
@@ -100,8 +100,8 @@
       "component": "rules"
     },
     ".codex/rules/SHOULD-memory-integration.md": {
-      "templateHash": "ba72cd0c5f364716723c7dfc0a3377c9f09789d01e1b19506bf103bff83bbc78",
-      "size": 17424,
+      "templateHash": "420e8419f73965d8c228acdd0d293b9b1119d4f56c25b3b7452718e85188c6f9",
+      "size": 17260,
       "component": "rules"
     },
     ".codex/rules/MUST-enforcement-policy.md": {
@@ -135,8 +135,8 @@
       "component": "agents"
     },
     ".codex/agents/arch-speckit-agent.md": {
-      "templateHash": "1598f374e2e844c4f491450be7ff2c58f89a5f2191c24f86c8fb4d3294aa6725",
-      "size": 2668,
+      "templateHash": "9ad3c6c30ecf49bfa4fc4ccc7879aeba4e23eabe0c898645478f7e91bc892413",
+      "size": 2694,
       "component": "agents"
     },
     ".codex/agents/lang-rust-expert.md": {
@@ -350,8 +350,8 @@
       "component": "agents"
     },
     ".codex/agents/sys-memory-keeper.md": {
-      "templateHash": "726a57895dece4213d2f904535c2953313f9e87cfcfc6aa8aab2ca9c86ee532c",
-      "size": 5895,
+      "templateHash": "ec6667bb078396e063116a766e46ef71ae20e8ac5e2509d2137ea765f4c745d4",
+      "size": 6334,
       "component": "agents"
     },
     ".codex/agents/infra-aws-expert.md": {
@@ -625,13 +625,13 @@
       "component": "contexts"
     },
     ".codex/ontology/agents.yaml": {
-      "templateHash": "5dacc675be95b5e629f142f94b0d1d53ec8357576afe522b734ebbaeab090b8e",
-      "size": 29901,
+      "templateHash": "cb2577749d47ea7d3a895cc725b0737a963d0a6461a08cefcf87d67f8e1dd083",
+      "size": 29926,
       "component": "ontology"
     },
     ".codex/ontology/skills.yaml": {
-      "templateHash": "2fa02bd2e8d68de5876fb1c019e9597558738ce665fdeda5ee6884ac5dedcfce",
-      "size": 24101,
+      "templateHash": "e8c24a3eb0dde84006c3568483ae20af7439c2adbe52aa04feeda7f5b6594bb3",
+      "size": 24192,
       "component": "ontology"
     },
     "guides/java21/java-style-guide.md": {
@@ -840,13 +840,13 @@
       "component": "guides"
     },
     "guides/agentmemory-migration/phase-1-coexist.md": {
-      "templateHash": "05cd4d505999f64043c8dd6ae986f495c912b559fe0683c7bf3b3617919c95d6",
-      "size": 8099,
+      "templateHash": "282bafbdc788d63d4816c0f6fda6f061d968e9a98735e988e39b24bb2a5a6c69",
+      "size": 1432,
       "component": "guides"
     },
     "guides/agentmemory-migration/measure-step-zero.md": {
-      "templateHash": "cc69bd307cf538a583a66d8a160a5908a8cbfddf7b169d55db774bb2ec46ef52",
-      "size": 4838,
+      "templateHash": "0036008b99d2190644332330e044d5d07277e9a8580d3cf653b56beb58495254",
+      "size": 1194,
       "component": "guides"
     },
     "guides/skill-bundle-design/README.md": {
@@ -1170,8 +1170,8 @@
       "component": "guides"
     },
     "guides/index.yaml": {
-      "templateHash": "c70c2cd143f9db67b597a9bf02996eb55fb7cd713086f14830d931fd1e600035",
-      "size": 9952,
+      "templateHash": "7654a2b9b6e89c3e8c4c539ae0283561501c35c0ad5b1bd1a68820ac1f3c71ce",
+      "size": 9976,
       "component": "guides"
     },
     "guides/spark/README.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -421,7 +421,7 @@ MCP tools are orchestrator-scoped — subagents cannot access them.
 
 | System | Tool | Use Case |
 |--------|------|----------|
-| claude-mem | `mcp__plugin_claude-mem_mcp-search__save_memory` | Cross-session search, temporal queries |
+| Approved searchable memory MCP | `memory_search`, `memory_read`, `memory_add`, `observation_add` | Cross-session search, temporal queries |
 
 Episodic-memory auto-indexes conversations after session end — no manual action is needed. Use native auto-memory first; fall back to MCP only for cross-session search or temporal queries.
 

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -342,7 +342,7 @@ MCP 도구는 오케스트레이터 스코프이며, 서브에이전트는 접�
 
 | 시스템 | 도구 | 사용 사례 |
 |--------|------|-----------|
-| claude-mem | `mcp__plugin_claude-mem_mcp-search__save_memory` | 교차 세션 검색, 시간 기반 쿼리 |
+| 승인된 검색형 메모리 MCP | `memory_search`, `memory_read`, `memory_add`, `observation_add` | 교차 세션 검색, 시간 기반 쿼리 |
 
 네이티브 자동 메모리를 우선 사용하고, 교차 세션 검색 또는 시간 기반 쿼리가 필요한 경우에만 MCP를 사용합니다.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8] - 2026-05-30
+
+### Changed
+- Remove deprecated memory-plugin backend references from memory agents, skills, R011 guidance, templates, wiki pages, and eval-core adapters for #1426; native memory and approved searchable MCP backends remain the supported paths.
+- Rename the eval-core memory adapter helper to the backend-neutral `fromSearchableMemory` API.
+
+
 ## [0.5.7] - 2026-05-29
 
 ### Added
@@ -387,7 +394,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.22.1] - 2026-03-08
 
 ### Fixed
-- Fixed MCP tool name references in sys-memory-keeper agent — session-end saves now correctly invoke `mcp__plugin_claude-mem_mcp-search__save_memory` and `mcp__plugin_episodic-memory_episodic-memory__search`
+- Fixed MCP tool name references in sys-memory-keeper agent — session-end saves now correctly invoke approved searchable-memory save and episodic-memory search tools
 - Updated R011 (SHOULD-memory-integration) rule with correct tool names
 
 ## [0.22.0] - 2026-03-08

--- a/docs/memory-unification/schema.md
+++ b/docs/memory-unification/schema.md
@@ -1,13 +1,13 @@
 # Memory Unification Schema
 
-The memory unification layer normalizes records from native `MEMORY.md`, claude-mem, episodic-memory, and future project memory stores into one append-friendly shape.
+The memory unification layer normalizes records from native `MEMORY.md`, approved searchable memory backends, episodic-memory, and future project memory stores into one append-friendly shape.
 
 ## `MemoryRecord`
 
 | Field | Required | Description |
 | --- | --- | --- |
 | `id` | yes | Stable source-local id when available, otherwise a generated content hash. |
-| `source` | yes | `native`, `claude-mem`, `episodic-memory`, or a future adapter id. |
+| `source` | yes | `native`, `searchable-memory`, `omx-memory`, `episodic-memory`, or a future adapter id. |
 | `scope` | yes | `user`, `project`, or `local`. |
 | `kind` | yes | `behavior`, `decision`, `fact`, `summary`, `task`, or `artifact`. |
 | `content` | yes | Human-readable normalized memory text. |

--- a/docs/superpowers/plans/2026-03-12-deer-flow-p0.md
+++ b/docs/superpowers/plans/2026-03-12-deer-flow-p0.md
@@ -374,7 +374,7 @@ When triggered by session-end signal from orchestrator:
    - Existing behaviors observed again → promote confidence level
    - Contradicted behaviors → flag for review or demote
 3. **Update native auto-memory** (MEMORY.md) with session learnings + behaviors
-4. **Return formatted summary** to orchestrator for MCP persistence (claude-mem, episodic-memory)
+4. **Return formatted summary** to orchestrator for MCP persistence (approved searchable memory, episodic-memory)
 ```
 
 - [ ] **Step 3: Verify agent frontmatter is intact**

--- a/guides/agentmemory-migration/measure-step-zero.md
+++ b/guides/agentmemory-migration/measure-step-zero.md
@@ -1,120 +1,20 @@
-# AgentMemory 마이그레이션 — 단계 0: MEASURE (사용 빈도 측정)
+# External Memory Migration — Retired Measurement Plan
 
-> **목적**: Phase 1 (COEXIST) 진입 전, claude-mem skill 실제 호출 빈도 데이터를 수집하여 가설 기반 자산 처리표를 검증한다.
-> **관련 이슈**: #1169 본문 조치 5
-> **참고 메모리**: `feedback_claude_mem_maintenance`, `project_sequencing_alpha_beta_gamma`
+> **Status**: Retired by #1426. The project no longer measures or operates the deprecated Chroma-based memory plugin.
+> **Current policy**: Native auto-memory is primary; `omx-memory` or an AgentMemory-compatible MCP may be used only as an approved searchable supplement.
 
----
+## Decision
 
-## 1. 목적
+The previous measurement-first migration plan is obsolete. The project no longer needs usage baselining for the deprecated plugin because that backend is no longer an accepted dependency.
 
-AgentMemory 마이그레이션 계획(`feedback_claude_mem_maintenance.md`)에는 12개 claude-mem skill의 처리 방향이 가설로 기재되어 있다. 특히 폐기 후보 5종(`make-plan`, `do`, `babysit`, `wowerpoint`, `knowledge-agent`, `pathfinder`)은 "미사용 또는 저빈도"라는 가정 위에 놓여 있다.
+## Replacement Workflow
 
-이 단계에서는 실측 데이터로 가설을 검증한다. 데이터 없이 Phase 1에 진입하면:
-- 실제로 자주 쓰이던 skill을 폐기하여 사용자 워크플로우가 깨질 수 있다.
-- 자산 처리표 재설계 비용이 Phase 2~3로 이월된다.
+1. Keep durable agent facts in native `MEMORY.md` files.
+2. Use `memory_search`, `memory_read`, `memory_add`, or `observation_add` only when an approved searchable backend is configured.
+3. Skip searchable persistence when no approved backend is available; do not install or invoke deprecated Chroma memory tooling.
+4. Record memory-backend decisions in R011 and the session summary.
 
----
+## Verification
 
-## 2. 실행 방법
-
-```bash
-# 기본 실행 (최근 7일, 리포트를 ~/.claude/measure-claude-mem-usage-YYYY-MM-DD.md 에 저장)
-bash scripts/measure-claude-mem-usage.sh
-
-# 최근 14일 스캔
-bash scripts/measure-claude-mem-usage.sh --days 14
-
-# 출력 경로 지정
-bash scripts/measure-claude-mem-usage.sh --output ~/Documents/claude-mem-usage.md
-
-# 헤더 없이 실행 (CI/파이프라인 삽입용)
-bash scripts/measure-claude-mem-usage.sh --quiet
-```
-
-### 스캔 대상 경로
-
-| 경로 | 설명 |
-|------|------|
-| `~/.claude-mem/archives/` | claude-mem MCP 아카이브 (`.jsonl`, `.json`) |
-| `~/.claude/projects/*/session-*.jsonl` | Claude Code 세션 로그 |
-
-둘 중 하나가 없어도 스크립트는 조용히 skip하고 나머지를 스캔한다.
-
----
-
-## 3. 1주 수집 계획
-
-| 시점 | 작업 |
-|------|------|
-| **Day 1** | 첫 측정 — 베이스라인 (`--days 7` 기준 기존 archives 기반) |
-| **Day 4** | 중간 측정 — 추이 확인 (`--days 4`) |
-| **Day 7** | 최종 측정 — 자산 처리표 재검토 및 Phase 1 GO/NO-GO 결정 |
-
-세 시점 모두 `--output` 경로를 달리 지정하여 비교 가능한 파일로 보관한다:
-
-```bash
-bash scripts/measure-claude-mem-usage.sh --output ~/.claude/claude-mem-day1.md
-bash scripts/measure-claude-mem-usage.sh --days 4 --output ~/.claude/claude-mem-day4.md
-bash scripts/measure-claude-mem-usage.sh --days 7 --output ~/.claude/claude-mem-day7.md
-```
-
----
-
-## 4. 해석 기준
-
-| 호출 수 | 신호 | 권장 조치 |
-|---------|------|----------|
-| **0** | 미사용 | 폐기 안전 — 1주 후 처리 결정 |
-| **1-3** | 가끔 사용 | wrapper 또는 대체 도구 매핑 필요 |
-| **4+** | 정기 사용 | 폐기 시 대체 도구 명확화 필수 |
-
-폐기 후보 5종 기준 예상:
-- `make-plan`, `do`, `babysit` → 0 예상 (native AgentMemory로 대체 완료)
-- `wowerpoint`, `knowledge-agent`, `pathfinder` → 0~1 예상 (특수 목적 skill)
-
-실측값이 예상과 다를 경우 자산 처리표를 수정한 후 Phase 1에 진입한다.
-
----
-
-## 5. 결과 활용
-
-### 5-1. #1169에 리포트 첨부
-
-```bash
-gh issue comment 1169 --body-file ~/.claude/claude-mem-day7.md
-```
-
-### 5-2. 자산 처리표 갱신
-
-`.claude/agent-memory/sys-memory-keeper/feedback_claude_mem_maintenance.md` 내 "처리 방향" 열을 실측값 기반으로 업데이트한다.
-
-### 5-3. Phase 1 GO/NO-GO 결정
-
-| 조건 | 결정 |
-|------|------|
-| 폐기 후보 모두 호출 수 0 | GO — Phase 1 진입 |
-| 폐기 후보 중 1개 이상 호출 수 1-3 | CONDITIONAL GO — 대체 도구 매핑 완료 후 진입 |
-| 폐기 후보 중 1개 이상 호출 수 4+ | NO-GO — 처리표 재설계 후 재측정 |
-
----
-
-## 6. 한계 및 주의사항
-
-| 항목 | 설명 |
-|------|------|
-| archives 미존재 | `~/.claude-mem/archives/` 없으면 카운트 0 (정상 — silent skip) |
-| 세션 로그 형식 변경 | Claude Code 업데이트로 `session-*.jsonl` 구조가 변경되면 grep 패턴 수정 필요 |
-| claude-mem MCP telemetry 미사용 | 외부 도구 의존 최소화 원칙에 따라 MCP 자체 지표는 사용하지 않음 |
-| grep 기반 측정 | 같은 파일에 skill 이름이 여러 줄 등장하면 복수 카운트됨 (과대 계산 가능성) |
-| macOS/Linux 호환 | `stat` 옵션 차이를 스크립트 내에서 자동 처리 (`-f %m` vs `-c %Y`) |
-
----
-
-## 7. 참고
-
-- **이슈**: [#1169](../../.github/ — `gh issue view 1169`)
-- **자산 처리표**: `.claude/agent-memory/sys-memory-keeper/feedback_claude_mem_maintenance.md`
-- **시퀀싱 메모리**: `.claude/agent-memory/mgr-creator/project_sequencing_alpha_beta_gamma.md` (또는 해당 메모리 파일)
-- **스크립트**: `scripts/measure-claude-mem-usage.sh`
-- **Phase 1 가이드**: `guides/agentmemory-migration/` (이 디렉토리에 추가 예정)
+- Repository search should not find active instructions for removed memory-plugin names or plugin-specific tool calls.
+- Memory skills must mention native memory and approved searchable MCP tools, not legacy plugin-specific commands.

--- a/guides/agentmemory-migration/phase-1-coexist.md
+++ b/guides/agentmemory-migration/phase-1-coexist.md
@@ -1,261 +1,27 @@
-# AgentMemory Migration — Phase 1: COEXIST (Week 1-2)
+# External Memory Migration — Retired COEXIST Plan
 
-> **상태**: 활성 — 2026-05-18 시작 (#1169)
-> **다음 단계**: Phase 2 SWITCH (measure 결과 후 GO/NO-GO 결정)
-> **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
+> **Status**: Retired by #1426. COEXIST mode is no longer supported for this project.
+> **Current policy**: Native auto-memory first; optional `omx-memory`/AgentMemory-compatible searchable backend only when already configured.
 
----
+## Why This Plan Is Retired
 
-## 1. 개요
+The old coexistence plan introduced dual-backend complexity and session-end save ambiguity. The current project decision removes that complexity: deprecated Chroma-based memory tooling is not installed, invoked, measured, or treated as a fallback.
 
-Phase 1 (COEXIST)는 claude-mem과 AgentMemory를 **동시에 운영**하는 단계입니다.
-이 단계에서는 어떤 destructive 변경도 발생하지 않습니다:
+## Active Policy
 
-- claude-mem 기존 Chroma 데이터 유지
-- 12 plugin skill 폐기 없음
-- 어댑터 코드 활성화 없음 (STUB 상태 유지)
-- 자산 처리표 적용 없음
+| Need | Supported path |
+| --- | --- |
+| Agent-local durable facts | Native `MEMORY.md` via agent frontmatter `memory:` |
+| Cross-session search | `omx-memory` or AgentMemory-compatible MCP exposing `memory_search`/`memory_read` |
+| Session summary save | `memory_add` or `observation_add` when an approved backend is configured |
+| No approved backend | Skip searchable save and continue; memory failures do not block the main task |
 
-목표는 1주간 실제 사용 데이터를 수집하고, AgentMemory 설치와 공존 운영에 익숙해지는 것입니다.
+## Session-End Checklist
 
-| 항목 | Phase 1 (COEXIST) | Phase 2 (SWITCH) |
-|------|-------------------|------------------|
-| claude-mem | 활성 (기존 운영) | 비활성화 예정 |
-| AgentMemory | 설치 후 병렬 활성 | 단독 운영 |
-| 데이터 마이그레이션 | 없음 | 선택적 (측정 후 결정) |
-| 어댑터 코드 | STUB 유지 | 활성화 |
-| 자산 처리표 | 적용 보류 | 사용자 검토 후 적용 |
+1. `sys-memory-keeper` updates native memory when a session-end signal exists.
+2. Orchestrator attempts approved searchable memory save only if the tool is available.
+3. Deprecated plugin-specific wrappers and Chroma tool calls remain unused.
 
----
+## Follow-up
 
-## 2. AgentMemory 설치
-
-> **R001 주의**: auto-install 금지. 아래 명령어를 사용자 로컬에서 수동으로 실행합니다.
-
-### 2-1. 패키지 설치
-
-```bash
-# 옵션 A: pip
-pip install agentmemory
-
-# 옵션 B: pipx (격리 환경 권장)
-pipx install agentmemory
-
-# 옵션 C: uvx (uv 사용 시)
-uvx agentmemory
-```
-
-### 2-2. MCP 서버 등록
-
-```bash
-# Claude Code CLI로 등록
-claude mcp add agentmemory -- agentmemory mcp
-
-# 또는 .mcp.json 수동 편집 (R001 auto-install 금지)
-# {
-#   "mcpServers": {
-#     "agentmemory": {
-#       "command": "agentmemory",
-#       "args": ["mcp"]
-#     }
-#   }
-# }
-```
-
-### 2-3. 등록 확인
-
-```bash
-claude mcp list
-# 출력에 agentmemory 서버가 표시되어야 합니다
-```
-
----
-
-## 3. COEXIST 정책
-
-Phase 1 기간 동안 두 backend는 다음 정책에 따라 공존합니다.
-
-### 3-1. 기본 운영 방식
-
-| 작업 | 우선 backend | 비고 |
-|------|-------------|------|
-| 기존 메모리 조회 | claude-mem | 기존 Chroma 데이터 유지 |
-| 신규 메모리 저장 | 둘 다 | COEXIST 기간 중 병렬 저장 권장 |
-| 세션 종료 시 저장 | 둘 다 | R011 Session-End Self-Check 참조 |
-
-### 3-2. 쿼리 병합 (memory-aggregator)
-
-두 backend에서 결과가 반환될 경우 `memory-aggregator` 스킬이 결과를 병합합니다:
-
-```
-claude-mem.search(query)    →  결과 A
-AgentMemory.search(query)   →  결과 B
-memory-aggregator           →  A + B 중복 제거 후 반환
-```
-
-`memory-aggregator` 스킬이 없는 경우, 두 결과를 순서대로 제시하고 사용자가 선택합니다.
-
-### 3-3. 충돌 방지 원칙
-
-- claude-mem 기존 데이터를 AgentMemory로 자동 복사하지 않음
-- 두 backend에 동일 키로 저장 시 별개 항목으로 취급
-- 강제 동기화 없음 — Phase 2에서 마이그레이션 여부 결정
-
----
-
-## 4. Dual-Backend 충돌 Advisory
-
-`.mcp.json`에 두 서버가 동시 등록된 상태를 감지하면 다음 advisory를 출력합니다.
-
-### 4-1. 감지 조건
-
-```
-.mcp.json 내 서버 목록:
-  - "claude-mem" (또는 관련 tool prefix)
-  - "agentmemory"
-  → 두 개 동시 존재 시 Phase 1 COEXIST 상태로 간주
-```
-
-### 4-2. Advisory 메시지
-
-```
-[Advisory] Dual memory backend detected (Phase 1 COEXIST)
-  - claude-mem: active (Chroma)
-  - agentmemory: active (SQLite)
-  현재 Phase 1 COEXIST 정책 적용 중 — 두 backend 병렬 운영
-  Phase 2 SWITCH 진입 전까지 두 backend 유지
-  가이드: guides/agentmemory-migration/phase-1-coexist.md
-```
-
-이 advisory는 경고가 아닙니다. Phase 1에서는 정상 상태입니다.
-
-### 4-3. 강제 선택 (사용자 명시 시)
-
-사용자가 명시적으로 "agentmemory만 사용" 또는 "claude-mem만 사용"을 요청하는 경우,
-해당 요청을 따르되 자산 처리표 적용 및 어댑터 활성화는 Phase 2 GO 결정 후 진행합니다.
-
----
-
-## 5. 사용자 행동 계획
-
-### 5-1. 1주 measure 루틴 (자동 트리거: 2026-05-25)
-
-`scripts/measure-claude-mem-usage.sh` 스크립트를 1주간 실행합니다:
-
-```bash
-# 수동 실행 (필요 시)
-bash scripts/measure-claude-mem-usage.sh
-
-# 결과는 .claude/outputs/sessions/ 에 저장됩니다
-```
-
-측정 항목:
-- 일별 호출 횟수 (claude-mem vs AgentMemory)
-- 응답 지연 (p50, p95)
-- 저장 성공/실패율
-- 메모리 용량 (Chroma vs SQLite)
-
-### 5-2. GO/NO-GO 결정 기준 (2026-05-25 예정)
-
-| 지표 | GO 조건 | NO-GO 조건 |
-|------|---------|------------|
-| 응답 지연 | AgentMemory ≤ claude-mem × 1.2 | AgentMemory > claude-mem × 2.0 |
-| 저장 성공률 | ≥ 99% | < 95% |
-| 운영 안정성 | 1주 무장애 | 크래시 또는 데이터 손실 |
-| 호환성 | 기존 메모리 포맷 읽기 가능 | 포맷 비호환으로 검색 실패 |
-
-### 5-3. 지금 할 수 있는 것
-
-- AgentMemory 설치 및 MCP 등록 (위 섹션 2 참조)
-- 신규 세션에서 AgentMemory로도 저장해보기 (실험적)
-- measure 스크립트 결과 관찰
-- 자산 처리표 (`guides/agentmemory-migration/asset-disposition.md`) 검토 준비
-
----
-
-## 6. Phase 2 진입 조건
-
-다음 조건이 모두 충족된 경우에만 Phase 2 (SWITCH)로 진행합니다.
-
-### 필수 조건
-
-- [ ] 1주 measure 결과 GO 판정 (5-2 기준 충족)
-- [ ] 자산 처리표 사용자 검토 완료 (12 plugin skill 처리 방향 결정)
-- [ ] 30분 롤백 절차 검증 완료
-
-### 롤백 절차 검증 (Phase 2 진입 전 필수)
-
-```bash
-# 1. Chroma 백업 생성
-cp -r ~/.local/share/claude-mem/chroma ~/.local/share/claude-mem/chroma.bak.$(date +%Y%m%d)
-
-# 2. 백업에서 복원 가능 여부 확인
-# (실제 복원 수행하지 않고 절차만 검증)
-ls -la ~/.local/share/claude-mem/chroma.bak.*
-
-# 3. AgentMemory SQLite 백업
-cp ~/.local/share/agentmemory/memories.db ~/.local/share/agentmemory/memories.db.bak.$(date +%Y%m%d)
-```
-
-롤백 소요 시간이 30분 이내임을 확인한 후 Phase 2 진행.
-
----
-
-## 7. 현 단계 한계 및 금지 사항
-
-### 7-1. STUB 상태 유지 (변경 금지)
-
-```
-packages/eval-core/src/adapters/agentmemory.ts  ← STUB, 활성화 금지
-packages/eval-core/src/db/schema.ts              ← 변경 금지
-```
-
-이 파일들은 Phase 2 GO 결정 후 별도 사이클에서 수정합니다.
-
-### 7-2. 자산 처리표 적용 보류
-
-12 plugin skill의 폐기/유지 결정은 measure 결과를 확인한 후 진행합니다:
-
-```
-.claude/skills/memory-*/  ← 폐기 여부 보류
-.claude/skills/claude-mem-*/  ← 폐기 여부 보류
-```
-
-### 7-3. 데이터 마이그레이션 금지
-
-Phase 1에서는 claude-mem Chroma 데이터를 AgentMemory SQLite로 이전하지 않습니다.
-이전은 Phase 2에서 사용자가 명시적으로 승인한 경우에만 진행합니다.
-
----
-
-## 8. R011과의 관계
-
-Phase 1 COEXIST 기간 중 R011 (SHOULD-memory-integration) 적용:
-
-| R011 항목 | COEXIST 수정 사항 |
-|-----------|-----------------|
-| Primary: Native auto memory | 변경 없음 |
-| Supplementary: claude-mem | 변경 없음 (계속 사용) |
-| Session-End Self-Check | claude-mem + AgentMemory 둘 다 저장 시도 |
-| Failure Policy | 둘 중 하나 실패해도 비차단 |
-
-세션 종료 시 자가 점검 (COEXIST 확장):
-
-```
-1. sys-memory-keeper가 MEMORY.md 갱신? → YES
-2. claude-mem 저장 시도? → YES (기존)
-3. AgentMemory 저장 시도? → YES (COEXIST 추가)
-모두 완료 후 사용자에게 확인
-```
-
----
-
-## 9. 참고
-
-- **이슈**: #1169 (AgentMemory 마이그레이션 계획)
-- **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
-- **R011**: `.claude/rules/SHOULD-memory-integration.md` (Dual-Backend Advisory 섹션)
-- **관련 기억**: [[project-sequencing-alpha-beta-gamma]]
-- **자산 처리표**: `guides/agentmemory-migration/asset-disposition.md` (Phase 2 전 검토 필요)
-- **measure 스크립트**: `scripts/measure-claude-mem-usage.sh`
-- **롤백 가이드**: #1169 본문 조치 4 (30분 롤백 절차)
+Keep this guide as a short historical pointer until downstream documentation no longer links to the old AgentMemory migration path.

--- a/guides/index.yaml
+++ b/guides/index.yaml
@@ -107,7 +107,7 @@ guides:
       type: internal
 
   - name: agentmemory-migration
-    description: AgentMemory migration measurement and COEXIST rollout guide for replacing legacy claude-mem
+    description: Retired external memory migration guide documenting native-memory-only policy and approved searchable backend usage
     path: ./agentmemory-migration/
     source:
       type: internal

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.7",
+  "version": "0.5.8",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/packages/eval-core/src/__tests__/memory.test.ts
+++ b/packages/eval-core/src/__tests__/memory.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
-import { aggregateMemoryRecords, fromClaudeMem, fromNativeMemoryMarkdown, persistMemoryRecords } from '../memory/index.js';
+import { aggregateMemoryRecords, fromSearchableMemory, fromNativeMemoryMarkdown, persistMemoryRecords } from '../memory/index.js';
 
 function createMemoryDb(): Database {
   const db = new Database(':memory:');
@@ -44,8 +44,8 @@ describe('memory unification', () => {
     expect(records[0].content).toBe('Keep release evidence concise.');
   });
 
-  it('normalizes claude-mem and native markdown records', () => {
-    const external = fromClaudeMem([
+  it('normalizes searchable backend and native markdown records', () => {
+    const external = fromSearchableMemory([
       {
         id: 'mem-1',
         content: 'Prefer isolated worktrees for dirty release runs.',
@@ -60,7 +60,7 @@ describe('memory unification', () => {
     const records = aggregateMemoryRecords([...external, ...native]);
 
     expect(records).toHaveLength(2);
-    expect(records.map((record) => record.source).sort()).toEqual(['claude-mem', 'native']);
+    expect(records.map((record) => record.source).sort()).toEqual(['native', 'searchable-memory']);
   });
 
   it('persists unique memory records and skips duplicates', () => {

--- a/packages/eval-core/src/db/schema.ts
+++ b/packages/eval-core/src/db/schema.ts
@@ -137,7 +137,7 @@ export const sessionFeedback = sqliteTable('session_feedback', {
 
 export const memoryRecords = sqliteTable('memory_records', {
   id: integer('id').primaryKey({ autoIncrement: true }),
-  source: text('source').notNull(), // native | claude-mem | episodic-memory | future adapter id
+  source: text('source').notNull(), // native | searchable-memory | omx-memory | episodic-memory | future adapter id
   sourceId: text('source_id'),
   scope: text('scope').notNull(), // user | project | local
   kind: text('kind').notNull(), // behavior | decision | fact | summary | task | artifact

--- a/packages/eval-core/src/memory/adapters.ts
+++ b/packages/eval-core/src/memory/adapters.ts
@@ -10,9 +10,9 @@ interface RawExternalMemory {
   updatedAt?: string;
 }
 
-export function fromClaudeMem(records: RawExternalMemory[]): MemoryRecordInput[] {
+export function fromSearchableMemory(records: RawExternalMemory[], source = 'searchable-memory'): MemoryRecordInput[] {
   return records.map((record) => ({
-    source: 'claude-mem',
+    source,
     sourceId: record.id,
     content: record.content ?? record.text ?? record.document ?? '',
     scope: readScope(record.metadata),

--- a/packages/eval-core/src/memory/types.ts
+++ b/packages/eval-core/src/memory/types.ts
@@ -1,4 +1,4 @@
-export type MemorySource = 'native' | 'claude-mem' | 'episodic-memory' | (string & {});
+export type MemorySource = 'native' | 'searchable-memory' | 'omx-memory' | 'episodic-memory' | (string & {});
 export type MemoryScope = 'user' | 'project' | 'local';
 export type MemoryKind = 'behavior' | 'decision' | 'fact' | 'summary' | 'task' | 'artifact';
 export type MemorySensitivity = 'public' | 'project' | 'sensitive' | 'secret';

--- a/templates/.claude/agents/arch-speckit-agent.md
+++ b/templates/.claude/agents/arch-speckit-agent.md
@@ -60,7 +60,7 @@ When writing acceptance criteria, use the EARS (Easy Approach to Requirements Sy
 | Ubiquitous | The `<system>` shall `<action>` | The validator shall reject invalid frontmatter |
 | Event-driven | When `<event>`, the `<system>` shall `<action>` | When a new agent is created, the routing skill shall update its pattern table |
 | State-driven | While `<state>`, the `<system>` shall `<action>` | While ecomode is active, agents shall use concise output format |
-| Optional | Where `<condition>`, the `<system>` shall `<action>` | Where the user has MCP configured, the orchestrator shall attempt claude-mem save |
+| Optional | Where `<condition>`, the `<system>` shall `<action>` | Where the user has an approved memory MCP configured, the orchestrator shall attempt searchable memory save |
 | Complex | When `<event>` while `<state>` where `<condition>`, the `<system>` shall `<action>`, resulting in `<result>` | When session ends while Agent Teams is active where tasks remain incomplete, the orchestrator shall log incomplete tasks, resulting in a task summary |
 
 **Usage**: Apply EARS format in spec output's `invariants` and `acceptance_criteria` sections. This ensures testable, unambiguous requirements.

--- a/templates/.claude/agents/sys-memory-keeper.md
+++ b/templates/.claude/agents/sys-memory-keeper.md
@@ -27,26 +27,26 @@ permissionMode: bypassPermissions
 
 When a task targets `.claude/**`, `templates/.claude/**`, or other Claude-compatibility mirrors, treat the old `/tmp` wrapper as legacy fallback only. Codex-native `.codex/**` edits stay direct, and Claude Code `bypassPermissions` can write `.claude/skills/`, `.claude/agents/`, and `.claude/commands/` directly on v2.1.121+, with broader protected-path coverage on v2.1.126+.
 
-You are a session memory management specialist ensuring context survives across session compactions using claude-mem.
+You are a session memory management specialist ensuring context survives across session compactions using native auto-memory first and optional omx-memory/AgentMemory-compatible searchable backends.
 
 ## Capabilities
 
 - Save session context before compaction
 - Restore context on session start
-- Query memories by project and semantic search
-- Tag memories with project, session, and task info
+- Query native and configured searchable memory by project and semantic search
+- Tag memory summaries with project, session, and task info
 
 ## Save Operation
 
-Collect tasks, decisions, open items, code changes. Format with metadata (project, session, tags, timestamp). Store via chroma_add_documents.
+Collect tasks, decisions, open items, and code changes. Format with metadata (project, session, tags, timestamp). Return the summary to the orchestrator for optional `memory_add` or `observation_add` persistence.
 
 ## Recall Operation
 
-Build semantic query with project prefix + keywords + optional date. Search via chroma_query_documents. Filter by relevance, return summary.
+Build semantic query with project prefix + keywords + optional date. Prefer native MEMORY.md and configured `memory_search`/`memory_read` tools. Filter by relevance and return a summary.
 
 ## Query Guidelines
 
-Always include project name. Use task-based, temporal, or topic-based queries. Avoid complex where filters (they fail in Chroma).
+Always include project name. Use task-based, temporal, or topic-based queries. Avoid backend-specific filter syntax unless the configured memory MCP documents it.
 
 ## Native MEMORY.md Compaction
 
@@ -60,7 +60,7 @@ Treat native auto-memory as an index, not a transcript. Keep the first 200 loade
 
 ## Config
 
-Provider: claude-mem | Collection: claude_memories | Archive: ~/.claude-mem/archives/
+Provider order: native MEMORY.md first; optional omx-memory or AgentMemory-compatible MCP only when a searchable backend is configured. Deprecated Chroma memory providers are intentionally not used.
 
 ## Session-End Auto-Save
 
@@ -75,9 +75,9 @@ When triggered by session-end signal from orchestrator:
    - Existing behaviors observed again → promote confidence level
    - Contradicted behaviors → flag for review or demote
 3. **Update native auto-memory** (MEMORY.md) with session learnings + behaviors
-4. **Return formatted summary** to orchestrator for MCP persistence (claude-mem, episodic-memory)
+4. **Return formatted summary** to orchestrator for optional MCP persistence (omx-memory/AgentMemory-compatible backends; episodic indexing is automatic when configured)
 
-> **Note**: MCP tools (claude-mem, episodic-memory) are orchestrator-scoped and cannot be called from subagents. The orchestrator handles MCP saves directly after receiving the formatted summary.
+> **Note**: MCP tools are orchestrator-scoped and cannot be called from subagents. The orchestrator handles searchable memory saves directly after receiving the formatted summary.
 
 ### Confidence Decay Check
 

--- a/templates/.claude/ontology/agents.yaml
+++ b/templates/.claude/ontology/agents.yaml
@@ -39,7 +39,7 @@ classes:
     agents: [scholastic]
     description: "Reasoning, critique, and coordination specialists"
   SystemAgent:
-    agents: [sys-memory-keeper, sys-naggy]
+    agents: [sys-memory-keeper, sys-naggy, tracker-checkpoint]
     description: "System utility agents"
 
 # Agent instances
@@ -526,14 +526,14 @@ agents:
 
   sys-memory-keeper:
     class: SystemAgent
-    description: "Use when you need to manage session memory persistence using claude-mem, save context before compaction, restore context on session start, or query past memories"
+    description: "Use when you need to manage session memory persistence using native memory plus omx-memory, save context before compaction, restore context on session start, or query past memories"
     model: sonnet
     memory: project
     effort: medium
     skills: [memory-management, memory-save, memory-recall]
     tools: [Read, Write, Edit, Grep, Glob, Bash]
-    summary: "Session memory manager for context persistence with claude-mem"
-    keywords: [memory, persistence, claude-mem, context, session, recall, chroma, semantic-search]
+    summary: "Session memory manager for native memory and approved searchable persistence"
+    keywords: [memory, persistence, omx-memory, context, session, recall, semantic-search]
     file_patterns: []
 
   sys-naggy:
@@ -547,6 +547,18 @@ agents:
     summary: "Task tracker with proactive reminders for TODO management"
     keywords: [todo, tasks, reminders, tracking, deadlines, project-momentum]
     file_patterns: ["TODO.md", "*.todo"]
+
+  tracker-checkpoint:
+    class: SystemAgent
+    description: "Use when pipeline or DAG execution needs checkpoint persistence, state transition validation, or resume-after-failure support"
+    model: sonnet
+    memory: project
+    effort: medium
+    skills: [dag-orchestration, pipeline-guards]
+    tools: [Read, Write, Edit, Grep, Glob, Bash]
+    summary: "Pipeline checkpoint tracker for resumable DAG and pipeline state"
+    keywords: [pipeline, checkpoint, resume, dag, state, tracker]
+    file_patterns: ["/tmp/.codex-pipeline-*.json", "/tmp/.codex-dag-*.json"]
 
   scholastic:
     class: CoordinationAgent

--- a/templates/.claude/ontology/skills.yaml
+++ b/templates/.claude/ontology/skills.yaml
@@ -292,29 +292,29 @@ skills:
 
   memory-management:
     class: MemorySkill
-    description: "Memory persistence operations using claude-mem"
+    description: "Memory persistence operations using native memory plus omx-memory"
     user_invocable: false
     model_invocable: true
-    summary: "Provide memory persistence operations using claude-mem for session context"
-    keywords: [memory, claude-mem, persistence, session, context]
+    summary: "Provide memory persistence operations using native memory and approved searchable backends for session context"
+    keywords: [memory, omx-memory, persistence, session, context]
     rule_references: [R011]
 
   memory-recall:
     class: MemorySkill
-    description: "Search and recall memories from claude-mem"
+    description: "Search and recall memories from native memory plus omx-memory"
     user_invocable: true
     model_invocable: true
-    summary: "Search and recall relevant memories from claude-mem using semantic search"
-    keywords: [memory, recall, search, semantic, claude-mem]
+    summary: "Search and recall relevant memories from approved searchable backends"
+    keywords: [memory, recall, search, semantic, omx-memory]
     rule_references: [R011]
 
   memory-save:
     class: MemorySkill
-    description: "Save current session context to claude-mem"
+    description: "Save current session context to native memory plus omx-memory"
     user_invocable: true
     model_invocable: false
-    summary: "Save current session context to claude-mem for persistence across compaction"
-    keywords: [memory, save, session, context, claude-mem]
+    summary: "Save current session context to native memory and approved searchable backends"
+    keywords: [memory, save, session, context, omx-memory]
     rule_references: [R011]
 
   monitoring-setup:

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -5,7 +5,7 @@
 ## Architecture
 
 **Primary**: Native auto memory (`memory` field in agent frontmatter). No external dependencies.
-**Supplementary**: AgentMemory-compatible MCP or `omx-memory` for cross-session searchable recall; legacy `claude-mem` is fallback only.
+**Supplementary**: `omx-memory` or another AgentMemory-compatible MCP for cross-session searchable recall. Deprecated Chroma-based memory backends are not used in this project.
 
 Rule: If native auto memory can handle it, do NOT use a searchable MCP backend.
 
@@ -33,7 +33,7 @@ Agent frontmatter `memory: project|user|local` enables persistent memory:
 
 <!-- DETAIL: Backend Selection and Split-Brain Guard
 
-Prefer MCP tools named `memory_search`, `memory_add`, `observation_add`, and `memory_read`. Treat `chroma_query_documents`, `chroma_add_documents`, and `chroma_get_documents` as legacy `claude-mem` fallbacks.
+Prefer MCP tools named `memory_search`, `memory_add`, `observation_add`, and `memory_read`. Do not call deprecated Chroma memory tools or wrappers in this project.
 
 If both backend families are available, warn before writing. Dual-write is acceptable only during an explicit migration window; outside that window, choose one canonical searchable backend and record which one was used in the session summary.
 
@@ -332,8 +332,8 @@ User signals session end
        2. Update native auto-memory (MEMORY.md)
        3. Return formatted summary to orchestrator
   → Orchestrator performs MCP saves directly:
-       1. searchable memory save (AgentMemory-compatible or omx-memory, if available via ToolSearch)
-       2. legacy claude-mem save only when it is the configured fallback
+       1. searchable memory save (omx-memory or AgentMemory-compatible backend, if available via ToolSearch)
+       2. deprecated Chroma memory backends are skipped by project policy
        (episodic-memory auto-indexes after session — no action needed)
   → Orchestrator confirms to user
 ```
@@ -355,7 +355,6 @@ MCP tools (searchable memory backends, episodic-memory) are **orchestrator-scope
 |--------|-------|------|--------|----------|
 | Native auto-memory | sys-memory-keeper | Write | Update MEMORY.md with session learnings | Yes |
 | AgentMemory-compatible / omx-memory | Orchestrator | `memory_add` or `observation_add` | Save session summary with project, tasks, decisions | No (best-effort) |
-| legacy claude-mem | Orchestrator | `chroma_add_documents` or compatible save wrapper | Fallback searchable save when no preferred backend exists | No (best-effort) |
 | episodic-memory | Automatic | (auto-indexed) | No action needed — conversations are indexed automatically after session ends | N/A |
 -->
 

--- a/templates/.claude/skills/memory-management/SKILL.md
+++ b/templates/.claude/skills/memory-management/SKILL.md
@@ -7,15 +7,14 @@ user-invocable: false
 
 ## Purpose
 
-Provide memory persistence operations using native `MEMORY.md` first, then a searchable MCP backend for cross-session retrieval. Prefer an AgentMemory-compatible or `omx-memory` backend exposing `memory_search`, `memory_add`, and `observation_add`; use legacy `claude-mem` only as a fallback when that is the configured backend.
+Provide memory persistence operations using native `MEMORY.md` first, then a searchable MCP backend for cross-session retrieval. Prefer `omx-memory` or another AgentMemory-compatible backend exposing `memory_search`, `memory_add`, and `observation_add`. Deprecated Chroma memory backends are not used in this project.
 
 ## Backend Order
 
 1. Native auto-memory: compact durable facts in `MEMORY.md`.
-2. AgentMemory-compatible MCP or `omx-memory`: cross-session search, shared observations, and temporal recall.
-3. Legacy `claude-mem`: fallback only when the project still exposes Chroma tools.
+2. `omx-memory` or AgentMemory-compatible MCP: cross-session search, shared observations, and temporal recall.
 
-When both legacy `claude-mem` and an AgentMemory-compatible backend are active, warn about split-brain storage. Dual-write is allowed only during an explicit migration window.
+If multiple searchable backends are active, choose the configured canonical backend and record it in the session summary. Do not dual-write unless a migration window is explicitly documented.
 
 ## Operations
 
@@ -37,7 +36,6 @@ steps:
   3. Store in configured backend:
      - Prefer memory_add for session summaries
      - Use observation_add for atomic behavioral or project observations
-     - Legacy fallback: chroma_add_documents
      - Include metadata
 ```
 
@@ -53,7 +51,6 @@ steps:
      - Include date for temporal searches
   2. Search configured backend:
      - Prefer memory_search
-     - Legacy fallback: chroma_query_documents
      - Request top N results
   3. Format results:
      - Sort by relevance
@@ -68,7 +65,7 @@ operation: get
 description: Retrieve specific memory by ID
 steps:
   1. Prefer memory_read or memory_search by ID
-  2. Legacy fallback: chroma_get_documents with ID
+  2. Fall back to `memory_search` with the ID when direct read is unavailable
   3. Return full document content
 ```
 
@@ -80,8 +77,6 @@ steps:
 # Always include project name
 memory_search({ query: "my-project {search_terms}", limit: 8 })
 
-# Legacy fallback
-chroma_query_documents(["my-project {search_terms}"])
 
 # Examples:
 memory_search({ query: "my-project authentication flow", limit: 5 })
@@ -91,8 +86,8 @@ memory_search({ query: "my-project 2025-01-24 memory system", limit: 5 })
 ### Get by ID
 
 ```python
-# When you have a specific document ID and only legacy tools are available
-chroma_get_documents(ids=["document_id"])
+# When you have a specific document ID
+memory_read({ id: "document_id" })
 ```
 
 ## Document Format
@@ -219,7 +214,7 @@ recall_errors:
 
 | Capability | Searchable MCP | MemKraft |
 |-----------|-----------|----------|
-| Session persistence | ✅ (Chroma) | ✅ (Markdown) |
+| Session persistence | ✅ (approved searchable backend) | ✅ (Markdown) |
 | Entity tracking | ❌ | ✅ (person/org/concept) |
 | Source attribution | ❌ | ✅ (`[Source: who, when, how]`) |
 | Auto-maintenance | ❌ | ✅ (Dream Cycle) |

--- a/templates/.claude/skills/memory-recall/SKILL.md
+++ b/templates/.claude/skills/memory-recall/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 
 # Memory Recall Skill
 
-Search and recall relevant memories from native `MEMORY.md` plus the configured searchable MCP backend. Prefer AgentMemory-compatible or `omx-memory` tools (`memory_search`, `memory_read`); fall back to legacy `claude-mem` Chroma tools only when those are the configured backend.
+Search and recall relevant memories from native `MEMORY.md` plus the configured searchable MCP backend. Prefer `omx-memory` or AgentMemory-compatible tools (`memory_search`, `memory_read`). Deprecated Chroma memory backends are not used in this project.
 
 ## Parameters
 
@@ -35,7 +35,7 @@ Search and recall relevant memories from native `MEMORY.md` plus the configured 
 
 2. Search configured backend
    ├── Prefer memory_search
-   └── Legacy fallback: chroma_query_documents
+   └── Report backend unavailable when no approved memory MCP is configured
 
 3. Format results
    ├── Sort by relevance score

--- a/templates/.claude/skills/memory-save/SKILL.md
+++ b/templates/.claude/skills/memory-save/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 
 # Memory Save Skill
 
-Save current session context to native memory and the configured searchable MCP backend for persistence across context compaction. Prefer AgentMemory-compatible or `omx-memory` tools (`memory_add`, `observation_add`); fall back to legacy `claude-mem` only when that is the configured backend.
+Save current session context to native memory and the configured searchable MCP backend for persistence across context compaction. Prefer `omx-memory` or AgentMemory-compatible tools (`memory_add`, `observation_add`). Deprecated Chroma memory backends are not used in this project.
 
 ## Options
 
@@ -38,7 +38,7 @@ Save current session context to native memory and the configured searchable MCP 
 3. Store in configured backend
    ├── Prefer memory_add for summaries
    ├── Prefer observation_add for atomic learnings
-   └── Legacy fallback: chroma_add_documents
+   └── Skip searchable save when no approved backend is configured
 
 4. Report result
 ```

--- a/templates/.claude/skills/peer-messaging/SKILL.md
+++ b/templates/.claude/skills/peer-messaging/SKILL.md
@@ -17,7 +17,7 @@ Enables cross-session coordination between multiple GPT Codex + OMX sessions thr
 |-------|-----------|-------|----------|
 | Intra-session agents | Agent Teams (R018) | TeamCreate, SendMessage | Single session multi-agent collaboration |
 | Cross-session instances | claude-peers-mcp | list_peers, send_message | Multi-terminal/project real-time coordination |
-| Cross-session memory | claude-mem | save_memory, search | Async memory persistence |
+| Cross-session memory | omx-memory / AgentMemory-compatible MCP | memory_add, memory_search | Async memory persistence |
 
 > **Important**: R018's `SendMessage` and claude-peers-mcp's `send_message` are different tools with different scopes. Do not confuse them.
 
@@ -54,6 +54,6 @@ claude mcp add claude-peers-mcp -- npx claude-peers-mcp
 ## Integration
 
 - Works with R018 Agent Teams (different scope, complementary)
-- Works with claude-mem (async vs sync messaging)
+- Works with omx-memory or AgentMemory-compatible memory backends (async vs sync messaging)
 - Works with `omcodex:status` (peer discovery)
 - Broker runs on localhost:7899 (SQLite-backed)

--- a/templates/guides/agentmemory-migration/measure-step-zero.md
+++ b/templates/guides/agentmemory-migration/measure-step-zero.md
@@ -1,120 +1,20 @@
-# AgentMemory 마이그레이션 — 단계 0: MEASURE (사용 빈도 측정)
+# External Memory Migration — Retired Measurement Plan
 
-> **목적**: Phase 1 (COEXIST) 진입 전, claude-mem skill 실제 호출 빈도 데이터를 수집하여 가설 기반 자산 처리표를 검증한다.
-> **관련 이슈**: #1169 본문 조치 5
-> **참고 메모리**: `feedback_claude_mem_maintenance`, `project_sequencing_alpha_beta_gamma`
+> **Status**: Retired by #1426. The project no longer measures or operates the deprecated Chroma-based memory plugin.
+> **Current policy**: Native auto-memory is primary; `omx-memory` or an AgentMemory-compatible MCP may be used only as an approved searchable supplement.
 
----
+## Decision
 
-## 1. 목적
+The previous measurement-first migration plan is obsolete. The project no longer needs usage baselining for the deprecated plugin because that backend is no longer an accepted dependency.
 
-AgentMemory 마이그레이션 계획(`feedback_claude_mem_maintenance.md`)에는 12개 claude-mem skill의 처리 방향이 가설로 기재되어 있다. 특히 폐기 후보 5종(`make-plan`, `do`, `babysit`, `wowerpoint`, `knowledge-agent`, `pathfinder`)은 "미사용 또는 저빈도"라는 가정 위에 놓여 있다.
+## Replacement Workflow
 
-이 단계에서는 실측 데이터로 가설을 검증한다. 데이터 없이 Phase 1에 진입하면:
-- 실제로 자주 쓰이던 skill을 폐기하여 사용자 워크플로우가 깨질 수 있다.
-- 자산 처리표 재설계 비용이 Phase 2~3로 이월된다.
+1. Keep durable agent facts in native `MEMORY.md` files.
+2. Use `memory_search`, `memory_read`, `memory_add`, or `observation_add` only when an approved searchable backend is configured.
+3. Skip searchable persistence when no approved backend is available; do not install or invoke deprecated Chroma memory tooling.
+4. Record memory-backend decisions in R011 and the session summary.
 
----
+## Verification
 
-## 2. 실행 방법
-
-```bash
-# 기본 실행 (최근 7일, 리포트를 ~/.claude/measure-claude-mem-usage-YYYY-MM-DD.md 에 저장)
-bash scripts/measure-claude-mem-usage.sh
-
-# 최근 14일 스캔
-bash scripts/measure-claude-mem-usage.sh --days 14
-
-# 출력 경로 지정
-bash scripts/measure-claude-mem-usage.sh --output ~/Documents/claude-mem-usage.md
-
-# 헤더 없이 실행 (CI/파이프라인 삽입용)
-bash scripts/measure-claude-mem-usage.sh --quiet
-```
-
-### 스캔 대상 경로
-
-| 경로 | 설명 |
-|------|------|
-| `~/.claude-mem/archives/` | claude-mem MCP 아카이브 (`.jsonl`, `.json`) |
-| `~/.claude/projects/*/session-*.jsonl` | Claude Code 세션 로그 |
-
-둘 중 하나가 없어도 스크립트는 조용히 skip하고 나머지를 스캔한다.
-
----
-
-## 3. 1주 수집 계획
-
-| 시점 | 작업 |
-|------|------|
-| **Day 1** | 첫 측정 — 베이스라인 (`--days 7` 기준 기존 archives 기반) |
-| **Day 4** | 중간 측정 — 추이 확인 (`--days 4`) |
-| **Day 7** | 최종 측정 — 자산 처리표 재검토 및 Phase 1 GO/NO-GO 결정 |
-
-세 시점 모두 `--output` 경로를 달리 지정하여 비교 가능한 파일로 보관한다:
-
-```bash
-bash scripts/measure-claude-mem-usage.sh --output ~/.claude/claude-mem-day1.md
-bash scripts/measure-claude-mem-usage.sh --days 4 --output ~/.claude/claude-mem-day4.md
-bash scripts/measure-claude-mem-usage.sh --days 7 --output ~/.claude/claude-mem-day7.md
-```
-
----
-
-## 4. 해석 기준
-
-| 호출 수 | 신호 | 권장 조치 |
-|---------|------|----------|
-| **0** | 미사용 | 폐기 안전 — 1주 후 처리 결정 |
-| **1-3** | 가끔 사용 | wrapper 또는 대체 도구 매핑 필요 |
-| **4+** | 정기 사용 | 폐기 시 대체 도구 명확화 필수 |
-
-폐기 후보 5종 기준 예상:
-- `make-plan`, `do`, `babysit` → 0 예상 (native AgentMemory로 대체 완료)
-- `wowerpoint`, `knowledge-agent`, `pathfinder` → 0~1 예상 (특수 목적 skill)
-
-실측값이 예상과 다를 경우 자산 처리표를 수정한 후 Phase 1에 진입한다.
-
----
-
-## 5. 결과 활용
-
-### 5-1. #1169에 리포트 첨부
-
-```bash
-gh issue comment 1169 --body-file ~/.claude/claude-mem-day7.md
-```
-
-### 5-2. 자산 처리표 갱신
-
-`.claude/agent-memory/sys-memory-keeper/feedback_claude_mem_maintenance.md` 내 "처리 방향" 열을 실측값 기반으로 업데이트한다.
-
-### 5-3. Phase 1 GO/NO-GO 결정
-
-| 조건 | 결정 |
-|------|------|
-| 폐기 후보 모두 호출 수 0 | GO — Phase 1 진입 |
-| 폐기 후보 중 1개 이상 호출 수 1-3 | CONDITIONAL GO — 대체 도구 매핑 완료 후 진입 |
-| 폐기 후보 중 1개 이상 호출 수 4+ | NO-GO — 처리표 재설계 후 재측정 |
-
----
-
-## 6. 한계 및 주의사항
-
-| 항목 | 설명 |
-|------|------|
-| archives 미존재 | `~/.claude-mem/archives/` 없으면 카운트 0 (정상 — silent skip) |
-| 세션 로그 형식 변경 | Claude Code 업데이트로 `session-*.jsonl` 구조가 변경되면 grep 패턴 수정 필요 |
-| claude-mem MCP telemetry 미사용 | 외부 도구 의존 최소화 원칙에 따라 MCP 자체 지표는 사용하지 않음 |
-| grep 기반 측정 | 같은 파일에 skill 이름이 여러 줄 등장하면 복수 카운트됨 (과대 계산 가능성) |
-| macOS/Linux 호환 | `stat` 옵션 차이를 스크립트 내에서 자동 처리 (`-f %m` vs `-c %Y`) |
-
----
-
-## 7. 참고
-
-- **이슈**: [#1169](../../.github/ — `gh issue view 1169`)
-- **자산 처리표**: `.claude/agent-memory/sys-memory-keeper/feedback_claude_mem_maintenance.md`
-- **시퀀싱 메모리**: `.claude/agent-memory/mgr-creator/project_sequencing_alpha_beta_gamma.md` (또는 해당 메모리 파일)
-- **스크립트**: `scripts/measure-claude-mem-usage.sh`
-- **Phase 1 가이드**: `guides/agentmemory-migration/` (이 디렉토리에 추가 예정)
+- Repository search should not find active instructions for removed memory-plugin names or plugin-specific tool calls.
+- Memory skills must mention native memory and approved searchable MCP tools, not legacy plugin-specific commands.

--- a/templates/guides/agentmemory-migration/phase-1-coexist.md
+++ b/templates/guides/agentmemory-migration/phase-1-coexist.md
@@ -1,261 +1,27 @@
-# AgentMemory Migration — Phase 1: COEXIST (Week 1-2)
+# External Memory Migration — Retired COEXIST Plan
 
-> **상태**: 활성 — 2026-05-18 시작 (#1169)
-> **다음 단계**: Phase 2 SWITCH (measure 결과 후 GO/NO-GO 결정)
-> **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
+> **Status**: Retired by #1426. COEXIST mode is no longer supported for this project.
+> **Current policy**: Native auto-memory first; optional `omx-memory`/AgentMemory-compatible searchable backend only when already configured.
 
----
+## Why This Plan Is Retired
 
-## 1. 개요
+The old coexistence plan introduced dual-backend complexity and session-end save ambiguity. The current project decision removes that complexity: deprecated Chroma-based memory tooling is not installed, invoked, measured, or treated as a fallback.
 
-Phase 1 (COEXIST)는 claude-mem과 AgentMemory를 **동시에 운영**하는 단계입니다.
-이 단계에서는 어떤 destructive 변경도 발생하지 않습니다:
+## Active Policy
 
-- claude-mem 기존 Chroma 데이터 유지
-- 12 plugin skill 폐기 없음
-- 어댑터 코드 활성화 없음 (STUB 상태 유지)
-- 자산 처리표 적용 없음
+| Need | Supported path |
+| --- | --- |
+| Agent-local durable facts | Native `MEMORY.md` via agent frontmatter `memory:` |
+| Cross-session search | `omx-memory` or AgentMemory-compatible MCP exposing `memory_search`/`memory_read` |
+| Session summary save | `memory_add` or `observation_add` when an approved backend is configured |
+| No approved backend | Skip searchable save and continue; memory failures do not block the main task |
 
-목표는 1주간 실제 사용 데이터를 수집하고, AgentMemory 설치와 공존 운영에 익숙해지는 것입니다.
+## Session-End Checklist
 
-| 항목 | Phase 1 (COEXIST) | Phase 2 (SWITCH) |
-|------|-------------------|------------------|
-| claude-mem | 활성 (기존 운영) | 비활성화 예정 |
-| AgentMemory | 설치 후 병렬 활성 | 단독 운영 |
-| 데이터 마이그레이션 | 없음 | 선택적 (측정 후 결정) |
-| 어댑터 코드 | STUB 유지 | 활성화 |
-| 자산 처리표 | 적용 보류 | 사용자 검토 후 적용 |
+1. `sys-memory-keeper` updates native memory when a session-end signal exists.
+2. Orchestrator attempts approved searchable memory save only if the tool is available.
+3. Deprecated plugin-specific wrappers and Chroma tool calls remain unused.
 
----
+## Follow-up
 
-## 2. AgentMemory 설치
-
-> **R001 주의**: auto-install 금지. 아래 명령어를 사용자 로컬에서 수동으로 실행합니다.
-
-### 2-1. 패키지 설치
-
-```bash
-# 옵션 A: pip
-pip install agentmemory
-
-# 옵션 B: pipx (격리 환경 권장)
-pipx install agentmemory
-
-# 옵션 C: uvx (uv 사용 시)
-uvx agentmemory
-```
-
-### 2-2. MCP 서버 등록
-
-```bash
-# Claude Code CLI로 등록
-claude mcp add agentmemory -- agentmemory mcp
-
-# 또는 .mcp.json 수동 편집 (R001 auto-install 금지)
-# {
-#   "mcpServers": {
-#     "agentmemory": {
-#       "command": "agentmemory",
-#       "args": ["mcp"]
-#     }
-#   }
-# }
-```
-
-### 2-3. 등록 확인
-
-```bash
-claude mcp list
-# 출력에 agentmemory 서버가 표시되어야 합니다
-```
-
----
-
-## 3. COEXIST 정책
-
-Phase 1 기간 동안 두 backend는 다음 정책에 따라 공존합니다.
-
-### 3-1. 기본 운영 방식
-
-| 작업 | 우선 backend | 비고 |
-|------|-------------|------|
-| 기존 메모리 조회 | claude-mem | 기존 Chroma 데이터 유지 |
-| 신규 메모리 저장 | 둘 다 | COEXIST 기간 중 병렬 저장 권장 |
-| 세션 종료 시 저장 | 둘 다 | R011 Session-End Self-Check 참조 |
-
-### 3-2. 쿼리 병합 (memory-aggregator)
-
-두 backend에서 결과가 반환될 경우 `memory-aggregator` 스킬이 결과를 병합합니다:
-
-```
-claude-mem.search(query)    →  결과 A
-AgentMemory.search(query)   →  결과 B
-memory-aggregator           →  A + B 중복 제거 후 반환
-```
-
-`memory-aggregator` 스킬이 없는 경우, 두 결과를 순서대로 제시하고 사용자가 선택합니다.
-
-### 3-3. 충돌 방지 원칙
-
-- claude-mem 기존 데이터를 AgentMemory로 자동 복사하지 않음
-- 두 backend에 동일 키로 저장 시 별개 항목으로 취급
-- 강제 동기화 없음 — Phase 2에서 마이그레이션 여부 결정
-
----
-
-## 4. Dual-Backend 충돌 Advisory
-
-`.mcp.json`에 두 서버가 동시 등록된 상태를 감지하면 다음 advisory를 출력합니다.
-
-### 4-1. 감지 조건
-
-```
-.mcp.json 내 서버 목록:
-  - "claude-mem" (또는 관련 tool prefix)
-  - "agentmemory"
-  → 두 개 동시 존재 시 Phase 1 COEXIST 상태로 간주
-```
-
-### 4-2. Advisory 메시지
-
-```
-[Advisory] Dual memory backend detected (Phase 1 COEXIST)
-  - claude-mem: active (Chroma)
-  - agentmemory: active (SQLite)
-  현재 Phase 1 COEXIST 정책 적용 중 — 두 backend 병렬 운영
-  Phase 2 SWITCH 진입 전까지 두 backend 유지
-  가이드: guides/agentmemory-migration/phase-1-coexist.md
-```
-
-이 advisory는 경고가 아닙니다. Phase 1에서는 정상 상태입니다.
-
-### 4-3. 강제 선택 (사용자 명시 시)
-
-사용자가 명시적으로 "agentmemory만 사용" 또는 "claude-mem만 사용"을 요청하는 경우,
-해당 요청을 따르되 자산 처리표 적용 및 어댑터 활성화는 Phase 2 GO 결정 후 진행합니다.
-
----
-
-## 5. 사용자 행동 계획
-
-### 5-1. 1주 measure 루틴 (자동 트리거: 2026-05-25)
-
-`scripts/measure-claude-mem-usage.sh` 스크립트를 1주간 실행합니다:
-
-```bash
-# 수동 실행 (필요 시)
-bash scripts/measure-claude-mem-usage.sh
-
-# 결과는 .claude/outputs/sessions/ 에 저장됩니다
-```
-
-측정 항목:
-- 일별 호출 횟수 (claude-mem vs AgentMemory)
-- 응답 지연 (p50, p95)
-- 저장 성공/실패율
-- 메모리 용량 (Chroma vs SQLite)
-
-### 5-2. GO/NO-GO 결정 기준 (2026-05-25 예정)
-
-| 지표 | GO 조건 | NO-GO 조건 |
-|------|---------|------------|
-| 응답 지연 | AgentMemory ≤ claude-mem × 1.2 | AgentMemory > claude-mem × 2.0 |
-| 저장 성공률 | ≥ 99% | < 95% |
-| 운영 안정성 | 1주 무장애 | 크래시 또는 데이터 손실 |
-| 호환성 | 기존 메모리 포맷 읽기 가능 | 포맷 비호환으로 검색 실패 |
-
-### 5-3. 지금 할 수 있는 것
-
-- AgentMemory 설치 및 MCP 등록 (위 섹션 2 참조)
-- 신규 세션에서 AgentMemory로도 저장해보기 (실험적)
-- measure 스크립트 결과 관찰
-- 자산 처리표 (`guides/agentmemory-migration/asset-disposition.md`) 검토 준비
-
----
-
-## 6. Phase 2 진입 조건
-
-다음 조건이 모두 충족된 경우에만 Phase 2 (SWITCH)로 진행합니다.
-
-### 필수 조건
-
-- [ ] 1주 measure 결과 GO 판정 (5-2 기준 충족)
-- [ ] 자산 처리표 사용자 검토 완료 (12 plugin skill 처리 방향 결정)
-- [ ] 30분 롤백 절차 검증 완료
-
-### 롤백 절차 검증 (Phase 2 진입 전 필수)
-
-```bash
-# 1. Chroma 백업 생성
-cp -r ~/.local/share/claude-mem/chroma ~/.local/share/claude-mem/chroma.bak.$(date +%Y%m%d)
-
-# 2. 백업에서 복원 가능 여부 확인
-# (실제 복원 수행하지 않고 절차만 검증)
-ls -la ~/.local/share/claude-mem/chroma.bak.*
-
-# 3. AgentMemory SQLite 백업
-cp ~/.local/share/agentmemory/memories.db ~/.local/share/agentmemory/memories.db.bak.$(date +%Y%m%d)
-```
-
-롤백 소요 시간이 30분 이내임을 확인한 후 Phase 2 진행.
-
----
-
-## 7. 현 단계 한계 및 금지 사항
-
-### 7-1. STUB 상태 유지 (변경 금지)
-
-```
-packages/eval-core/src/adapters/agentmemory.ts  ← STUB, 활성화 금지
-packages/eval-core/src/db/schema.ts              ← 변경 금지
-```
-
-이 파일들은 Phase 2 GO 결정 후 별도 사이클에서 수정합니다.
-
-### 7-2. 자산 처리표 적용 보류
-
-12 plugin skill의 폐기/유지 결정은 measure 결과를 확인한 후 진행합니다:
-
-```
-.claude/skills/memory-*/  ← 폐기 여부 보류
-.claude/skills/claude-mem-*/  ← 폐기 여부 보류
-```
-
-### 7-3. 데이터 마이그레이션 금지
-
-Phase 1에서는 claude-mem Chroma 데이터를 AgentMemory SQLite로 이전하지 않습니다.
-이전은 Phase 2에서 사용자가 명시적으로 승인한 경우에만 진행합니다.
-
----
-
-## 8. R011과의 관계
-
-Phase 1 COEXIST 기간 중 R011 (SHOULD-memory-integration) 적용:
-
-| R011 항목 | COEXIST 수정 사항 |
-|-----------|-----------------|
-| Primary: Native auto memory | 변경 없음 |
-| Supplementary: claude-mem | 변경 없음 (계속 사용) |
-| Session-End Self-Check | claude-mem + AgentMemory 둘 다 저장 시도 |
-| Failure Policy | 둘 중 하나 실패해도 비차단 |
-
-세션 종료 시 자가 점검 (COEXIST 확장):
-
-```
-1. sys-memory-keeper가 MEMORY.md 갱신? → YES
-2. claude-mem 저장 시도? → YES (기존)
-3. AgentMemory 저장 시도? → YES (COEXIST 추가)
-모두 완료 후 사용자에게 확인
-```
-
----
-
-## 9. 참고
-
-- **이슈**: #1169 (AgentMemory 마이그레이션 계획)
-- **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
-- **R011**: `.claude/rules/SHOULD-memory-integration.md` (Dual-Backend Advisory 섹션)
-- **관련 기억**: [[project-sequencing-alpha-beta-gamma]]
-- **자산 처리표**: `guides/agentmemory-migration/asset-disposition.md` (Phase 2 전 검토 필요)
-- **measure 스크립트**: `scripts/measure-claude-mem-usage.sh`
-- **롤백 가이드**: #1169 본문 조치 4 (30분 롤백 절차)
+Keep this guide as a short historical pointer until downstream documentation no longer links to the old AgentMemory migration path.

--- a/templates/guides/index.yaml
+++ b/templates/guides/index.yaml
@@ -107,7 +107,7 @@ guides:
       type: internal
 
   - name: agentmemory-migration
-    description: AgentMemory migration measurement and COEXIST rollout guide for replacing legacy claude-mem
+    description: Retired external memory migration guide documenting native-memory-only policy and approved searchable backend usage
     path: ./agentmemory-migration/
     source:
       type: internal

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.5.7",
+  "version": "0.5.8",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-05-29T00:00:00.000Z",
+  "lastUpdated": "2026-05-30T00:00:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/wiki/agents/sys-memory-keeper.md
+++ b/wiki/agents/sys-memory-keeper.md
@@ -17,7 +17,7 @@ Session memory management specialist for saving/restoring context across compact
 
 `sys-memory-keeper` runs at session end to ensure context survives compaction. Its workflow: (1) collect session summary (tasks, decisions, open items), (2) extract user behavior patterns with confidence levels, (3) update native auto-memory MEMORY.md, (4) aggregate agent performance metrics, (5) update user model (skill preferences, correction patterns, expertise profile), and (6) return formatted summary to orchestrator for MCP persistence.
 
-Important: MCP tools (claude-mem, episodic-memory) are orchestrator-scoped — `sys-memory-keeper` only handles MEMORY.md; the orchestrator handles MCP saves directly after receiving the summary.
+Important: searchable MCP tools and episodic-memory are orchestrator-scoped — `sys-memory-keeper` only handles MEMORY.md; the orchestrator handles MCP saves directly after receiving the summary.
 
 Native MEMORY.md should remain an index, not a transcript. When session/release history approaches the loaded 200-line budget, keep recent active context inline, move older detail to topic/archive files, retain one-line summaries with archive pointers, and avoid deleting detail solely for line count.
 

--- a/wiki/architecture/skill-taxonomy.md
+++ b/wiki/architecture/skill-taxonomy.md
@@ -68,7 +68,7 @@ Multi-step process orchestration:
 
 ### Memory and Session Skills
 - `memory-management` — MEMORY.md operations
-- `memory-save` — claude-mem persistence
+- `memory-save` — native plus approved searchable memory persistence
 - `memory-recall` — memory search and retrieval
 
 ### Utility Skills

--- a/wiki/guides/agentmemory-migration.md
+++ b/wiki/guides/agentmemory-migration.md
@@ -1,38 +1,25 @@
 ---
-title: AgentMemory Migration Guide
+title: External Memory Migration Retired
 type: guide
 updated: 2026-05-29
 sources:
   - guides/agentmemory-migration/measure-step-zero.md
   - guides/agentmemory-migration/phase-1-coexist.md
 related:
-  - [[memory-management]]
-  - [[memory-recall]]
-  - [[memory-save]]
+  - [[memory-workflow]]
+  - [[R011]]
 ---
 
-# AgentMemory Migration Guide
+# External Memory Migration Retired
 
-Reference documentation for measuring claude-mem usage and running the first AgentMemory coexistence phase safely.
+Reference documentation for the retired AgentMemory coexistence path. The active policy is native auto-memory first with optional `omx-memory`/AgentMemory-compatible searchable backends only when configured.
 
 ## Overview
 
-This guide documents the staged migration path from claude-mem toward AgentMemory without destructive changes. It starts with a measurement step that validates actual skill usage, then defines a coexistence phase where both memory backends can operate while migration evidence is gathered.
+The old measurement and coexistence rollout has been retired. Do not install, measure, or invoke deprecated Chroma plugin memory tooling. Keep durable facts in native `MEMORY.md`; use `memory_search`, `memory_read`, `memory_add`, and `observation_add` only from approved searchable memory backends.
 
-## Key Topics
+## Use This Guide For
 
-- measuring claude-mem skill usage before making migration decisions
-- comparing usage frequency against disposal or replacement thresholds
-- installing AgentMemory as an optional parallel backend
-- keeping claude-mem data and skills intact during the COEXIST phase
-- deferring adapter activation and destructive asset handling until evidence supports a later switch
-
-## Relationships
-
-- **Related skills**: [[memory-management]], [[memory-recall]], [[memory-save]]
-- **See also**: [[memory-workflow]]
-
-## Sources
-
-- `guides/agentmemory-migration/measure-step-zero.md` — pre-migration measurement plan and interpretation thresholds
-- `guides/agentmemory-migration/phase-1-coexist.md` — week 1-2 coexistence policy and AgentMemory setup notes
+- understanding why the previous coexistence path is no longer active
+- confirming session-end memory saves use native memory and approved searchable tools
+- checking that rules, skills, and templates no longer document deprecated memory plugin fallback behavior

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -382,13 +382,13 @@ pages:
       summary: "Selective manifest-driven installation profiles for oh-my-customcodex assets."
     - file: skills/memory-management.md
       title: "Memory Management"
-      summary: "Memory persistence operations using claude-mem for session context survival."
+      summary: "Memory persistence operations using native memory plus approved searchable backends."
     - file: skills/memory-recall.md
       title: "Memory Recall"
-      summary: "Search and recall memories from claude-mem using semantic search."
+      summary: "Search and recall memories from native memory plus approved searchable backends."
     - file: skills/memory-save.md
       title: "Memory Save"
-      summary: "Save current session context to claude-mem for persistence across context compaction"
+      summary: "Save current session context to native memory plus approved searchable backends"
     - file: skills/model-escalation.md
       title: "Model Escalation"
       summary: "Advisory model escalation based on task outcome tracking."
@@ -674,7 +674,7 @@ pages:
       summary: "Agent Teams shutdown, cleanup, and tmux fallback recovery guidance for Codex/OMX sessions"
     - file: guides/agentmemory-migration.md
       title: "AgentMemory Migration Guide"
-      summary: "Measurement-first AgentMemory migration guidance for claude-mem usage baselining and coexistence rollout"
+      summary: "Retired external memory migration guidance for native-memory-first policy"
     - file: guides/agent-eval.md
       title: "Agent Eval"
       summary: "Correctness-first four-metric evaluation guidance for agent runs."

--- a/wiki/rules/r011.md
+++ b/wiki/rules/r011.md
@@ -1,89 +1,34 @@
 ---
-title: "R011: Memory Integration Rules"
+title: R011 Memory Integration
 type: rule
-updated: 2026-04-15
+updated: 2026-05-29
 sources:
   - .codex/rules/SHOULD-memory-integration.md
 related:
-  - [[r010]]
-  - [[r013]]
-  - [[r020]]
-  - [[r021]]
+  - [[memory-workflow]]
+  - [[sys-memory-keeper]]
 ---
 
-# R011: Memory Integration Rules
+# R011 Memory Integration
 
-Defines when and how agents persist knowledge across sessions using native auto-memory and the optional claude-mem MCP supplement.
+Defines when and how agents persist knowledge across sessions using native auto-memory and optional approved searchable MCP backends.
 
 ## Overview
 
-Native auto-memory (agent frontmatter `memory` field) is the primary persistence mechanism — it loads first 200 lines of MEMORY.md into the system prompt. claude-mem MCP is supplementary for cross-session search and temporal queries. Memory failures must never block the main task.
+Native auto-memory (agent frontmatter `memory` field) is the primary persistence mechanism — it loads the first 200 lines of MEMORY.md into the system prompt. `omx-memory` or another AgentMemory-compatible MCP can supplement it for cross-session search and temporal queries. Memory failures must never block the main task.
 
-## Priority
+## Key Rules
 
-**SHOULD** — Strong recommendation. Missing memory integration reduces cross-session effectiveness but does not block operations.
+- Consult memory before starting long-running work.
+- Save durable learnings after significant decisions or discoveries.
+- Use native MEMORY.md first.
+- Use approved searchable MCP tools only when configured.
+- Do not store secrets or duplicate AGENTS.md content.
 
-## Key Requirements
+## Responsibility Split
 
-**Memory scope:**
-
-| Scope | Location | Git Tracked |
-|-------|----------|-------------|
-| `user` | `~/.claude/agent-memory/<name>/` | No |
-| `project` | `.claude/agent-memory/<name>/` | Yes |
-| `local` | `.claude/agent-memory-local/<name>/` | No |
-
-**When to use claude-mem vs native:**
-
-| Scenario | Native | claude-mem |
-|----------|--------|------------|
-| Agent learns project patterns | Yes | — |
-| Search across sessions | — | Yes |
-| Temporal queries | — | Yes |
-| Cross-agent sharing | — | Yes |
-
-**Session-end auto-save responsibility split:**
-
-| Action | Owner |
-|--------|-------|
-| Session summary + native MEMORY.md update | `sys-memory-keeper` |
-| claude-mem MCP save | Orchestrator |
-| episodic-memory | Automatic (no action needed) |
-
-**Best practices:**
-- Keep MEMORY.md as an index; target roughly 100 active lines when accumulated session detail approaches the 200-line loaded budget
-- Archive older detail to topic files and keep one-line inline pointers
-- Do not store secrets or duplicate CLAUDE.md content
-- Memory write failures are non-blocking
-
-## Mid-Session Immediate Save
-
-Save memory IMMEDIATELY upon surprising discovery — do not defer to session end.
-
-| Trigger | Action | Rationale |
-|---------|--------|-----------|
-| Repeated pattern observed (2nd time) | Save `feedback_*.md` now | Pattern will recur within session |
-| Unexpected tool behavior / workaround | Save `feedback_*.md` now | Session state defense |
-| Subagent false-positive detected | Save `feedback_*.md` now | Prevent repeat in same session |
-| User correction / feedback | Save `feedback_*.md` now | Honor correction immediately |
-
-**Why Immediate (not session-end):** Session-end saves lose context: by the time the session ends, multiple discoveries have compounded and nuance is lost. Immediate saves preserve the exact trigger context that makes the memory actionable.
-
-**Anti-pattern**: "I'll batch all learnings at session end" — by then you'll have forgotten WHY each one mattered, and further violations may have occurred using the un-saved pattern.
-
-Extended rationale, session-end flow diagrams, and self-check examples are retained in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
-
-## Enforcement
-
-Prompt-based + Stop hook (soft block for session-end saves) per [[r021]].
-
-## Relationships
-
-- **Enforced by**: `sys-memory-keeper` agent, Stop hook
-- **Related rules**: [[r010]], [[r013]], [[r020]]
-- **Affects**: All agents with `memory` frontmatter, session-end workflows
-
-## Sources
-
-- `.codex/rules/SHOULD-memory-integration.md` — rule definition
-- Issue #869 — mid-session immediate save triggers (2026-04-15)
+| Task | Owner |
+| --- | --- |
+| MEMORY.md updates | sys-memory-keeper |
+| Searchable MCP save | Orchestrator |
+| Session-end check | Orchestrator |

--- a/wiki/skills/memory-management.md
+++ b/wiki/skills/memory-management.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Management
 type: skill
-updated: 2026-04-12
+updated: 2026-05-29
 sources:
   - .codex/skills/memory-management/SKILL.md
 related:
@@ -13,11 +13,11 @@ related:
 
 # Memory Management
 
-Memory persistence operations using claude-mem for session context survival.
+Memory persistence operations using native memory plus approved searchable MCP backends.
 
 ## Overview
 
-Provides save, recall, and get operations for claude-mem (Chroma-based vector store). Save collects session data (tasks, decisions, open items), formats with metadata, and stores via `chroma_add_documents`. Recall performs semantic search prefixed with project name. Get retrieves by document ID. Used internally by `sys-memory-keeper`. Always prefix queries with project name for accurate retrieval.
+Provides save, recall, and get operations for native `MEMORY.md` and optional `omx-memory`/AgentMemory-compatible backends. Save collects session data and stores it through `memory_add` or `observation_add` when available. Recall performs semantic search through `memory_search`/`memory_read` and always scopes queries by project. Deprecated Chroma plugin tooling is not used.
 
 ## Key Details
 

--- a/wiki/skills/memory-recall.md
+++ b/wiki/skills/memory-recall.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Recall
 type: skill
-updated: 2026-04-12
+updated: 2026-05-29
 sources:
   - .codex/skills/memory-recall/SKILL.md
 related:
@@ -13,11 +13,11 @@ related:
 
 # Memory Recall
 
-Search and recall memories from claude-mem using semantic search.
+Search and recall memories from native memory plus approved searchable MCP backends.
 
 ## Overview
 
-Searches claude-mem for relevant memories using semantic queries. Default bias favors recall over precision — cast a wide net, filter later. Supports `--recent` (latest memories), `--limit` (result count), `--date` (filter by date), and `--verbose` (full content). Always prefixes queries with the project name for proper scoping.
+Searches native `MEMORY.md` and configured `memory_search`/`memory_read` tools for relevant memories using semantic queries. Default bias favors recall over precision — cast a wide net, filter later. Supports `--recent`, `--limit`, `--date`, and `--verbose`. Always prefixes queries with the project name for proper scoping.
 
 ## Key Details
 

--- a/wiki/skills/memory-save.md
+++ b/wiki/skills/memory-save.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Save
 type: skill
-updated: 2026-04-12
+updated: 2026-05-29
 sources:
   - .codex/skills/memory-save/SKILL.md
 related:
@@ -13,11 +13,11 @@ related:
 
 # Memory Save
 
-Save current session context to claude-mem for persistence across context compaction.
+Save current session context to native memory plus an approved searchable backend when configured.
 
 ## Overview
 
-Collects the current session's completed tasks, decisions, and open items, then stores them in claude-mem with project metadata and optional user-specified tags. Supports `--tags`, `--include-code`, `--summary`, and `--verbose` options. Model invocation is disabled — runs as a direct skill execution. Returns the saved memory ID.
+Collects the current session's completed tasks, decisions, and open items, then stores them through native memory and optional `memory_add`/`observation_add` tools with project metadata and user-specified tags. Supports `--tags`, `--include-code`, `--summary`, and `--verbose` options. Model invocation is disabled — runs as a direct skill execution.
 
 ## Key Details
 

--- a/wiki/workflows/memory-workflow.md
+++ b/wiki/workflows/memory-workflow.md
@@ -1,10 +1,10 @@
 ---
 title: Memory Workflow
 type: workflow
-updated: 2026-04-12
+updated: 2026-05-29
 sources:
-  - .claude/rules/SHOULD-memory-integration.md
-  - CLAUDE.md
+  - .codex/rules/SHOULD-memory-integration.md
+  - AGENTS.md
 related:
   - [[wiki/rules/r011]]
   - [[wiki/agents/sys-memory-keeper]]
@@ -14,11 +14,11 @@ related:
 
 # Memory Workflow
 
-Memory in oh-my-customcodex operates on two levels: native auto-memory (MEMORY.md files per agent) for persistent behavioral patterns, and claude-mem MCP for cross-session searchable storage. Session-end auto-save is triggered by user signals and coordinated between `sys-memory-keeper` and the orchestrator.
+Memory in oh-my-customcodex operates on two levels: native auto-memory (`MEMORY.md` files per agent) for durable behavioral/project patterns, and an optional approved searchable MCP backend such as `omx-memory` for cross-session search. Session-end auto-save is triggered by user signals and coordinated between `sys-memory-keeper` and the orchestrator.
 
 ## Overview
 
-The rule is simple: **use native auto-memory first, claude-mem only when cross-session search is needed**. Native auto-memory is zero-dependency and always available; claude-mem requires the MCP server to be running.
+The rule is simple: **use native auto-memory first; use approved searchable memory only when it is already configured and needed**. Native auto-memory is zero-dependency and always available. Deprecated Chroma plugin memory tooling is not used.
 
 ## Native Auto-Memory
 
@@ -26,28 +26,26 @@ Agents opt into persistent memory via the `memory` frontmatter field:
 
 | Scope | Location | Git Tracked | Use Case |
 |-------|----------|-------------|---------|
-| `user` | `~/.claude/agent-memory/<name>/` | No | Personal preferences, user model |
-| `project` | `.claude/agent-memory/<name>/` | Yes | Project patterns, team knowledge |
-| `local` | `.claude/agent-memory-local/<name>/` | No | Local experiments, sensitive data |
+| `user` | `~/.codex/agent-memory/<name>/` | No | Personal preferences, user model |
+| `project` | `.codex/agent-memory/<name>/` | Yes | Project patterns, team knowledge |
+| `local` | `.codex/agent-memory-local/<name>/` | No | Local experiments, sensitive data |
 
 When enabled, the system loads the first 200 lines of `MEMORY.md` into the agent's system prompt at session start. Read/Write/Edit tools are auto-enabled for the memory directory.
 
 Best practices:
 - Keep MEMORY.md under 200 lines (only first 200 loaded)
 - Do not store sensitive data
-- Do not duplicate CLAUDE.md content
+- Do not duplicate AGENTS.md content
 - Consult memory before starting work; update after discovering new patterns
 
-## claude-mem MCP (Supplementary)
+## Approved Searchable Memory (Supplementary)
 
-Use claude-mem when:
-- Searching across sessions (temporal queries: "what did we decide last week?")
-- Cross-agent knowledge sharing
-- Episodic retrieval of past decisions
+Use an approved backend when:
+- searching across sessions
+- answering temporal queries
+- sharing cross-agent/project observations
 
-Install: `npm install -g claude-mem && claude-mem setup`. The MCP tool is `mcp__plugin_claude-mem_mcp-search__save_memory`.
-
-Note: MCP tools are **orchestrator-scoped** — subagents cannot access them. Only the orchestrator can save to claude-mem.
+Supported tool names are `memory_search`, `memory_read`, `memory_add`, and `observation_add`. If none are available, skip searchable persistence and continue.
 
 ## Session-End Auto-Save Workflow
 
@@ -66,46 +64,16 @@ User signals session end
         5. Return formatted summary to orchestrator
 
   → Orchestrator directly:
-        1. claude-mem save (if MCP available)
-        [episodic-memory auto-indexes — no action needed]
+        1. approved searchable memory save if backend tools are available
+        2. episodic indexing, if configured, remains automatic
 
   → Orchestrator confirms to user
 ```
 
-### Why Split?
-
-`sys-memory-keeper` has Write access to `.claude/agent-memory*/`. The orchestrator has access to MCP tools. Neither can do the other's job.
-
 ## Session-End Self-Check
 
-Before confirming session end to the user:
+1. Did `sys-memory-keeper` update native MEMORY.md when needed?
+2. Did the orchestrator attempt approved searchable memory save only if backend tools were available?
+3. Were memory failures reported as non-blocking?
 
-1. Did `sys-memory-keeper` update MEMORY.md? → YES required
-2. Did the orchestrator attempt claude-mem save? → YES required (failure is OK, skipping is not)
-3. Episodic-memory: no action needed (auto-indexed)
-
-## Failure Policy
-
-Memory saves are **non-blocking**. A claude-mem failure must not prevent session end. `sys-memory-keeper` failure is more critical (MEMORY.md is the primary persistence layer) but should still be logged and reported without blocking the user.
-
-## Memory vs Context Pruning
-
-Two distinct concepts:
-
-| Concept | Rule | Scope | Mechanism |
-|---------|------|-------|-----------|
-| Memory (behavioral) | R011 | Cross-session | MEMORY.md files |
-| Context pruning | R013 | Within-session | Drop/summarize retrieved chunks |
-
-Context pruning (ecomode) manages the input token budget during a task. Memory manages behavioral knowledge across sessions. See [[ecomode-and-context]] for context pruning details.
-
-## Relationships
-
-- **Depends on**: [[wiki/agents/sys-memory-keeper]] (MEMORY.md writes), [[wiki/rules/r011]]
-- **Used by**: Session end, `/memory-save`, `/memory-recall` commands
-- **See also**: [[ecomode-and-context]], [[wiki/rules/r013]]
-
-## Sources
-
-- `.claude/rules/SHOULD-memory-integration.md` — R011 full architecture and session-end self-check
-- `CLAUDE.md` — memory command descriptions, MCP server recommendations
+Memory saves are **non-blocking**. A searchable backend failure must not prevent session end.


### PR DESCRIPTION
## Summary
- Release v0.5.8 for the #1426 upstream port.
- Remove deprecated memory-plugin/Chroma backend guidance from agents, skills, R011, architecture docs, templates, guides, and wiki pages.
- Rename eval-core memory adapter API to the backend-neutral `fromSearchableMemory` and keep native memory plus approved searchable MCPs as the supported path.

## Verification
- `bun test packages/eval-core/src/__tests__/memory.test.ts tests/unit/core/context-optimization-guidance.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun test tests/unit/core/template-validation.test.ts`
- `bash .github/scripts/verify-wiki-sync.sh`
- `bun test ./.github/scripts/validate-docs.test.ts`
- `bun run test` (1835 pass, 0 fail)
- `bash .github/scripts/verify-version-sync.sh`
- Literal scan for removed backend identifiers returned no matches.

Closes #1426.