### PR TITLE
Release v0.5.13

### DIFF
--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -67,6 +67,29 @@ Parallel batches return results together, so a same-batch permanent dispatch pro
 
 Example: do not diagnose `triage-dispatch.yml` from memory, create an issue, and delegate a fix in the same parallel call before reading the workflow. If the read later shows a different root cause, the issue, PR, and commit trail become correction debt even when the eventual code direction is acceptable.
 
+## Degraded-Output Re-Verification Gate
+
+When tool output shows provider instability, buffering, truncation, duplicated chunks, `529`, timeout recovery, or `(no result)` while a permanent action is being considered, treat the current read as degraded. Do not characterize corruption, missing files, stale state, release failure, or data loss from that single degraded read.
+
+Before destructive recovery, issue creation, rule/workflow/template edits, release publication, or fix delegation based on degraded output:
+
+1. Re-read the authoritative source with a deterministic command or API call.
+2. Use a second narrow check that can falsify the failure hypothesis, such as `grep -c`, `sort -u`, `git status`, `git show`, `gh api`, or a direct file diff.
+3. Record whether the first read was degraded and whether the re-check confirmed or corrected the hypothesis.
+
+If the deterministic re-check cannot run, halt or reduce the action to a non-destructive diagnostic note.
+
+## Workflow Script Sanity Check
+
+Before invoking or registering generated workflow code, run a Tier-1 sanity pass:
+
+1. Search for unresolved placeholders, malformed identifiers, and known dead-line patterns.
+2. Assemble the exact script body before execution; do not concatenate facts or guardrails after the call starts.
+3. Run the language parser or the narrowest no-side-effect syntax check available.
+4. If syntax validation is unavailable, read the generated body back and perform a focused self-review before launch.
+
+This check is mandatory for workflow scripts that will run automation, mutate GitHub state, or gate a release.
+
 ## Test-Skip Is Not Completion
 
 Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO may be a temporary containment step, but it never satisfies completion by itself.

--- a/.codex/rules/MUST-continuous-improvement.md
+++ b/.codex/rules/MUST-continuous-improvement.md
@@ -51,6 +51,18 @@ When repeating agent failures or suboptimal routing is detected:
 
 This connects R016's continuous improvement loop with the adaptive-harness skill's learning capability.
 
+## Skill Promotion Threshold
+
+Promote a recurring workflow into a skill only when the evidence is strong enough to justify a durable interface.
+
+| Evidence | Action |
+|----------|--------|
+| One clear occurrence | Record memory or issue; do not create a skill by default |
+| Two direct successful repetitions with stable inputs/outputs | Candidate for `skill-extractor` Phase 1 shortlist |
+| Three or more direct repetitions, or two repetitions plus explicit user confirmation | Confirmed promotion candidate |
+
+Before creating a new skill, verify the candidate is not already covered by an existing skill, rule, guide, hook, or lightweight memory entry. Ambiguous, sensitive, one-off, or ownership-unclear candidates are explicitly skipped with a reason.
+
 ## External Repository Contribution Pre-Check
 
 Before creating or modifying assets for an external repository or upstream contribution target, inspect that repository's local contract before implementing:

--- a/.codex/rules/MUST-orchestrator-coordination.md
+++ b/.codex/rules/MUST-orchestrator-coordination.md
@@ -248,6 +248,19 @@ Known limitation: `arch-documenter` has `disallowedTools: [Bash]`. Do not ask it
 
 The `agent-capability-precheck.sh` hook blocks obvious mismatches so the orchestrator re-routes before spawning an agent that cannot execute the requested work.
 
+### Delegated Path Existence Pre-Check
+
+Before putting concrete file paths in a delegated prompt, verify those paths exist or explicitly mark them as new files. A tool-capability match is insufficient when the prompt names a path.
+
+Required check:
+
+1. Use `rg --files`, `find`, `ls`, or the repository index to prove each existing path.
+2. If a path is missing, locate the current equivalent before delegating.
+3. Include only verified paths in the prompt, or say `create new file: <path>` when creation is intended.
+4. For multi-copy assets, verify all source/template mirrors before assigning the edit.
+
+Do not rely on the delegate to repair stale path guesses in shared workflow, rule, guide, or release tasks.
+
 <!-- DETAIL: Autonomous Execution Mode
 
 ## Autonomous Execution Mode

