### PR TITLE
Release v0.5.11

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -157,7 +157,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           ISSUES=$(printf '%s\n' "$PR_BODY" \
-            | grep -oiE '(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+' \
+            | grep -oiE '(Closes|Fixes|Resolves)[[:space:]]+#[0-9]+([[:space:],;]+#[0-9]+)*' \
             | grep -oE '#[0-9]+' \
             | tr -d '#' \
             | sort -u)

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.10",
-  "generatedAt": "2026-05-31T23:43:14.798Z",
-  "templateVersion": "0.5.10",
+  "generatorVersion": "0.5.11",
+  "generatedAt": "2026-06-02T14:13:40.588Z",
+  "templateVersion": "0.5.11",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.10",
+  "version": "0.5.11",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.10",
+  "version": "0.5.11",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/tests/unit/core/auto-tag-workflow.test.ts
+++ b/tests/unit/core/auto-tag-workflow.test.ts
@@ -8,8 +8,10 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 const AUTO_TAG_WORKFLOW = resolve(import.meta.dir, '../../../.github/workflows/auto-tag.yml');
 
@@ -19,6 +21,42 @@ const AUTO_TAG_WORKFLOW = resolve(import.meta.dir, '../../../.github/workflows/a
 
 async function readWorkflow(): Promise<string> {
   return readFile(AUTO_TAG_WORKFLOW, 'utf-8');
+}
+
+async function extractIssuesLikeWorkflow(body: string): Promise<string[]> {
+  const dir = await mkdtemp(join(tmpdir(), 'auto-tag-'));
+  const bodyFile = join(dir, 'body.txt');
+  try {
+    await writeFile(bodyFile, body);
+    const script = `cat "$1" \
+      | grep -oiE '(Closes|Fixes|Resolves)[[:space:]]+#[0-9]+([[:space:],;]+#[0-9]+)*' \
+      | grep -oE '#[0-9]+' \
+      | tr -d '#' \
+      | sort -u`;
+    return await new Promise((resolvePromise, reject) => {
+      const child = spawn('bash', ['-lc', script, 'bash', bodyFile], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code && code !== 1) {
+          reject(new Error(`extract failed with ${code}: ${stderr}`));
+          return;
+        }
+        resolvePromise(stdout.split('\n').filter(Boolean));
+      });
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -316,7 +354,9 @@ describe('auto-tag.yml — tag creation', () => {
 describe('auto-tag.yml — linked issue closure', () => {
   it('should close multiple issue references from one closing keyword', async () => {
     const content = await readWorkflow();
-    expect(content).toContain("'(Closes|Fixes|Resolves)([[:space:]]+#[0-9]+)+'");
+    expect(content).toContain(
+      "'(Closes|Fixes|Resolves)[[:space:]]+#[0-9]+([[:space:],;]+#[0-9]+)*'"
+    );
     expect(content).toContain("grep -oE '#[0-9]+'");
     expect(content).toContain("tr -d '#'");
   });
@@ -325,6 +365,16 @@ describe('auto-tag.yml — linked issue closure', () => {
     const content = await readWorkflow();
     expect(content).toContain('sort -u');
     expect(content).toContain('for ISSUE in $ISSUES');
+  });
+
+  it('should extract all comma-separated issue references from one closing keyword', async () => {
+    await expect(
+      extractIssuesLikeWorkflow('Release notes\n\nCloses #1268, #1269, #1271\n')
+    ).resolves.toEqual(['1268', '1269', '1271']);
+  });
+
+  it('should extract all whitespace-separated issue references from one closing keyword', async () => {
+    await expect(extractIssuesLikeWorkflow('Fixes #1 #2 #3\n')).resolves.toEqual(['1', '2', '3']);
   });
 
   it('should close the release milestone only when all milestone issues are closed', async () => {


### PR DESCRIPTION
## Summary

- Fix `.github/workflows/auto-tag.yml` linked-issue extraction so one closing keyword handles comma- or whitespace-separated issue refs.
- Add executable regression coverage for `Closes #1268, #1269, #1271` and `Fixes #1 #2 #3`.
- Bump package/template version to `0.5.11` and refresh `.omcodex.lock.json`.

Closes #1443

## Verification

- `bun install` (no dependency changes)
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/core/auto-tag-workflow.test.ts tests/unit/core/template-validation.test.ts`
- `bun run build`
- `bash .github/scripts/verify-version-sync.sh`
- `bun test tests/ packages/eval-core/` — 1834 pass, 0 fail

## Notes

- #1444 and #1445 were reviewed as monitor-only compatibility issues and closed with no local implementation required.
