### PR TITLE
chore: prepare v0.5.10 auto-dev release

### DIFF
--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -22,6 +22,18 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.
 
+## Workflow Prompt and Verifier Ground Truth
+
+When a workflow delegates to `agent()` or equivalent subagent calls, complete the full prompt string before the call. Do not append guardrails, fact sheets, or critical constraints to the returned value after the agent has already run.
+
+Verifier lanes must receive the ground-truth sources needed to check cross-cutting claims, especially external URLs, cluster DNS/service names, credentials metadata, release facts, and infrastructure identifiers. A verifier cannot validate a fact that was never provided and is not present in the inspected source.
+
+## Read-Before-Characterize Diagnostics
+
+Do not characterize logs, traces, or diagnostics as an "error loop", "root cause", "flaky test", or similar conclusion before reading the relevant evidence. First capture the observed symptom, then inspect the authoritative log/output/source, then label the failure mode.
+
+For large or noisy logs, read a representative targeted slice before making permanent workflow, rule, template, or release-process changes. If the initial characterization changes after reading, report the correction explicitly.
+
 ## Diagnostic Hypothesis Verification
 
 When a failure diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until it is directly verified.

--- a/.codex/rules/MUST-orchestrator-coordination.md
+++ b/.codex/rules/MUST-orchestrator-coordination.md
@@ -116,6 +116,26 @@ Main Conversation (orchestrator)
 ```
 -->
 
+## Subagent Scope-Creep STOP Protocol
+
+Before delegating broad work, decompose it into narrow domains with explicit write/command boundaries. For example, do not hand one agent an open-ended "migrate + backfill + fix infra" prompt when the work can split into data migration, credential handling, tunnel/networking, dashboard verification, and release notes.
+
+The orchestrator must stop and redesign a delegated lane when any of these occur:
+
+1. The same subagent trips the security classifier twice on one assignment.
+2. The subagent requests or attempts privileged actions outside the delegated scope.
+3. The subagent chains from an approved action into a different credential, tunnel, namespace, pod, cluster, account, or shared service.
+4. The user corrects the agent for acting beyond the requested scope.
+
+Required STOP response:
+
+1. Stop that subagent lane; do not retry the same broad prompt.
+2. Preserve evidence and summarize the exact scope breach.
+3. Redesign the task into smaller bounded lanes with explicit allowed and forbidden actions.
+4. Reconfirm authorization before any irreversible shared-infrastructure or credential action.
+
+Thirteen repeated security trips or repeated privileged retries are an anti-pattern: after the second trip, continuing without redesign is a coordination failure.
+
 ## Common Violations
 
 Key violations to avoid (file writes, git commands, bundled operations — all must be delegated):

--- a/.codex/rules/MUST-permissions.md
+++ b/.codex/rules/MUST-permissions.md
@@ -13,6 +13,12 @@
 | 5: Conditional | TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop, TaskOutput | Available when Agent Teams enabled |
 | 6: MCP | ListMcpResourcesTool, ReadMcpResourceTool, CronCreate, CronDelete, CronList, RemoteTrigger | MCP/extension tools, available when servers configured |
 
+## Privileged Scope Boundaries
+
+- Approval for one privileged action does not authorize follow-on privileged chaining. A request to remove one tunnel, secret, pod, namespace object, or credential does not authorize creating a replacement, rotating credentials, deleting adjacent resources, or executing inside production workloads.
+- Treat credential-store reads as sensitive even when the tool is otherwise available. Never paste raw secret values or full credential-store transcripts into chat; use redacted names, fingerprints, or boolean verification results.
+- Reconfirm scope before irreversible shared infrastructure or credential actions, including production pod exec/write, Kubernetes secret mutation, public tunnel creation, credential rotation, and shared namespace deletion.
+
 ## File Access
 
 | Operation | Allowed | Prohibited |

--- a/.codex/rules/MUST-safety.md
+++ b/.codex/rules/MUST-safety.md
@@ -11,6 +11,13 @@
 | Commands | `rm -rf /` or broad deletes, shutdown/restart, sudo/su, network config changes |
 | External | Access URLs without approval, send user data externally, download/execute unknown scripts |
 
+## Credential and Shared-Infrastructure Guardrails
+
+- Do not dump credential-store contents, `.env` files, OAuth material, kube secrets, or secret-manager values into transcripts, logs, issue bodies, or summaries. Report only the minimum redacted key names or verification status required for the task.
+- Do not rotate, delete, recreate, or replace credentials unless the user explicitly requested that exact credential action.
+- Before irreversible action on shared infrastructure or credentials, reconfirm the target, namespace/account/project, requested scope, rollback path, and user authorization.
+- Stop instead of chaining privileged actions when the next step would affect a different credential, tunnel, namespace, pod, cluster, account, or shared service than the user requested.
+
 ## Required Before Destructive Operations
 
 Verify target, assess impact scope, check recoverability, get user approval.

--- a/.codex/rules/SHOULD-interaction.md
+++ b/.codex/rules/SHOULD-interaction.md
@@ -27,6 +27,17 @@
 | Ambiguous | `[Confirm] Understood "{request}" as {interpretation}. Proceed?` |
 | Risky | `[Warning] This action has {risk}. Continue? Yes: {action} / No: Cancel` |
 
+## External Product UI Claims
+
+Avoid presenting unverified external product UI field names, button labels, or step-by-step paths as fact. Product consoles change frequently and screenshots/docs may be stale.
+
+When UI evidence is not directly verified:
+
+- State that the UI path is an inference or may vary by account/version.
+- Prefer stable facts already observed in the environment: URLs, config keys, resource IDs, CLI output, or API results.
+- Ask the user to map those verified values into the current UI instead of inventing missing fields.
+- If exact UI steps are required, verify against current official docs or a live screenshot before giving precise labels.
+
 ## Multiple Tasks
 
 - Dependent: Sequential

--- a/.codex/skills/skill-extractor/SKILL.md
+++ b/.codex/skills/skill-extractor/SKILL.md
@@ -1,150 +1,239 @@
 ---
 name: skill-extractor
-description: Analyze task trajectories to propose reusable SKILL.md candidates from successful patterns
+description: Analyze recurring task trajectories and evidence to propose reusable workflow packaging candidates
 scope: core
 user-invocable: true
-argument-hint: "[--threshold <n>] [--dry-run]"
-version: 1.0.0
+argument-hint: "[--threshold <n>] [--dry-run] [--all]"
+version: 1.1.0
 ---
 
 # Skill Extractor
 
-Analyze completed task outcomes to identify reusable patterns and propose new SKILL.md candidates. Inspired by Hermes Agent's self-learning skill extraction — adapted for oh-my-customcodex's compilation metaphor.
+Analyze completed task outcomes and recent work evidence to identify recurring workflows that may deserve reusable packaging. Inspired by Hermes Agent's self-learning skill extraction — adapted for oh-my-customcodex's compilation metaphor.
 
 ## Philosophy
 
-In the compilation metaphor: task trajectories are runtime traces, and extracted skills are new source code. This skill turns successful execution patterns into reusable knowledge artifacts.
+In the compilation metaphor: task trajectories are runtime traces, and extracted skills are new source code. This skill turns repeated, successful execution patterns into reusable knowledge artifacts only after evidence review and user approval.
 
 ```
-Runtime traces (task outcomes) → Pattern analysis → SKILL.md proposal → User approval → mgr-creator
+Runtime traces + memory + rollout summaries + inventory → Evidence-first shortlist → Packaging recommendation → User approval → mgr-creator or automation owner
 ```
 
 ## Usage
 
 ```
