### PR TITLE
Release v0.5.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Repo-local response contract:
   - Start responses with an agent identification block.
   - If no skill is active, still show `Agent` and `Status`.
+  - Match the user's language for all progress updates and final reports. If the user writes in Korean, respond in Korean unless quoting commands, code, logs, or required proper nouns.
   - Prefer this visible format:
 
     ```text

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.11",
+  "version": "0.5.12",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.11",
+  "version": "0.5.12",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",


### PR DESCRIPTION
## Summary
- Enforce repo-local response contract to match the user's language, including Korean progress/final replies.
- Bump package and template manifest versions to `0.5.12`.

## Scope
- Closes #1458
- Milestone: v0.5.12
- Compression mode: docs-only

## Verification
- `git diff --check`
- Pre-commit hook on implementation commit: `tsc --noEmit`, `biome check src/ tests/ scripts/`, stable Bun test batches passed
- `bun install` (no dependency drift)
- `bun run lint`
- `bun run typecheck`
- `bun test` — 1834 pass, 0 fail
- `bun run build`
- `bash .github/scripts/verify-version-sync.sh` — 0.5.12 parity passed

## Notes
- Build generated `.omcodex.lock.json` timestamp-only drift during verification; reverted because it is outside this release scope.