--- a/.codex/skills/instinct-extractor/SKILL.md
+++ b/.codex/skills/instinct-extractor/SKILL.md
@@ -41,6 +41,17 @@ Find repeated operator or agent behavior that should become a rule, skill, guide
 4. Assign confidence and cite concrete files, commits, or artifacts.
 5. Emit proposals only; do not create new rules or skills without an explicit follow-up task.
 
+## Selection Discipline
+
+Before emitting a reusable-asset proposal, apply these filters:
+
+- **Duplicate check**: search existing skills, rules, guides, hooks, and memory entries for equivalent behavior. Prefer extending the existing asset.
+- **Skip filter**: explicitly skip ambiguous, sensitive, one-off, or ownership-unclear candidates.
+- **Stable interface check**: require stable trigger, input, output, and verification evidence before recommending a skill.
+- **Frequency check**: one occurrence is memory/issue material; two direct repetitions can enter a shortlist; three or more direct repetitions or explicit user confirmation can justify promotion.
+
+When a candidate is skipped, include the skip reason so future extraction runs do not re-open the same weak proposal without new evidence.
+
 ## Output
 
 ```text

--- a/.codex/skills/pipeline/SKILL.md
+++ b/.codex/skills/pipeline/SKILL.md
@@ -24,6 +24,14 @@ source:
 
 ## Behavior
 
+## Workflow File Locations
+
+`workflows/*.yaml` is the Codex pipeline invocation surface used by `/pipeline <name>` in this repository. `templates/workflows/*.yaml` is its packaged template mirror and must remain content-identical.
+
+`.codex/skills/pipeline/workflows/*.yaml` is a skill-local reference copy retained for compatibility with older skill bundles and detailed examples. It is not the primary repo-root invocation surface unless a runtime explicitly resolves workflows relative to this skill directory.
+
+When changing pipeline behavior, update the active repo-root workflow first, update its template mirror in the same change, and then update skill-local reference copies when they describe the same behavior.
+
 ### List Mode (no arguments or --list flag)
 
 Execute these steps to display available pipelines:

--- a/.codex/skills/pipeline/labels.md
+++ b/.codex/skills/pipeline/labels.md
@@ -18,6 +18,8 @@ Used by `scope-selection` to include or exclude issues and by `implement` for li
 | `claude-code-release` | Claude compatibility release trigger | INCLUDE (preferred) |
 | `documentation` | Documentation-only scope | INCLUDE (preferred for docs-only release) |
 | `enhancement-yaml-only` | YAML/config-only scope change | INCLUDE (eligible for docs-only compression) |
+| `feedback` | Session feedback or retrospective follow-up | INCLUDE for low-risk rule/skill/doc scope |
+| `improvement` | Process or harness improvement | INCLUDE for low-risk rule/skill/doc scope |
 
 ## Selection Rule
 
@@ -43,6 +45,13 @@ An issue is eligible for `docs-only` compression mode if its labels include at l
 If all scoped issues are compression-eligible and scope size is 3 or fewer, the pipeline may use
 `compression_mode=docs-only` and replace heavyweight triage, planning, and verification spawns with
 direct manifest summaries plus a local self-review checklist.
+
+An issue is eligible for `lite` compression mode if its labels or triage evidence show a low-risk
+documentation, release-monitor, feedback, improvement, enhancement, YAML/config-only, or rule/skill text
+change. `lite` mode requires scope size 5 or fewer and must still run verify-build.
+
+Do not add or change labels solely to qualify for a compression tier. If triage label changes affect
+compression eligibility, report that fact in the compression-mode decision.
 
 ## Lifecycle Labels
 

--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -122,13 +122,22 @@ steps:
 
   - name: compression-mode-eval
     prompt: |
-      Evaluate whether this pipeline run qualifies for docs-only compression mode.
+      Evaluate whether this pipeline run qualifies for compression mode.
 
       Reference: .codex/skills/pipeline/labels.md — "Compression Eligibility" section.
 
       Conditions for compression_mode=docs-only:
       1. Scope size is 3 or fewer issues.
       2. All scoped issues have labels intersecting {documentation, automated, codex-release, oh-my-codex-release, claude-code-release, enhancement-yaml-only}.
+
+      Conditions for compression_mode=lite:
+      1. Scope size is 5 or fewer issues.
+      2. All scoped issues are documentation, automated release-monitor, feedback, improvement, enhancement, YAML/config-only, or low-risk rule/skill text.
+      3. No scoped issue requires TypeScript runtime behavior, package dependency changes, migration, or security-sensitive logic.
+
+      Gate transparency:
+      - Do not add or change labels solely to qualify for docs-only or lite mode.
+      - If labels were changed during triage and affect compression eligibility, state that fact in the mode decision.
 
       If both conditions match:
       - Set compression_mode=docs-only.
@@ -138,13 +147,19 @@ steps:
       - Deep-verify step: skip deep-verify skill; perform self-review checklist instead.
       - Log: "[compression-mode] docs-only compression activated (scope={n}, all docs/yaml labels)".
 
+      If lite conditions match:
+      - Set compression_mode=lite.
+      - Keep a concise implementation plan and local self-review.
+      - Still run verify-build.
+      - Log: "[compression-mode] lite compression activated (scope={n}, low-risk docs/rules/skills)".
+
       Otherwise:
       - Set compression_mode=standard.
       - Execute all pipeline steps normally with full skill spawns.
       - Log: "[compression-mode] standard mode (scope={n}, mixed labels or large scope)".
 
       Output compression_mode as pipeline state for downstream steps.
-    description: "Evaluate docs-only compression eligibility; set compression_mode state"
+    description: "Evaluate compression eligibility; set compression_mode state"
     depends_on: scope-selection
 
   - name: triage
@@ -191,6 +206,10 @@ steps:
   - name: verify-build
     prompt: |
       Project-specific build + test verification.
+
+      Scope-change re-entry guard:
+      - If a scoped issue is added or materially changed after verify-build starts, reset this phase and re-run the full verify-build gate for the new aggregate scope.
+      - Do not proceed to release from a verify-build result collected before the latest scoped implementation change.
 
       For Node/Bun projects (this repo):
       1. bun install — verify lockfile sync (halt on lockfile drift)

--- a/.codex/statusline.sh
+++ b/.codex/statusline.sh
@@ -408,8 +408,20 @@ if [[ -f "$env_status_file" ]]; then
     fi
 fi
 
+extra_segment=""
+if [[ -n "${STATUSLINE_EXTRA_PROVIDERS:-}" ]]; then
+    IFS=':' read -r -a extra_providers <<< "$STATUSLINE_EXTRA_PROVIDERS"
+    for provider in "${extra_providers[@]}"; do
+        [[ -n "$provider" && -x "$provider" ]] || continue
+        provider_output="$("$provider" </dev/null 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        if [[ -n "$provider_output" ]]; then
+            extra_segment="${extra_segment} | ${provider_output}"
+        fi
+    done
+fi
+
 if [[ -n "$git_branch" ]]; then
-    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$branch_display" \
@@ -418,9 +430,10 @@ if [[ -n "$git_branch" ]]; then
         "$wl_segment" \
         "$agent_segment" \
         "$rtk_segment" \
+        "$extra_segment" \
         "$ctx_display"
 else
-    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$pr_segment" \
@@ -428,5 +441,6 @@ else
         "$wl_segment" \
         "$agent_segment" \
         "$rtk_segment" \
+        "$extra_segment" \
         "$ctx_display"
 fi

--- a/.github/scripts/verify-template-sync.sh
+++ b/.github/scripts/verify-template-sync.sh
@@ -190,6 +190,8 @@ check_content_dir ".codex/rules" "templates/.claude/rules" "*.md" "rules"
 check_content_dir ".codex/agents" "templates/.claude/agents" "*.md" "agents"
 check_content_dir ".codex/hooks/scripts" "templates/.claude/hooks/scripts" "*.sh" "hooks/scripts"
 check_content_file ".codex/hooks/hooks.json" "templates/.claude/hooks/hooks.json" "hooks/hooks.json"
+check_content_file ".codex/statusline.sh" "templates/.claude/statusline.sh" "statusline.sh"
+check_content_dir "workflows" "templates/workflows" "*.yaml" "workflow yaml"
 
 while IFS= read -r src_skill; do
   skill_name=$(basename "$(dirname "$src_skill")")
@@ -207,7 +209,7 @@ if [ "$content_drift" -gt 0 ]; then
   echo "::error::$content_drift content drift(s) detected between .codex/ and templates/.claude/"
   errors=$((errors + content_drift))
 else
-  echo "[OK] Content drift check: rules, agents, hooks, and skills are in sync"
+  echo "[OK] Content drift check: rules, agents, hooks, statusline, workflow yaml, and skills are in sync"
 fi
 
 if [ "$errors" -gt 0 ]; then

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.11",
-  "generatedAt": "2026-06-02T14:13:40.588Z",
-  "templateVersion": "0.5.11",
+  "generatorVersion": "0.5.13",
+  "generatedAt": "2026-06-06T04:49:01.519Z",
+  "templateVersion": "0.5.13",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "b6851016a5f7e741e4de8aaee074fc74c126d938792f5f992d58e8ac80884d7d",
-      "size": 25898,
+      "templateHash": "c0ca0426f234e7859f8f372d287f1103313a28759c15d6a449e589c44ead8b90",
+      "size": 26613,
       "component": "rules"
     },
     ".codex/rules/MUST-intent-transparency.md": {
@@ -75,8 +75,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-continuous-improvement.md": {
-      "templateHash": "1f0fcc0381b9df78aa811c7b2e6867f665f98b77cf39cc2f04b2b9fed85edcff",
-      "size": 4341,
+      "templateHash": "9eb6b22d1fef645c5be412901faba5200cde07b71d4c46916300d6526e11cd27",
+      "size": 5098,
       "component": "rules"
     },
     ".codex/rules/MUST-permissions.md": {
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "5dc0f871fe19fa3721f861a968a2cc768920364ad41ea13c0546ea135bd87b4d",
-      "size": 11543,
+      "templateHash": "308097247642a506ccff4dac9409e5a3f1bb02bb59ca9bc25688a57b8fc436e3",
+      "size": 13150,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.13] - 2026-06-06
+
+### Added
+- Add statusline external provider merging through `STATUSLINE_EXTRA_PROVIDERS` and guard statusline/workflow template drift in `verify-template-sync.sh` for #1448 and #1455.
+- Add the missing `templates/workflows/eraser.yaml` mirror so workflow YAML drift is caught consistently.
+
+### Changed
+- Harden auto-dev compression guidance with `lite` mode transparency and verify-build re-entry after mid-run scope changes for #1468.
+- Strengthen R016, R020, and R010 guidance for skill-promotion thresholds, degraded-output re-verification, workflow script sanity checks, and delegated path existence checks for #1440, #1441, and #1442.
+
 ## [0.5.10] - 2026-06-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.12",
+  "version": "0.5.13",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -67,6 +67,29 @@ Parallel batches return results together, so a same-batch permanent dispatch pro
 
 Example: do not diagnose `triage-dispatch.yml` from memory, create an issue, and delegate a fix in the same parallel call before reading the workflow. If the read later shows a different root cause, the issue, PR, and commit trail become correction debt even when the eventual code direction is acceptable.
 
+## Degraded-Output Re-Verification Gate
+
+When tool output shows provider instability, buffering, truncation, duplicated chunks, `529`, timeout recovery, or `(no result)` while a permanent action is being considered, treat the current read as degraded. Do not characterize corruption, missing files, stale state, release failure, or data loss from that single degraded read.
+
+Before destructive recovery, issue creation, rule/workflow/template edits, release publication, or fix delegation based on degraded output:
+
+1. Re-read the authoritative source with a deterministic command or API call.
+2. Use a second narrow check that can falsify the failure hypothesis, such as `grep -c`, `sort -u`, `git status`, `git show`, `gh api`, or a direct file diff.
+3. Record whether the first read was degraded and whether the re-check confirmed or corrected the hypothesis.
+
+If the deterministic re-check cannot run, halt or reduce the action to a non-destructive diagnostic note.
+
+## Workflow Script Sanity Check
+
+Before invoking or registering generated workflow code, run a Tier-1 sanity pass:
+
+1. Search for unresolved placeholders, malformed identifiers, and known dead-line patterns.
+2. Assemble the exact script body before execution; do not concatenate facts or guardrails after the call starts.
+3. Run the language parser or the narrowest no-side-effect syntax check available.
+4. If syntax validation is unavailable, read the generated body back and perform a focused self-review before launch.
+
+This check is mandatory for workflow scripts that will run automation, mutate GitHub state, or gate a release.
+
 ## Test-Skip Is Not Completion
 
 Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO may be a temporary containment step, but it never satisfies completion by itself.

--- a/templates/.claude/rules/MUST-continuous-improvement.md
+++ b/templates/.claude/rules/MUST-continuous-improvement.md
@@ -51,6 +51,18 @@ When repeating agent failures or suboptimal routing is detected:
 
 This connects R016's continuous improvement loop with the adaptive-harness skill's learning capability.
 
+## Skill Promotion Threshold
+
+Promote a recurring workflow into a skill only when the evidence is strong enough to justify a durable interface.
+
+| Evidence | Action |
+|----------|--------|
+| One clear occurrence | Record memory or issue; do not create a skill by default |
+| Two direct successful repetitions with stable inputs/outputs | Candidate for `skill-extractor` Phase 1 shortlist |
+| Three or more direct repetitions, or two repetitions plus explicit user confirmation | Confirmed promotion candidate |
+
+Before creating a new skill, verify the candidate is not already covered by an existing skill, rule, guide, hook, or lightweight memory entry. Ambiguous, sensitive, one-off, or ownership-unclear candidates are explicitly skipped with a reason.
+
 ## External Repository Contribution Pre-Check
 
 Before creating or modifying assets for an external repository or upstream contribution target, inspect that repository's local contract before implementing:

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -248,6 +248,19 @@ Known limitation: `arch-documenter` has `disallowedTools: [Bash]`. Do not ask it
 
 The `agent-capability-precheck.sh` hook blocks obvious mismatches so the orchestrator re-routes before spawning an agent that cannot execute the requested work.
 
+### Delegated Path Existence Pre-Check
+
+Before putting concrete file paths in a delegated prompt, verify those paths exist or explicitly mark them as new files. A tool-capability match is insufficient when the prompt names a path.
+
+Required check:
+
+1. Use `rg --files`, `find`, `ls`, or the repository index to prove each existing path.
+2. If a path is missing, locate the current equivalent before delegating.
+3. Include only verified paths in the prompt, or say `create new file: <path>` when creation is intended.
+4. For multi-copy assets, verify all source/template mirrors before assigning the edit.
+
+Do not rely on the delegate to repair stale path guesses in shared workflow, rule, guide, or release tasks.
+
 <!-- DETAIL: Autonomous Execution Mode
 
 ## Autonomous Execution Mode

--- a/templates/.claude/skills/instinct-extractor/SKILL.md
+++ b/templates/.claude/skills/instinct-extractor/SKILL.md
@@ -41,6 +41,17 @@ Find repeated operator or agent behavior that should become a rule, skill, guide
 4. Assign confidence and cite concrete files, commits, or artifacts.
 5. Emit proposals only; do not create new rules or skills without an explicit follow-up task.
 
+## Selection Discipline
+
+Before emitting a reusable-asset proposal, apply these filters:
+
+- **Duplicate check**: search existing skills, rules, guides, hooks, and memory entries for equivalent behavior. Prefer extending the existing asset.
+- **Skip filter**: explicitly skip ambiguous, sensitive, one-off, or ownership-unclear candidates.
+- **Stable interface check**: require stable trigger, input, output, and verification evidence before recommending a skill.
+- **Frequency check**: one occurrence is memory/issue material; two direct repetitions can enter a shortlist; three or more direct repetitions or explicit user confirmation can justify promotion.
+
+When a candidate is skipped, include the skip reason so future extraction runs do not re-open the same weak proposal without new evidence.
+
 ## Output
 
 ```text

--- a/templates/.claude/skills/pipeline/SKILL.md
+++ b/templates/.claude/skills/pipeline/SKILL.md
@@ -24,6 +24,14 @@ source:
 
 ## Behavior
 
+## Workflow File Locations
+
+`workflows/*.yaml` is the Codex pipeline invocation surface used by `/pipeline <name>` in this repository. `templates/workflows/*.yaml` is its packaged template mirror and must remain content-identical.
+
+`.codex/skills/pipeline/workflows/*.yaml` is a skill-local reference copy retained for compatibility with older skill bundles and detailed examples. It is not the primary repo-root invocation surface unless a runtime explicitly resolves workflows relative to this skill directory.
+
+When changing pipeline behavior, update the active repo-root workflow first, update its template mirror in the same change, and then update skill-local reference copies when they describe the same behavior.
+
 ### List Mode (no arguments or --list flag)
 
 Execute these steps to display available pipelines:

--- a/templates/.claude/skills/pipeline/labels.md
+++ b/templates/.claude/skills/pipeline/labels.md
@@ -18,6 +18,8 @@ Used by `scope-selection` to include or exclude issues and by `implement` for li
 | `claude-code-release` | Claude compatibility release trigger | INCLUDE (preferred) |
 | `documentation` | Documentation-only scope | INCLUDE (preferred for docs-only release) |
 | `enhancement-yaml-only` | YAML/config-only scope change | INCLUDE (eligible for docs-only compression) |
+| `feedback` | Session feedback or retrospective follow-up | INCLUDE for low-risk rule/skill/doc scope |
+| `improvement` | Process or harness improvement | INCLUDE for low-risk rule/skill/doc scope |
 
 ## Selection Rule
 
@@ -43,6 +45,13 @@ An issue is eligible for `docs-only` compression mode if its labels include at l
 If all scoped issues are compression-eligible and scope size is 3 or fewer, the pipeline may use
 `compression_mode=docs-only` and replace heavyweight triage, planning, and verification spawns with
 direct manifest summaries plus a local self-review checklist.
+
+An issue is eligible for `lite` compression mode if its labels or triage evidence show a low-risk
+documentation, release-monitor, feedback, improvement, enhancement, YAML/config-only, or rule/skill text
+change. `lite` mode requires scope size 5 or fewer and must still run verify-build.
+
+Do not add or change labels solely to qualify for a compression tier. If triage label changes affect
+compression eligibility, report that fact in the compression-mode decision.
 
 ## Lifecycle Labels
 

--- a/templates/.claude/statusline.sh
+++ b/templates/.claude/statusline.sh
@@ -408,8 +408,20 @@ if [[ -f "$env_status_file" ]]; then
     fi
 fi
 
+extra_segment=""
+if [[ -n "${STATUSLINE_EXTRA_PROVIDERS:-}" ]]; then
+    IFS=':' read -r -a extra_providers <<< "$STATUSLINE_EXTRA_PROVIDERS"
+    for provider in "${extra_providers[@]}"; do
+        [[ -n "$provider" && -x "$provider" ]] || continue
+        provider_output="$("$provider" </dev/null 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        if [[ -n "$provider_output" ]]; then
+            extra_segment="${extra_segment} | ${provider_output}"
+        fi
+    done
+fi
+
 if [[ -n "$git_branch" ]]; then
-    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$branch_display" \
@@ -418,9 +430,10 @@ if [[ -n "$git_branch" ]]; then
         "$wl_segment" \
         "$agent_segment" \
         "$rtk_segment" \
+        "$extra_segment" \
         "$ctx_display"
 else
-    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$pr_segment" \
@@ -428,5 +441,6 @@ else
         "$wl_segment" \
         "$agent_segment" \
         "$rtk_segment" \
+        "$extra_segment" \
         "$ctx_display"
 fi

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.5.12",
+  "version": "0.5.13",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-06-01T00:00:00.000Z",
+  "lastUpdated": "2026-06-06T00:00:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -60,13 +60,24 @@ steps:
   - name: compression-mode-eval
     depends_on: scope-selection
     prompt: |
-      Evaluate docs-only compression mode.
+      Evaluate compression mode.
 
       Use `compression_mode=docs-only` only when:
       - scope size is 3 or fewer issues
       - every scoped issue has at least one of documentation, automated, codex-release, oh-my-codex-release, claude-code-release, or enhancement-yaml-only
 
-      In docs-only mode, replace heavyweight triage/plan/deep-plan/deep-verify spawns with direct summaries plus local self-review. Otherwise use standard mode.
+      Use `compression_mode=lite` only when:
+      - scope size is 5 or fewer issues
+      - every scoped issue is documentation, automated release-monitor, feedback, improvement, enhancement, YAML/config-only, or low-risk rule/skill text
+      - no scoped issue requires TypeScript runtime behavior, package dependency changes, migration, or security-sensitive logic
+
+      Gate transparency:
+      - Do not add or change labels solely to qualify for docs-only or lite mode.
+      - If labels were changed during triage and affect compression eligibility, state that fact in the mode decision.
+
+      In docs-only mode, replace heavyweight triage/plan/deep-plan/deep-verify spawns with direct summaries plus local self-review.
+      In lite mode, keep a concise implementation plan and local self-review, but still run verify-build.
+      Otherwise use standard mode.
       Output the selected compression_mode for downstream steps.
     description: Evaluate docs-only compression eligibility
 
@@ -99,6 +110,10 @@ steps:
     depends_on: implement
     prompt: |
       Project-specific build + test verification.
+
+      Scope-change re-entry guard:
+      - If a scoped issue is added or materially changed after verify-build starts, reset this phase and re-run the full verify-build gate for the new aggregate scope.
+      - Do not proceed to release from a verify-build result collected before the latest scoped implementation change.
 
       For Node/Bun projects:
       1. Run `bun install` and halt on lockfile drift.

--- a/templates/workflows/eraser.yaml
+++ b/templates/workflows/eraser.yaml
@@ -1,0 +1,60 @@
+# /pipeline eraser — Architecture documentation sync via Eraser MCP
+# Analyzes ARCHITECTURE.md, updates text, generates/replaces diagrams
+
+name: eraser
+description: "Architecture documentation sync: analyze → update text → generate/replace diagrams → verify"
+mode: confirm
+error: halt-and-report
+
+steps:
+  - name: analyze
+    prompt: >
+      Compare ARCHITECTURE.md counts/versions against actual codebase.
+      Run: agent count (ls .claude/agents/*.md | wc -l),
+      skill count (find .claude/skills -name SKILL.md | wc -l),
+      guide count (find guides -mindepth 1 -maxdepth 1 -type d | wc -l).
+      Compare with documented values. List outdated sections.
+    description: >
+      Compare ARCHITECTURE.md counts/versions against actual codebase.
+      Run: agent count (ls .claude/agents/*.md | wc -l),
+      skill count (find .claude/skills -name SKILL.md | wc -l),
+      guide count (find guides -mindepth 1 -maxdepth 1 -type d | wc -l).
+      Compare with documented values. List outdated sections.
+
+  - name: update-text
+    prompt: >
+      Update ARCHITECTURE.md and ARCHITECTURE_ko.md text content:
+      version numbers, agent/skill/guide counts, feature descriptions,
+      new sections for recently added features, version history.
+      Delegate to arch-documenter agent.
+    description: >
+      Update ARCHITECTURE.md and ARCHITECTURE_ko.md text content:
+      version numbers, agent/skill/guide counts, feature descriptions,
+      new sections for recently added features, version history.
+      Delegate to arch-documenter agent.
+
+  - name: generate-diagrams
+    prompt: >
+      Use Eraser MCP to generate/replace diagrams in assets/diagrams/.
+      Diagram types: renderCloudArchitectureDiagram (system overview),
+      renderSequenceDiagram (API flows), renderFlowchart (decision flows).
+      Settings: imageQuality 2, format png, background true, theme light,
+      typeface clean, colorMode bold.
+      Download generated images and save to assets/diagrams/.
+    description: >
+      Use Eraser MCP to generate/replace diagrams in assets/diagrams/.
+      Diagram types: renderCloudArchitectureDiagram (system overview),
+      renderSequenceDiagram (API flows), renderFlowchart (decision flows).
+      Settings: imageQuality 2, format png, background true, theme light,
+      typeface clean, colorMode bold.
+      Download generated images and save to assets/diagrams/.
+
+  - name: verify
+    skill: dev-review
+    description: >
+      Verify all image references are valid, counts match filesystem,
+      no broken links, English and Korean docs are synchronized.
+
+  - name: release
+    prompt: "Create PR with documentation updates"
+    description: Create PR with documentation updates

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -60,13 +60,24 @@ steps:
   - name: compression-mode-eval
     depends_on: scope-selection
     prompt: |
-      Evaluate docs-only compression mode.
+      Evaluate compression mode.
 
       Use `compression_mode=docs-only` only when:
       - scope size is 3 or fewer issues
       - every scoped issue has at least one of documentation, automated, codex-release, oh-my-codex-release, claude-code-release, or enhancement-yaml-only
 
-      In docs-only mode, replace heavyweight triage/plan/deep-plan/deep-verify spawns with direct summaries plus local self-review. Otherwise use standard mode.
+      Use `compression_mode=lite` only when:
+      - scope size is 5 or fewer issues
+      - every scoped issue is documentation, automated release-monitor, feedback, improvement, enhancement, YAML/config-only, or low-risk rule/skill text
+      - no scoped issue requires TypeScript runtime behavior, package dependency changes, migration, or security-sensitive logic
+
+      Gate transparency:
+      - Do not add or change labels solely to qualify for docs-only or lite mode.
+      - If labels were changed during triage and affect compression eligibility, state that fact in the mode decision.
+
+      In docs-only mode, replace heavyweight triage/plan/deep-plan/deep-verify spawns with direct summaries plus local self-review.
+      In lite mode, keep a concise implementation plan and local self-review, but still run verify-build.
+      Otherwise use standard mode.
       Output the selected compression_mode for downstream steps.
     description: Evaluate docs-only compression eligibility
 
@@ -99,6 +110,10 @@ steps:
     depends_on: implement
     prompt: |
       Project-specific build + test verification.
+
+      Scope-change re-entry guard:
+      - If a scoped issue is added or materially changed after verify-build starts, reset this phase and re-run the full verify-build gate for the new aggregate scope.
+      - Do not proceed to release from a verify-build result collected before the latest scoped implementation change.
 
       For Node/Bun projects:
       1. Run `bun install` and halt on lockfile drift.


### PR DESCRIPTION
## Summary
- harden auto-dev compression decisions with lite-mode transparency and verify-build re-entry after mid-run scope changes
- add degraded-output, workflow script sanity, delegated path existence, and skill-promotion guardrails across source/template surfaces
- add statusline extra provider support and expand template drift checks to statusline plus workflow YAML mirrors
- bump package/template metadata to v0.5.13

## Scope
Addresses selected auto-dev release scope: #1440, #1441, #1442, #1448, #1455, #1468.

## Verification
- bash .github/scripts/verify-template-sync.sh
- bash -n .codex/statusline.sh
- bash -n .github/scripts/verify-template-sync.sh
- bun install
- bun run lint
- bun run typecheck
- bun test (external rerun: 1834 pass, 0 fail)
- bun run build
- bash .github/scripts/verify-version-sync.sh
- git diff --check
- pre-commit stable batches passed during commit

## Publish
Not published yet. npm publish / registry verification should run only after PR merge and release approval.