-/skill-extractor                    # Analyze current session outcomes
-/skill-extractor --threshold 2      # Lower success threshold (default: 3)
-/skill-extractor --dry-run          # Preview proposals without writing
+/skill-extractor                    # Analyze current session outcomes and local evidence
+/skill-extractor --threshold 2      # Lower recurring evidence threshold (default: 3)
+/skill-extractor --dry-run          # Preview shortlist without writing
+/skill-extractor --all              # Include broader session and memory history when available
 ```
 
 ## Options
 
 ```
---threshold, -t   Minimum success count for pattern qualification (default: 3)
---dry-run, -d     Preview proposals to stdout only, no file writes
---all             Include all sessions (not just current, requires task outcome history)
+--threshold, -t   Minimum evidence count for recurring-workflow qualification (default: 3)
+--dry-run, -d     Preview candidates to stdout only, no file writes
+--all             Include all sessions and available memory/history, not just current session
 ```
 
 ## Workflow
 
-### Phase 1: Collect Task Outcomes
+### Phase 1: Evidence-First Candidate Discovery
 
-Read task outcome data from the session:
+Collect candidates from concrete, dated evidence before proposing any packageable artifact. Prefer local evidence first; use optional integrations only when available.
 
-```bash
-# Current session outcomes (from task-outcome-recorder hook)
-OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
-```
+Required and recommended sources:
 
-If file doesn't exist or is empty: report "No task outcomes recorded in this session." and stop.
+1. **Recent session outcomes** from the task-outcome-recorder hook:
 
-Parse JSONL entries. Each entry has:
+   ```bash
+   # Current session outcomes
+   OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
+   ```
+
+2. **Recent sessions and memory**: relevant `claude-mem`/OMX memory observations, session checkpoints, `.omx/notepad.md`, and `.omx/state/**` summaries when present.
+3. **Rollout or release summaries**: changelog entries, release notes, PR summaries, compatibility notes, and post-release follow-up reports that show repeated manual steps.
+4. **Optional Chronicle/history integrations**: Chronicle, shell history, or external task timeline summaries if installed and explicitly available. Do not fail when absent.
+5. **Existing inventory**: compare against `.codex/skills/*/SKILL.md`, `.codex/agents/*`, `templates/.claude/skills/*/SKILL.md`, and generated wiki pages to avoid duplicate or overlapping packaging.
+
+If no evidence source exists or all sources are empty: report "No recurring workflow evidence found." and stop without creating anything.
+
+Parse JSONL outcome entries when available. Each entry has:
+
 ```json
 {"agent_type": "lang-typescript-expert", "skill": "typescript-best-practices", "description": "Fix type error in auth module", "outcome": "success", "model": "sonnet", "timestamp": "2026-04-05T09:30:00Z", "duration_ms": 15000}
 ```
 
-### Phase 2: Pattern Detection
-
-Group outcomes by `(agent_type, skill)` tuple:
-
-```
-Pattern: (lang-typescript-expert, typescript-best-practices)
-  → success: 5, failure: 1, total: 6
-  → success_rate: 0.83
-  → descriptions: ["Fix type error...", "Refactor module...", ...]
-```
-
-Filter qualifying patterns:
-- `success_count >= threshold` (default: 3)
-- `success_rate >= 0.8`
-- Not already an existing skill (check `.codex/skills/*/SKILL.md`)
-
-### Phase 3: Generate Proposals
-
-For each qualifying pattern, generate a SKILL.md proposal:
+For prose evidence, extract only dated or source-attributed observations, for example:
 
 ```markdown
-## Proposal: {proposed-skill-name}
+- 2026-05-24, release PR summary: repeated manual wiki parity fixes after adding new guides.
+- 2026-05-22, memory #29064: sync-upstream-release-issues dry-run needed repeated validation after issue-reference parsing changes.
+```
 
-**Source Pattern**: {agent_type} + {skill} ({success_count} successes, {success_rate}% rate)
-**Confidence**: {low|medium|high} (based on count and rate)
+### Phase 2: Recurring Workflow Detection
 
-### Proposed SKILL.md
+Group evidence by the workflow being repeated, not only by `(agent_type, skill)` tuple. A workflow can span agents, commands, checklist steps, or release procedures.
+
+```
+Workflow: release-docs-parity-check
+  → evidence_count: 4 dated occurrences
+  → successful_reuse: 3
+  → failure_or_friction: 1
+  → sources: [memory:29148, PR summary, changelog, wiki staleness check]
+  → existing_overlap: wiki, update-docs, sauron-watch
+```
+
+Filter qualifying candidates:
+
+- `evidence_count >= threshold` (default: 3), or two strong dated incidents plus high user impact.
+- Repeated manual judgment or sequencing exists; one-off bugs are not enough.
+- Evidence includes dates or source names, not vague recollection.
+- Candidate is not already fully covered by an existing skill, custom subagent, automation, or documented checklist.
+- R006 separation of concerns can be preserved: package one coherent responsibility, not a catch-all meta-agent.
+
+### Phase 3: Build the Shortlist
+
+For each candidate, create a shortlist entry before generating any SKILL.md proposal. Every entry must include these fields:
+
+```markdown
+## Candidate: {candidate-name}
+
+**Workflow**: {one-sentence recurring workflow description}
+**Evidence / Dates**:
+- {date or source}: {specific repeated task, success, failure, or friction point}
+- {date or source}: {specific repeated task, success, failure, or friction point}
+**Frequency / Confidence**: {count and low|medium|high confidence with reason}
+**Recommended Form**: {Skill | Custom subagent | Automation | Skip}
+**Duplicate / Overlap Check**: {existing skills, agents, hooks, scripts, docs, or "none found"}
+**Why**: {why packaging would reduce repeated manual work or improve safety}
+**Why Not**: {risks, overlap, insufficient evidence, or why a lighter form may be better}
+```
+
+Recommended-form guidance:
+
+| Form | Use When | Do Not Use When |
+|------|----------|-----------------|
+| Skill | A repeatable human-invoked workflow/checklist improves outcomes and needs judgment | Existing skill already covers it or it is fully automatable |
+| Custom subagent | A specialized role with stable responsibilities, tools, and boundaries is recurring | It is just a checklist or would violate R006 by mixing unrelated duties |
+| Automation | The steps are deterministic, cheap to validate, and safe to run without judgment | User approval, external credentials, or destructive actions are required |
+| Skip | Evidence is weak, duplicated, obsolete, or one-off | There is enough dated evidence and clear reuse value |
+
+### Phase 4: Generate Packaging Proposals
+
+Only for shortlist entries whose recommended form is `Skill` or `Custom subagent`, generate a proposal. For `Automation`, recommend the script/hook/check location and required guardrails. For `Skip`, explain the evidence gap.
+
+```markdown
+## Proposal: {proposed-package-name}
+
+**Recommended Form**: {Skill | Custom subagent | Automation | Skip}
+**Source Workflow**: {workflow} ({evidence_count} evidence points, {confidence})
+**Evidence Window**: {earliest date/source} → {latest date/source}
+**Confidence**: {low|medium|high} (based on frequency, recency, and outcome consistency)
+
+### Proposed Artifact
 
 name: {proposed-name}
-description: {inferred from common description patterns}
+description: {inferred from recurring workflow evidence}
 scope: core
-user-invocable: false
+user-invocable: {true|false}
 
 ### Rationale
-{Why this pattern should be extracted as a skill — based on frequency and success rate}
+{Why this workflow should be packaged — based on dates, frequency, success/failure pattern, and user impact}
 
-### Overlap Check
-{List any existing skills with >50% keyword overlap}
+### Duplicate / Overlap Check
+{List existing skills, agents, hooks, scripts, or wiki docs with meaningful overlap and how this proposal differs}
+
+### Guardrails
+{User approval, R006 responsibility boundary, R020 verification requirement, dry-run behavior, and non-destructive defaults}
 ```
 
 **Confidence scoring**:
-| Successes | Rate | Confidence |
-|-----------|------|------------|
-| 3-5 | >= 0.8 | low |
-| 6-10 | >= 0.85 | medium |
-| 10+ | >= 0.9 | high |
 
-### Phase 4: Present to User
+| Evidence | Recency / Outcome | Confidence |
+|----------|-------------------|------------|
+| 2 strong incidents or 3 weak signals | Mixed outcomes or older than 90 days | low |
+| 3-5 dated occurrences | Mostly successful or repeated friction in last 90 days | medium |
+| 6+ dated occurrences | Clear recurrence, recent evidence, and stable success criteria | high |
 
-Display proposals in ranked order (highest confidence first):
+### Phase 5: Present to User
 
+Display the shortlist in ranked order (highest confidence and lowest overlap first):
+
+```text
+[skill-extractor] {N} recurring workflow candidates detected
+
+  1. [high] release-docs-parity-check
+     Workflow: Validate guide/wiki/template parity before release PRs
+     Evidence: 4 dated sources, latest 2026-05-24
+     Recommended form: Skill
+     Overlap: update-docs, sauron-watch (partial)
+     Why: Prevents repeated CI wiki-staleness failures
+     Why not: May be redundant if update-docs grows the same gate
+
+  2. [medium] upstream-release-issue-validation
+     Workflow: Validate upstream issue references before sync workflows
+     Evidence: 3 dated sources, latest 2026-05-22
+     Recommended form: Automation
+     Overlap: sync-upstream-release-issues script
+     Why: Deterministic validation prevents repeated 404 workflow failures
+     Why not: Better as script/test than human-invoked skill
+
+Select [1-N] to create, "all" to create all approved packageable items, or "skip" to cancel:
 ```
-[skill-extractor] {N} skill candidates detected
 
-  1. [high] proposed-skill-name
-     Source: {agent_type} + {skill} (12 successes, 92%)
-     Description: {inferred description}
+### Phase 6: Create Artifact (on approval only)
 
-  2. [medium] another-skill-name
-     Source: {agent_type} + {skill} (7 successes, 86%)
-     Description: {inferred description}
+Never create or modify reusable artifacts without explicit user approval after showing the shortlist.
 
-Select [1-N] to create, "all" to create all, or "skip" to cancel:
-```
+On approval:
 
-### Phase 5: Create Skill (on approval)
+- `Skill`: delegate to `mgr-creator` with the full shortlist entry, proposal, overlap warnings, and guardrails.
+- `Custom subagent`: delegate to `mgr-creator` with the R006 responsibility boundary and required related skills/guides.
+- `Automation`: hand off a scoped implementation recommendation; require a dry-run/default-safe mode and R020 verification evidence.
+- `Skip`: record the decision only if the user asks to save it.
 
-Delegate to mgr-creator with the proposal context:
-- Proposed name and description
-- Source pattern data
-- Confidence level
-- Any overlap warnings
+mgr-creator handles: SKILL.md creation, template sync, ontology registration, and generated docs parity.
 
-mgr-creator handles: SKILL.md creation, template sync, ontology registration.
+## Recurring-Workflow Packaging Checklist
+
+Before recommending packaging, verify:
+
+- [ ] Evidence is source-attributed and includes dates or stable identifiers.
+- [ ] Frequency meets `--threshold` or has two strong high-impact incidents.
+- [ ] The workflow has stable trigger conditions and a clear stop condition.
+- [ ] Existing skills, agents, hooks, scripts, and wiki docs were checked for duplicate or partial coverage.
+- [ ] Recommended form is justified as `Skill`, `Custom subagent`, `Automation`, or `Skip`.
+- [ ] `Why` and `Why Not` both name concrete evidence.
+- [ ] R006 is preserved: one coherent responsibility and clear boundaries.
+- [ ] R020 is preserved: proposal includes verification evidence or a test/check path.
+- [ ] User approval is required before any artifact creation or mutation.
+- [ ] Dry-run/no-write behavior remains available for review-only usage.
 
 ## Integration
 
 | System | How |
 |--------|-----|
-| task-outcome-recorder | Reads JSONL outcomes as input data |
-| feedback-collector | Complementary: feedback-collector extracts failure patterns, skill-extractor extracts success patterns |
-| mgr-creator | Delegated skill creation on user approval |
+| task-outcome-recorder | Reads JSONL outcomes as one input data source |
+| memory-management / memory-recall | Supplies dated recurring-workflow evidence when available |
+| rollout and release summaries | Surface repeated manual release, docs, and compatibility procedures |
+| optional Chronicle/history | Adds timeline evidence when installed; absence is non-fatal |
+| existing skills and agents inventory | Prevents duplicate skills, subagents, or automations |
+| feedback-collector | Complementary: feedback-collector extracts failure patterns, skill-extractor extracts recurring packageable workflows |
+| mgr-creator | Delegated skill or subagent creation on user approval |
 | skills-sh-search | Check agentskills.io for existing equivalent before creating |
-| R011 (memory) | User Model tracks extraction decisions in Override Decisions |
+| R006 | Enforces coherent responsibility boundaries for custom subagents and skills |
+| R011 (memory) | User Model tracks extraction decisions in Override Decisions when explicitly saved |
+| R020 | Requires verification evidence before completion claims |
 
 ## Hook Integration
 
 The `skill-extractor-analyzer.sh` Stop hook provides a lightweight pre-analysis:
+
 - Reads task outcomes file
-- Counts qualifying patterns
+- Counts qualifying recurring patterns
 - Emits advisory stderr message if candidates found
-- Does NOT create skills (that requires user approval via the skill)
+- Does NOT create skills, subagents, or automation (that requires user approval via the skill)
 
 ## Compatibility Artifact Protocol
 
@@ -152,8 +241,11 @@ Sensitive-path compatibility note: when delegated work touches `.claude/outputs/
 
 ## Safety
 
-- **User approval required**: Never auto-creates skills
-- **Overlap check**: Prevents duplicating existing skills
+- **User approval required**: Never auto-creates skills, subagents, or automation
+- **Evidence-first**: Never recommends packaging from vague memory or unverified anecdotes
+- **Overlap check**: Prevents duplicating existing skills, agents, hooks, scripts, or docs
+- **R006 guardrail**: Rejects catch-all artifacts with mixed responsibilities
+- **R020 guardrail**: Every approved artifact must include a verification path before completion is claimed
 - **Dry-run mode**: Preview without side effects
 - **Advisory hook**: Stop hook is advisory-only (exit 0)
-- **Confidence transparency**: All proposals show confidence scores
+- **Confidence transparency**: All shortlist entries and proposals show confidence scores and evidence dates

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,12 +1,12 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.9",
-  "generatedAt": "2026-05-30T05:02:20.677Z",
-  "templateVersion": "0.5.9",
+  "generatorVersion": "0.5.10",
+  "generatedAt": "2026-05-31T23:43:14.798Z",
+  "templateVersion": "0.5.10",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
-      "templateHash": "ab7e8d06735652b3a3b19473162bc2bdefc65676deed91e0420f919cc5496fe9",
-      "size": 2796,
+      "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
+      "size": 3466,
       "component": "rules"
     },
     ".codex/rules/SHOULD-hud-statusline.md": {
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "b37c80b32e9e3912e76b31134408c3de002c15512aa5c36e077d2cdd2ba6707f",
-      "size": 24585,
+      "templateHash": "b6851016a5f7e741e4de8aaee074fc74c126d938792f5f992d58e8ac80884d7d",
+      "size": 25898,
       "component": "rules"
     },
     ".codex/rules/MUST-intent-transparency.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-permissions.md": {
-      "templateHash": "94f78cbedf41abc2929f0d6e47534f960a4a1da6e333b76a9a1b1511d7e5dd64",
-      "size": 2483,
+      "templateHash": "43064c0f6154354c83b6764ff5f20f6b0498f4bd0c9579e3b8dfdc58a3c82dd5",
+      "size": 3272,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ontology-rag-routing.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-safety.md": {
-      "templateHash": "30931267fa33c7f6c274102cef730cc0669a66dc533a8a9705a4da14c248d5af",
-      "size": 2045,
+      "templateHash": "8c0600348ab83eb536b4d5911834429b53dc71e123248f046a0188696a755cd1",
+      "size": 2836,
       "component": "rules"
     },
     ".codex/rules/MUST-tool-identification.md": {
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "4f7266c62ec564a933043811b2c6cd3db98ce873c5f498772e0e45b68e113f32",
-      "size": 10400,
+      "templateHash": "5dc0f871fe19fa3721f861a968a2cc768920364ad41ea13c0546ea135bd87b4d",
+      "size": 11543,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {
@@ -680,8 +680,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "b73cf8acdd71a498d8d39d6681ed29a15159543e4b3f59709861eb03212db000",
-      "size": 23915,
+      "templateHash": "a9d4ed24068ad42aeef56dfc685aa65250c9bae7cd34fb0eba77913da82306d8",
+      "size": 26670,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-06-01
+
+### Added
+- Record the #1434 upstream `Yeachan-Heo/oh-my-codex` v0.18.7 no-op compatibility review and its no-source-port disposition.
+- Add #1435 skill-extractor recurring-workflow packaging checklist coverage across source, templates, and wiki documentation.
+- Document Claude Code v2.1.157 and v2.1.158 compatibility notes for #1436 and #1437.
+
+### Changed
+- Harden safety, orchestration, and rule guidance for #1438 across the packaged agent coordination surface.
+
 ## [0.5.9] - 2026-05-30
 
 ### Changed

--- a/docs/superpowers/plans/2026-06-01-v0.5.10-release.md
+++ b/docs/superpowers/plans/2026-06-01-v0.5.10-release.md
@@ -1,0 +1,64 @@
+# v0.5.10 Auto-Dev Release Plan
+
+Date: 2026-06-01
+Branch: `release/v0.5.10-auto-dev`
+Sources: release tracking issues #1434, #1435, #1436, #1437, and #1438.
+
+**Expected scope**: S | **Issues**: 5 | **Release type**: compatibility notes, packaging checklist, and safety/orchestration hardening
+
+| # | Priority | Size | Title | Dependencies | Decision |
+|---|----------|------|-------|--------------|----------|
+| #1434 | P2 | XS | Review `Yeachan-Heo/oh-my-codex` v0.18.7 runtime reliability release | None | No source port required; record compatibility disposition |
+| #1435 | P1 | S | Package skill-extractor recurring-workflow checklist | None | Add checklist guidance to source, template, and wiki surfaces |
+| #1436 | P2 | XS | Record Claude Code v2.1.157 compatibility notes | None | Document compatibility impact |
+| #1437 | P2 | XS | Record Claude Code v2.1.158 compatibility notes | None | Document compatibility impact |
+| #1438 | P1 | S | Harden safety, orchestration, and rule guidance | #1435-#1437 context | Update rule/guidance surfaces without broadening release scope |
+
+## Scope Summary
+
+v0.5.10 consolidates the current auto-dev branch work into one release unit:
+
+- #1434 records an upstream `oh-my-codex` v0.18.7 runtime reliability review as a no-op compatibility decision for this package.
+- #1435 packages the skill-extractor recurring-workflow checklist so repeated workflow lessons are captured in source, templates, and wiki documentation.
+- #1436 and #1437 add Claude Code v2.1.157/v2.1.158 compatibility notes.
+- #1438 hardens safety, orchestration, permission, interaction, and completion-verification guidance for agent coordination.
+
+## Upstream Review: #1434 / oh-my-codex v0.18.7
+
+Upstream v0.18.7 is a runtime reliability patch focused on:
+
+- duplicate HUD pane prevention and HUD owner preservation during native tmux session replacement;
+- question renderer and worker Stop-hook duplicate suppression;
+- stricter Autopilot completion evidence and ralplan planning-only boundaries;
+- team/MCP/tmux routing robustness, including Hermes MCP bridge pane routing and detached history growth limits;
+- focused regression coverage for the changed HUD/tmux/runtime surfaces.
+
+### Codex-Port Decision
+
+No code or guide/rule port is required for #1434 in this repo.
+
+Rationale:
+
+- The release-critical changes are upstream OMX runtime/tmux/HUD implementation details, not behavior owned by this package's source templates or guides.
+- Existing project guidance already covers the portable boundaries that matter here: `omx question` usage and Stop-hook blocking in AGENTS runtime guidance, ralplan planning-only gating, Agent Teams/R018 routing robustness, MCP fallback guidance, and HUD/statusline duplicate-avoidance guidance.
+- Adding local runtime stubs or duplicating upstream implementation notes would imply support for panes/session behavior this repo does not implement directly.
+
+## Required Action
+
+- Keep #1434 documented as reviewed/deferred with no source changes.
+- Include #1435 recurring-workflow checklist packaging in the release notes.
+- Include #1436/#1437 Claude Code v2.1.157/v2.1.158 compatibility documentation in the release notes.
+- Include #1438 safety/orchestration/rules hardening in the release notes.
+- Bump package, template manifest, and Codex lock metadata from 0.5.9 to 0.5.10.
+
+## Verification Gates
+
+- Confirm `CHANGELOG.md` has a `## [0.5.10] - 2026-06-01` section covering #1434-#1438.
+- Confirm release metadata in `package.json`, `templates/manifest.json`, and `.omcodex.lock.json` is 0.5.10.
+- Confirm `.omcustom.lock.json` has no 0.5.9 release metadata requiring a version-only update.
+- Read this release plan after writing to confirm the branch and issue scope are correct.
+
+## Notes
+
+- The term `Stop-hook` in #1434 is an upstream release-note topic, not a user cancellation request for this branch task.
+- `.omcustom.lock.json` retains its legacy 0.99.1 generator/template metadata because it does not contain 0.5.9 release metadata.

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,30 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.158
+
+Published: 2026-05-30.
+
+Source: upstream oh-my-customcode #1264, Codex port #1436.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Auto mode is available on Bedrock, Vertex, and Foundry for Opus 4.7 and Opus 4.8 via `CLAUDE_CODE_ENABLE_AUTO_MODE=1` | Claude compatibility sessions can opt into provider-backed auto mode for those Opus surfaces. Codex-native model routing and approval policy are unchanged. | Document as Claude provider compatibility only. Do not infer Codex auto-mode behavior from this env var. |
+
+## v2.1.157
+
+Published: 2026-05-29.
+
+Source: upstream oh-my-customcode #1265, Codex port #1437.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Plugins under `.claude/skills` auto-load, `claude plugin init <name>` scaffolds plugins there, and `/plugin` has argument autocomplete | Useful for Claude compatibility plugin setup. Codex-native skills remain under `.codex/skills`, `.agents/skills`, and OMX skill roots. | Keep `.codex/OMX` primary. Mention `.claude/skills` only when documenting Claude plugin compatibility. |
+| `claude agents` honors the `agent` field in `settings.json`, with `--agent <name>` as an override | Claude dispatched sessions can inherit a configured default agent unless explicitly overridden. | Do not mirror this into Codex routing. Codex native subagents still follow prompt routing, role metadata, and explicit delegation. |
+| `EnterWorktree` can switch between Claude-managed worktrees mid-session, and Claude-managed worktrees are left unlocked for `git worktree remove`/`prune` cleanup | Claude worktree lifecycle is more flexible and less likely to leave locked cleanup blockers. | Keep auto-dev work in clean worktrees, verify `git status`, and do not treat Claude-managed worktree state as OMX state. |
+| `tool_decision` telemetry can include `tool_parameters` such as Bash commands and MCP/skill names when `OTEL_LOG_TOOL_DETAILS=1` | Telemetry may contain more detailed operational data, including command and tool-parameter strings. | Treat logs as potentially sensitive. Avoid exporting transcripts or telemetry that may expose secrets, credentials, or privileged commands. |
+| Background/session fixes cover parked subagents, leaked background shells, orphaned `.claude/worktrees`, resume state, date after sleep/wake, fullscreen picker cleanup, current linked worktree return, image placeholders, network prompts, and tmux clipboard behavior | Reduces false blockers and stale-state surprises in Claude compatibility sessions. | No Codex runtime change. Continue using OMX state, Codex worktree checks, and direct command evidence for Codex-native completion claims. |
+
 ## v2.1.156
 
 Published: 2026-05-29.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.9",
+  "version": "0.5.10",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -22,6 +22,18 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.
 
+## Workflow Prompt and Verifier Ground Truth
+
+When a workflow delegates to `agent()` or equivalent subagent calls, complete the full prompt string before the call. Do not append guardrails, fact sheets, or critical constraints to the returned value after the agent has already run.
+
+Verifier lanes must receive the ground-truth sources needed to check cross-cutting claims, especially external URLs, cluster DNS/service names, credentials metadata, release facts, and infrastructure identifiers. A verifier cannot validate a fact that was never provided and is not present in the inspected source.
+
+## Read-Before-Characterize Diagnostics
+
+Do not characterize logs, traces, or diagnostics as an "error loop", "root cause", "flaky test", or similar conclusion before reading the relevant evidence. First capture the observed symptom, then inspect the authoritative log/output/source, then label the failure mode.
+
+For large or noisy logs, read a representative targeted slice before making permanent workflow, rule, template, or release-process changes. If the initial characterization changes after reading, report the correction explicitly.
+
 ## Diagnostic Hypothesis Verification
 
 When a failure diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until it is directly verified.

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -116,6 +116,26 @@ Main Conversation (orchestrator)
 ```
 -->
 
+## Subagent Scope-Creep STOP Protocol
+
+Before delegating broad work, decompose it into narrow domains with explicit write/command boundaries. For example, do not hand one agent an open-ended "migrate + backfill + fix infra" prompt when the work can split into data migration, credential handling, tunnel/networking, dashboard verification, and release notes.
+
+The orchestrator must stop and redesign a delegated lane when any of these occur:
+
+1. The same subagent trips the security classifier twice on one assignment.
+2. The subagent requests or attempts privileged actions outside the delegated scope.
+3. The subagent chains from an approved action into a different credential, tunnel, namespace, pod, cluster, account, or shared service.
+4. The user corrects the agent for acting beyond the requested scope.
+
+Required STOP response:
+
+1. Stop that subagent lane; do not retry the same broad prompt.
+2. Preserve evidence and summarize the exact scope breach.
+3. Redesign the task into smaller bounded lanes with explicit allowed and forbidden actions.
+4. Reconfirm authorization before any irreversible shared-infrastructure or credential action.
+
+Thirteen repeated security trips or repeated privileged retries are an anti-pattern: after the second trip, continuing without redesign is a coordination failure.
+
 ## Common Violations
 
 Key violations to avoid (file writes, git commands, bundled operations — all must be delegated):

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -13,6 +13,12 @@
 | 5: Conditional | TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop, TaskOutput | Available when Agent Teams enabled |
 | 6: MCP | ListMcpResourcesTool, ReadMcpResourceTool, CronCreate, CronDelete, CronList, RemoteTrigger | MCP/extension tools, available when servers configured |
 
+## Privileged Scope Boundaries
+
+- Approval for one privileged action does not authorize follow-on privileged chaining. A request to remove one tunnel, secret, pod, namespace object, or credential does not authorize creating a replacement, rotating credentials, deleting adjacent resources, or executing inside production workloads.
+- Treat credential-store reads as sensitive even when the tool is otherwise available. Never paste raw secret values or full credential-store transcripts into chat; use redacted names, fingerprints, or boolean verification results.
+- Reconfirm scope before irreversible shared infrastructure or credential actions, including production pod exec/write, Kubernetes secret mutation, public tunnel creation, credential rotation, and shared namespace deletion.
+
 ## File Access
 
 | Operation | Allowed | Prohibited |

--- a/templates/.claude/rules/MUST-safety.md
+++ b/templates/.claude/rules/MUST-safety.md
@@ -11,6 +11,13 @@
 | Commands | `rm -rf /` or broad deletes, shutdown/restart, sudo/su, network config changes |
 | External | Access URLs without approval, send user data externally, download/execute unknown scripts |
 
+## Credential and Shared-Infrastructure Guardrails
+
+- Do not dump credential-store contents, `.env` files, OAuth material, kube secrets, or secret-manager values into transcripts, logs, issue bodies, or summaries. Report only the minimum redacted key names or verification status required for the task.
+- Do not rotate, delete, recreate, or replace credentials unless the user explicitly requested that exact credential action.
+- Before irreversible action on shared infrastructure or credentials, reconfirm the target, namespace/account/project, requested scope, rollback path, and user authorization.
+- Stop instead of chaining privileged actions when the next step would affect a different credential, tunnel, namespace, pod, cluster, account, or shared service than the user requested.
+
 ## Required Before Destructive Operations
 
 Verify target, assess impact scope, check recoverability, get user approval.

--- a/templates/.claude/rules/SHOULD-interaction.md
+++ b/templates/.claude/rules/SHOULD-interaction.md
@@ -27,6 +27,17 @@
 | Ambiguous | `[Confirm] Understood "{request}" as {interpretation}. Proceed?` |
 | Risky | `[Warning] This action has {risk}. Continue? Yes: {action} / No: Cancel` |
 
+## External Product UI Claims
+
+Avoid presenting unverified external product UI field names, button labels, or step-by-step paths as fact. Product consoles change frequently and screenshots/docs may be stale.
+
+When UI evidence is not directly verified:
+
+- State that the UI path is an inference or may vary by account/version.
+- Prefer stable facts already observed in the environment: URLs, config keys, resource IDs, CLI output, or API results.
+- Ask the user to map those verified values into the current UI instead of inventing missing fields.
+- If exact UI steps are required, verify against current official docs or a live screenshot before giving precise labels.
+
 ## Multiple Tasks
 
 - Dependent: Sequential

--- a/templates/.claude/skills/skill-extractor/SKILL.md
+++ b/templates/.claude/skills/skill-extractor/SKILL.md
@@ -1,150 +1,239 @@
 ---
 name: skill-extractor
-description: Analyze task trajectories to propose reusable SKILL.md candidates from successful patterns
+description: Analyze recurring task trajectories and evidence to propose reusable workflow packaging candidates
 scope: core
 user-invocable: true
-argument-hint: "[--threshold <n>] [--dry-run]"
-version: 1.0.0
+argument-hint: "[--threshold <n>] [--dry-run] [--all]"
+version: 1.1.0
 ---
 
 # Skill Extractor
 
-Analyze completed task outcomes to identify reusable patterns and propose new SKILL.md candidates. Inspired by Hermes Agent's self-learning skill extraction — adapted for oh-my-customcodex's compilation metaphor.
+Analyze completed task outcomes and recent work evidence to identify recurring workflows that may deserve reusable packaging. Inspired by Hermes Agent's self-learning skill extraction — adapted for oh-my-customcodex's compilation metaphor.
 
 ## Philosophy
 
-In the compilation metaphor: task trajectories are runtime traces, and extracted skills are new source code. This skill turns successful execution patterns into reusable knowledge artifacts.
+In the compilation metaphor: task trajectories are runtime traces, and extracted skills are new source code. This skill turns repeated, successful execution patterns into reusable knowledge artifacts only after evidence review and user approval.
 
 ```
-Runtime traces (task outcomes) → Pattern analysis → SKILL.md proposal → User approval → mgr-creator
+Runtime traces + memory + rollout summaries + inventory → Evidence-first shortlist → Packaging recommendation → User approval → mgr-creator or automation owner
 ```
 
 ## Usage
 
 ```
-/skill-extractor                    # Analyze current session outcomes
-/skill-extractor --threshold 2      # Lower success threshold (default: 3)
-/skill-extractor --dry-run          # Preview proposals without writing
+/skill-extractor                    # Analyze current session outcomes and local evidence
+/skill-extractor --threshold 2      # Lower recurring evidence threshold (default: 3)
+/skill-extractor --dry-run          # Preview shortlist without writing
+/skill-extractor --all              # Include broader session and memory history when available
 ```
 
 ## Options
 
 ```
---threshold, -t   Minimum success count for pattern qualification (default: 3)
---dry-run, -d     Preview proposals to stdout only, no file writes
---all             Include all sessions (not just current, requires task outcome history)
+--threshold, -t   Minimum evidence count for recurring-workflow qualification (default: 3)
+--dry-run, -d     Preview candidates to stdout only, no file writes
+--all             Include all sessions and available memory/history, not just current session
 ```
 
 ## Workflow
 
-### Phase 1: Collect Task Outcomes
+### Phase 1: Evidence-First Candidate Discovery
 
-Read task outcome data from the session:
+Collect candidates from concrete, dated evidence before proposing any packageable artifact. Prefer local evidence first; use optional integrations only when available.
 
-```bash
-# Current session outcomes (from task-outcome-recorder hook)
-OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
-```
+Required and recommended sources:
 
-If file doesn't exist or is empty: report "No task outcomes recorded in this session." and stop.
+1. **Recent session outcomes** from the task-outcome-recorder hook:
 
-Parse JSONL entries. Each entry has:
+   ```bash
+   # Current session outcomes
+   OUTCOMES_FILE="/tmp/.codex-task-outcomes-${PPID}"
+   ```
+
+2. **Recent sessions and memory**: relevant `claude-mem`/OMX memory observations, session checkpoints, `.omx/notepad.md`, and `.omx/state/**` summaries when present.
+3. **Rollout or release summaries**: changelog entries, release notes, PR summaries, compatibility notes, and post-release follow-up reports that show repeated manual steps.
+4. **Optional Chronicle/history integrations**: Chronicle, shell history, or external task timeline summaries if installed and explicitly available. Do not fail when absent.
+5. **Existing inventory**: compare against `.codex/skills/*/SKILL.md`, `.codex/agents/*`, `templates/.claude/skills/*/SKILL.md`, and generated wiki pages to avoid duplicate or overlapping packaging.
+
+If no evidence source exists or all sources are empty: report "No recurring workflow evidence found." and stop without creating anything.
+
+Parse JSONL outcome entries when available. Each entry has:
+
 ```json
 {"agent_type": "lang-typescript-expert", "skill": "typescript-best-practices", "description": "Fix type error in auth module", "outcome": "success", "model": "sonnet", "timestamp": "2026-04-05T09:30:00Z", "duration_ms": 15000}
 ```
 
-### Phase 2: Pattern Detection
-
-Group outcomes by `(agent_type, skill)` tuple:
-
-```
-Pattern: (lang-typescript-expert, typescript-best-practices)
-  → success: 5, failure: 1, total: 6
-  → success_rate: 0.83
-  → descriptions: ["Fix type error...", "Refactor module...", ...]
-```
-
-Filter qualifying patterns:
-- `success_count >= threshold` (default: 3)
-- `success_rate >= 0.8`
-- Not already an existing skill (check `.codex/skills/*/SKILL.md`)
-
-### Phase 3: Generate Proposals
-
-For each qualifying pattern, generate a SKILL.md proposal:
+For prose evidence, extract only dated or source-attributed observations, for example:
 
 ```markdown
-## Proposal: {proposed-skill-name}
+- 2026-05-24, release PR summary: repeated manual wiki parity fixes after adding new guides.
+- 2026-05-22, memory #29064: sync-upstream-release-issues dry-run needed repeated validation after issue-reference parsing changes.
+```
 
-**Source Pattern**: {agent_type} + {skill} ({success_count} successes, {success_rate}% rate)
-**Confidence**: {low|medium|high} (based on count and rate)
+### Phase 2: Recurring Workflow Detection
 
-### Proposed SKILL.md
+Group evidence by the workflow being repeated, not only by `(agent_type, skill)` tuple. A workflow can span agents, commands, checklist steps, or release procedures.
+
+```
+Workflow: release-docs-parity-check
+  → evidence_count: 4 dated occurrences
+  → successful_reuse: 3
+  → failure_or_friction: 1
+  → sources: [memory:29148, PR summary, changelog, wiki staleness check]
+  → existing_overlap: wiki, update-docs, sauron-watch
+```
+
+Filter qualifying candidates:
+
+- `evidence_count >= threshold` (default: 3), or two strong dated incidents plus high user impact.
+- Repeated manual judgment or sequencing exists; one-off bugs are not enough.
+- Evidence includes dates or source names, not vague recollection.
+- Candidate is not already fully covered by an existing skill, custom subagent, automation, or documented checklist.
+- R006 separation of concerns can be preserved: package one coherent responsibility, not a catch-all meta-agent.
+
+### Phase 3: Build the Shortlist
+
+For each candidate, create a shortlist entry before generating any SKILL.md proposal. Every entry must include these fields:
+
+```markdown
+## Candidate: {candidate-name}
+
+**Workflow**: {one-sentence recurring workflow description}
+**Evidence / Dates**:
+- {date or source}: {specific repeated task, success, failure, or friction point}
+- {date or source}: {specific repeated task, success, failure, or friction point}
+**Frequency / Confidence**: {count and low|medium|high confidence with reason}
+**Recommended Form**: {Skill | Custom subagent | Automation | Skip}
+**Duplicate / Overlap Check**: {existing skills, agents, hooks, scripts, docs, or "none found"}
+**Why**: {why packaging would reduce repeated manual work or improve safety}
+**Why Not**: {risks, overlap, insufficient evidence, or why a lighter form may be better}
+```
+
+Recommended-form guidance:
+
+| Form | Use When | Do Not Use When |
+|------|----------|-----------------|
+| Skill | A repeatable human-invoked workflow/checklist improves outcomes and needs judgment | Existing skill already covers it or it is fully automatable |
+| Custom subagent | A specialized role with stable responsibilities, tools, and boundaries is recurring | It is just a checklist or would violate R006 by mixing unrelated duties |
+| Automation | The steps are deterministic, cheap to validate, and safe to run without judgment | User approval, external credentials, or destructive actions are required |
+| Skip | Evidence is weak, duplicated, obsolete, or one-off | There is enough dated evidence and clear reuse value |
+
+### Phase 4: Generate Packaging Proposals
+
+Only for shortlist entries whose recommended form is `Skill` or `Custom subagent`, generate a proposal. For `Automation`, recommend the script/hook/check location and required guardrails. For `Skip`, explain the evidence gap.
+
+```markdown
+## Proposal: {proposed-package-name}
+
+**Recommended Form**: {Skill | Custom subagent | Automation | Skip}
+**Source Workflow**: {workflow} ({evidence_count} evidence points, {confidence})
+**Evidence Window**: {earliest date/source} → {latest date/source}
+**Confidence**: {low|medium|high} (based on frequency, recency, and outcome consistency)
+
+### Proposed Artifact
 
 name: {proposed-name}
-description: {inferred from common description patterns}
+description: {inferred from recurring workflow evidence}
 scope: core
-user-invocable: false
+user-invocable: {true|false}
 
 ### Rationale
-{Why this pattern should be extracted as a skill — based on frequency and success rate}
+{Why this workflow should be packaged — based on dates, frequency, success/failure pattern, and user impact}
 
-### Overlap Check
-{List any existing skills with >50% keyword overlap}
+### Duplicate / Overlap Check
+{List existing skills, agents, hooks, scripts, or wiki docs with meaningful overlap and how this proposal differs}
+
+### Guardrails
+{User approval, R006 responsibility boundary, R020 verification requirement, dry-run behavior, and non-destructive defaults}
 ```
 
 **Confidence scoring**:
-| Successes | Rate | Confidence |
-|-----------|------|------------|
-| 3-5 | >= 0.8 | low |
-| 6-10 | >= 0.85 | medium |
-| 10+ | >= 0.9 | high |
 
-### Phase 4: Present to User
+| Evidence | Recency / Outcome | Confidence |
+|----------|-------------------|------------|
+| 2 strong incidents or 3 weak signals | Mixed outcomes or older than 90 days | low |
+| 3-5 dated occurrences | Mostly successful or repeated friction in last 90 days | medium |
+| 6+ dated occurrences | Clear recurrence, recent evidence, and stable success criteria | high |
 
-Display proposals in ranked order (highest confidence first):
+### Phase 5: Present to User
 
+Display the shortlist in ranked order (highest confidence and lowest overlap first):
+
+```text
+[skill-extractor] {N} recurring workflow candidates detected
+
+  1. [high] release-docs-parity-check
+     Workflow: Validate guide/wiki/template parity before release PRs
+     Evidence: 4 dated sources, latest 2026-05-24
+     Recommended form: Skill
+     Overlap: update-docs, sauron-watch (partial)
+     Why: Prevents repeated CI wiki-staleness failures
+     Why not: May be redundant if update-docs grows the same gate
+
+  2. [medium] upstream-release-issue-validation
+     Workflow: Validate upstream issue references before sync workflows
+     Evidence: 3 dated sources, latest 2026-05-22
+     Recommended form: Automation
+     Overlap: sync-upstream-release-issues script
+     Why: Deterministic validation prevents repeated 404 workflow failures
+     Why not: Better as script/test than human-invoked skill
+
+Select [1-N] to create, "all" to create all approved packageable items, or "skip" to cancel:
 ```
-[skill-extractor] {N} skill candidates detected
 
-  1. [high] proposed-skill-name
-     Source: {agent_type} + {skill} (12 successes, 92%)
-     Description: {inferred description}
+### Phase 6: Create Artifact (on approval only)
 
-  2. [medium] another-skill-name
-     Source: {agent_type} + {skill} (7 successes, 86%)
-     Description: {inferred description}
+Never create or modify reusable artifacts without explicit user approval after showing the shortlist.
 
-Select [1-N] to create, "all" to create all, or "skip" to cancel:
-```
+On approval:
 
-### Phase 5: Create Skill (on approval)
+- `Skill`: delegate to `mgr-creator` with the full shortlist entry, proposal, overlap warnings, and guardrails.
+- `Custom subagent`: delegate to `mgr-creator` with the R006 responsibility boundary and required related skills/guides.
+- `Automation`: hand off a scoped implementation recommendation; require a dry-run/default-safe mode and R020 verification evidence.
+- `Skip`: record the decision only if the user asks to save it.
 
-Delegate to mgr-creator with the proposal context:
-- Proposed name and description
-- Source pattern data
-- Confidence level
-- Any overlap warnings
+mgr-creator handles: SKILL.md creation, template sync, ontology registration, and generated docs parity.
 
-mgr-creator handles: SKILL.md creation, template sync, ontology registration.
+## Recurring-Workflow Packaging Checklist
+
+Before recommending packaging, verify:
+
+- [ ] Evidence is source-attributed and includes dates or stable identifiers.
+- [ ] Frequency meets `--threshold` or has two strong high-impact incidents.
+- [ ] The workflow has stable trigger conditions and a clear stop condition.
+- [ ] Existing skills, agents, hooks, scripts, and wiki docs were checked for duplicate or partial coverage.
+- [ ] Recommended form is justified as `Skill`, `Custom subagent`, `Automation`, or `Skip`.
+- [ ] `Why` and `Why Not` both name concrete evidence.
+- [ ] R006 is preserved: one coherent responsibility and clear boundaries.
+- [ ] R020 is preserved: proposal includes verification evidence or a test/check path.
+- [ ] User approval is required before any artifact creation or mutation.
+- [ ] Dry-run/no-write behavior remains available for review-only usage.
 
 ## Integration
 
 | System | How |
 |--------|-----|
-| task-outcome-recorder | Reads JSONL outcomes as input data |
-| feedback-collector | Complementary: feedback-collector extracts failure patterns, skill-extractor extracts success patterns |
-| mgr-creator | Delegated skill creation on user approval |
+| task-outcome-recorder | Reads JSONL outcomes as one input data source |
+| memory-management / memory-recall | Supplies dated recurring-workflow evidence when available |
+| rollout and release summaries | Surface repeated manual release, docs, and compatibility procedures |
+| optional Chronicle/history | Adds timeline evidence when installed; absence is non-fatal |
+| existing skills and agents inventory | Prevents duplicate skills, subagents, or automations |
+| feedback-collector | Complementary: feedback-collector extracts failure patterns, skill-extractor extracts recurring packageable workflows |
+| mgr-creator | Delegated skill or subagent creation on user approval |
 | skills-sh-search | Check agentskills.io for existing equivalent before creating |
-| R011 (memory) | User Model tracks extraction decisions in Override Decisions |
+| R006 | Enforces coherent responsibility boundaries for custom subagents and skills |
+| R011 (memory) | User Model tracks extraction decisions in Override Decisions when explicitly saved |
+| R020 | Requires verification evidence before completion claims |
 
 ## Hook Integration
 
 The `skill-extractor-analyzer.sh` Stop hook provides a lightweight pre-analysis:
+
 - Reads task outcomes file
-- Counts qualifying patterns
+- Counts qualifying recurring patterns
 - Emits advisory stderr message if candidates found
-- Does NOT create skills (that requires user approval via the skill)
+- Does NOT create skills, subagents, or automation (that requires user approval via the skill)
 
 ## Compatibility Artifact Protocol
 
@@ -152,8 +241,11 @@ Sensitive-path compatibility note: when delegated work touches `.claude/outputs/
 
 ## Safety
 
-- **User approval required**: Never auto-creates skills
-- **Overlap check**: Prevents duplicating existing skills
+- **User approval required**: Never auto-creates skills, subagents, or automation
+- **Evidence-first**: Never recommends packaging from vague memory or unverified anecdotes
+- **Overlap check**: Prevents duplicating existing skills, agents, hooks, scripts, or docs
+- **R006 guardrail**: Rejects catch-all artifacts with mixed responsibilities
+- **R020 guardrail**: Every approved artifact must include a verification path before completion is claimed
 - **Dry-run mode**: Preview without side effects
 - **Advisory hook**: Stop hook is advisory-only (exit 0)
-- **Confidence transparency**: All proposals show confidence scores
+- **Confidence transparency**: All shortlist entries and proposals show confidence scores and evidence dates

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,30 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.158
+
+Published: 2026-05-30.
+
+Source: upstream oh-my-customcode #1264, Codex port #1436.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Auto mode is available on Bedrock, Vertex, and Foundry for Opus 4.7 and Opus 4.8 via `CLAUDE_CODE_ENABLE_AUTO_MODE=1` | Claude compatibility sessions can opt into provider-backed auto mode for those Opus surfaces. Codex-native model routing and approval policy are unchanged. | Document as Claude provider compatibility only. Do not infer Codex auto-mode behavior from this env var. |
+
+## v2.1.157
+
+Published: 2026-05-29.
+
+Source: upstream oh-my-customcode #1265, Codex port #1437.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Plugins under `.claude/skills` auto-load, `claude plugin init <name>` scaffolds plugins there, and `/plugin` has argument autocomplete | Useful for Claude compatibility plugin setup. Codex-native skills remain under `.codex/skills`, `.agents/skills`, and OMX skill roots. | Keep `.codex/OMX` primary. Mention `.claude/skills` only when documenting Claude plugin compatibility. |
+| `claude agents` honors the `agent` field in `settings.json`, with `--agent <name>` as an override | Claude dispatched sessions can inherit a configured default agent unless explicitly overridden. | Do not mirror this into Codex routing. Codex native subagents still follow prompt routing, role metadata, and explicit delegation. |
+| `EnterWorktree` can switch between Claude-managed worktrees mid-session, and Claude-managed worktrees are left unlocked for `git worktree remove`/`prune` cleanup | Claude worktree lifecycle is more flexible and less likely to leave locked cleanup blockers. | Keep auto-dev work in clean worktrees, verify `git status`, and do not treat Claude-managed worktree state as OMX state. |
+| `tool_decision` telemetry can include `tool_parameters` such as Bash commands and MCP/skill names when `OTEL_LOG_TOOL_DETAILS=1` | Telemetry may contain more detailed operational data, including command and tool-parameter strings. | Treat logs as potentially sensitive. Avoid exporting transcripts or telemetry that may expose secrets, credentials, or privileged commands. |
+| Background/session fixes cover parked subagents, leaked background shells, orphaned `.claude/worktrees`, resume state, date after sleep/wake, fullscreen picker cleanup, current linked worktree return, image placeholders, network prompts, and tmux clipboard behavior | Reduces false blockers and stale-state surprises in Claude compatibility sessions. | No Codex runtime change. Continue using OMX state, Codex worktree checks, and direct command evidence for Codex-native completion claims. |
+
 ## v2.1.156
 
 Published: 2026-05-29.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.5.9",
+  "version": "0.5.10",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-05-30T00:00:00.000Z",
+  "lastUpdated": "2026-06-01T00:00:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/wiki/skills/skill-extractor.md
+++ b/wiki/skills/skill-extractor.md
@@ -1,35 +1,40 @@
 ---
 title: Skill Extractor
 type: skill
-updated: 2026-04-12
+updated: 2026-06-01
 sources:
   - .codex/skills/skill-extractor/SKILL.md
 related:
   - [[mgr-creator]]
+  - [[R006]]
+  - [[R020]]
   - [[R016]]
 ---
 
 # Skill Extractor
 
-Analyze task trajectories to propose reusable SKILL.md candidates from successful patterns.
+Analyze recurring task trajectories and evidence to propose reusable workflow packaging candidates.
 
 ## Overview
 
-Reads task outcome data (`/tmp/.claude-task-outcomes-$PPID`), groups by `(agent_type, skill)` pattern, and proposes new SKILL.md candidates for patterns with ≥3 successes and ≥80% success rate. Presents confidence-ranked proposals (low/medium/high) and delegates approved skill creation to `mgr-creator`. Never auto-creates without user approval. A Stop hook (`skill-extractor-analyzer.sh`) provides lightweight pre-analysis.
+Collects evidence from recent session outcomes (`/tmp/.codex-task-outcomes-$PPID`), memory/session summaries, rollout or release summaries, optional Chronicle/history integrations, and the existing skills/agents inventory. It builds an evidence-first shortlist before proposing any reusable artifact.
+
+Each shortlist entry records the workflow, evidence and dates, frequency/confidence, recommended form (`Skill`, `Custom subagent`, `Automation`, or `Skip`), duplicate/overlap check, why, and why-not. Approved `Skill` or `Custom subagent` work is delegated to `mgr-creator`; deterministic `Automation` candidates are handed off as scoped implementation recommendations. Nothing is created without explicit user approval.
 
 ## Key Details
 
 - **Scope**: core
 - **User-invocable**: yes
 - **Command**: `/skill-extractor`
-- **Effort**: not specified
-- **Argument hint**: `[--threshold <n>] [--dry-run]`
+- **Argument hint**: `[--threshold <n>] [--dry-run] [--all]`
+- **Default threshold**: 3 source-attributed evidence points
+- **Guardrails**: user approval, duplicate/overlap checks, R006 responsibility boundaries, and R020 verification evidence
 
 ## Relationships
 
 - **Used by agents**: orchestrator
-- **Related skills**: [[mgr-creator]], [[skills-sh-search]]
-- **See also**: [[R016]], [[R006]]
+- **Related skills**: [[mgr-creator]], [[skills-sh-search]], [[memory-recall]], [[memory-management]]
+- **See also**: [[R016]], [[R006]], [[R020]]
 
 ## Sources
 


### PR DESCRIPTION
## Summary

- Records the upstream `Yeachan-Heo/oh-my-codex` v0.18.7 no-op compatibility review for #1434.
- Adds recurring-workflow packaging checklist coverage to `skill-extractor` for #1435.
- Documents Claude Code v2.1.157 / v2.1.158 compatibility notes for #1436 and #1437.
- Hardens safety, orchestration, and completion verification guidance for #1438.
- Bumps package/template metadata to `0.5.10` and refreshes the source lockfile.

## Validation

- `git diff --check`
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run test` → 1832 pass, 0 fail

Closes #1434
Closes #1435
Closes #1436
Closes #1437
Closes #1438