### PR TITLE
Release v0.5.14 Codex harness parity updates

### DIFF
--- a/.codex/hooks/hooks.json
+++ b/.codex/hooks/hooks.json
@@ -110,7 +110,7 @@
             "command": "bash .codex/hooks/scripts/rtk-intercept.sh"
           }
         ],
-        "description": "RTK auto-intercept — transparently rewrites CLI commands through RTK proxy when available (R015 advisory)"
+        "description": "RTK auto-intercept — transparently rewrites CLI commands through RTK proxy when available (R013 advisory)"
       },
       {
         "matcher": "tool == \"Bash\" && tool_input.command matches \"(rm|git rm|mv|unlink|codex/rules)\"",

--- a/.codex/rules/MUST-agent-design.md
+++ b/.codex/rules/MUST-agent-design.md
@@ -75,6 +75,17 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 Agent frontmatter `hooks:` fire when the agent runs as a main-thread agent via `--agent` flag in v2.1.116+. Hook JSON output `terminalSequence` field for desktop notifications, window title changes, and terminal bells without controlling terminal added in v2.1.141+. `claude agents --cwd <path>` for directory-scoped session lists added in v2.1.141+. Background agents launched via `/bg` preserve current permission mode in v2.1.141+. `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` and `ANTHROPIC_WORKSPACE_ID` environment variables added in v2.1.141+ for HTTPS plugin clones and workspace-scoped federation.
 -->
 
+<!-- DETAIL: Claude Compatibility Notes for Packaged `.claude` Templates
+This Codex port ships `.claude` compatibility templates. When updating those templates, account for recent Claude Code behavior even though the active runtime surface is Codex/OMX:
+
+- v2.1.159: no user-facing template action required (internal infrastructure release).
+- v2.1.160: `acceptEdits` prompts for build-tool config writes; grep/egrep/fgrep of a single file can satisfy read-before-edit in Claude Code, but Codex agents should still follow the active Codex read/edit policy.
+- v2.1.161: independent parallel tool calls no longer cancel siblings when one Bash call fails; this supports R009 same-message batching for independent work.
+- v2.1.162: `claude agents --json` includes waiting/blocker metadata and explicit `--tools Grep/Glob` behavior is fixed; compatibility prompts may use those fields when diagnosing stuck Claude sessions.
+- v2.1.163: managed `requiredMinimumVersion`/`requiredMaximumVersion`, `/plugin list`, Stop/SubagentStop `hookSpecificOutput.additionalContext`, and skill command literal `\$` escaping are available. Hook/skill template changes should preserve these affordances.
+- v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation.
+-->
+
 ## Hook Event Types
 
 27 event types documented: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest, PermissionDenied, PostToolUse, PostToolUseFailure, Notification, SubagentStart, SubagentStop, TaskCreated, TaskCompleted, Stop, StopFailure, TeammateIdle, InstructionsLoaded, ConfigChange, CwdChanged, FileChanged, WorktreeCreate, WorktreeRemove, PreCompact, PostCompact, Elicitation, ElicitationResult, PostMessage, SessionEnd. 4 handler types: command, prompt, http, agent. See full reference table via Read tool.

--- a/.codex/rules/MUST-agent-teams.md
+++ b/.codex/rules/MUST-agent-teams.md
@@ -48,6 +48,20 @@ Quick rule: explicit user preference for plain subagents wins. Otherwise use Tea
 7. Otherwise, use Agent Teams when collaboration or shared state has material value.
 -->
 
+## Gate Transparency
+
+For 3+ agent dispatches, announce the R018 gate result before spawning (Agent Tool fallback reason or Agent Teams choice).
+
+<!-- DETAIL: Gate Transparency
+When the R018 gate resolves to standalone Agent Tool for a 3+ agent dispatch (for example mechanical disjoint-file editing with no review loop), announce the gate result in one line before spawning: `R018 gate: 3 disjoint-file domains, no review loop → Agent Tool fallback`. Silently selecting Agent Tool on a 3+ agent batch loses the gate-evaluation audit trail.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 3+ 에이전트 병렬 스폰 announce에 게이트 평가 결과 누락 | 스폰 전 한 줄로 Agent Tool 폴백 사유 또는 Agent Teams 선택 사유 명시 |
+
+Origin: #1464.
+-->
+
 ## Spawn Completeness
 
 Spawn all members for a parallel team slice in one message; partial/sequential spawning needs correction.

--- a/.codex/rules/MUST-orchestrator-coordination.md
+++ b/.codex/rules/MUST-orchestrator-coordination.md
@@ -257,7 +257,7 @@ Required check:
 1. Use `rg --files`, `find`, `ls`, or the repository index to prove each existing path.
 2. If a path is missing, locate the current equivalent before delegating.
 3. Include only verified paths in the prompt, or say `create new file: <path>` when creation is intended.
-4. For multi-copy assets, verify all source/template mirrors before assigning the edit.
+4. For multi-copy assets, verify all source/template mirrors before assigning the edit. If the copies are expected to match, check content identity (`cmp`, checksum, or `diff -q`) before delegation; if they intentionally differ, document the canonical source and drift rationale in the prompt.
 
 Do not rely on the delegate to repair stale path guesses in shared workflow, rule, guide, or release tasks.
 

--- a/.codex/rules/MUST-parallel-execution.md
+++ b/.codex/rules/MUST-parallel-execution.md
@@ -30,15 +30,21 @@ Before writing/editing multiple files:
 1. Are files independent? → YES: spawn parallel agents
 2. Using Write/Edit sequentially for 2+ files? → parallelize instead
 3. Specialized agent available? → Use it (not general-purpose)
-4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents**
+4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents; announce 3+ agent gate result**
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
+6. Parallel dispatch announced? → put all announced tool calls in the same message
 
 ### Common Violations to Avoid
 
+<!-- DETAIL: Common Violations Short Examples
 ```
 ❌ WRONG: Write(file1.kt) → Write(file2.kt) → ... (sequential)
 ✓ CORRECT: Agent(agent1→file1.kt) + Agent(agent2→file2.kt) + ... (same message, parallel)
+
+❌ WRONG: Announce "milestone 생성 + 구조 확인 병렬" but dispatch only one tool; run the other next turn (announce-execution mismatch)
+✓ CORRECT: When announcing N parallel tools, include ALL N tool calls in the SAME message as the announcement
 ```
+-->
 
 <!-- DETAIL: Full violation examples (4 pairs)
 ❌ WRONG: Writing files one by one
@@ -57,6 +63,10 @@ Before writing/editing multiple files:
 -->
 
 > **Agent Teams partial spawn** → See R018 (MUST-agent-teams.md) "Spawn Completeness Check".
+
+<!-- DETAIL: v2.1.161 compatibility
+Claude Code parallel tool calls in a single batch are independent — one failed Bash command no longer cancels sibling calls. This lowers the safety cost of R009 announce-execution consistency for independent work.
+-->
 
 ## Execution Rules
 

--- a/.codex/rules/SHOULD-memory-integration.md
+++ b/.codex/rules/SHOULD-memory-integration.md
@@ -285,6 +285,30 @@ User Model data feeds into intent-detection (R015) and routing skill confidence 
 
 -->
 
+<!-- DETAIL: Attention-Weight Memory Tiering
+> Origin: #1450 (Dual-Brain scout:internalize partial port — attention-weight tiering only)
+
+Memory entries are managed across two orthogonal axes: confidence and attention weight. Confidence answers “how verified is this?”; attention weight answers “how frequently/recently should this be loaded?”.
+
+| Axis | Tag example | Meaning |
+|------|-------------|---------|
+| Confidence | `[confidence: high/medium/low]` | Verification level |
+| Attention Weight | `[tier: hot/warm/cold/archived]` | Loading priority and recency/frequency |
+
+### 4-tier policy
+
+| Tier | Meaning | Handling |
+|------|---------|----------|
+| Hot | Active current-session patterns | Keep near the top of MEMORY.md / active recall |
+| Warm | Recently relevant patterns | Keep in MEMORY.md after Hot entries |
+| Cold | Rarely referenced but still useful | Move to an archive/index when memory budget is tight |
+| Archived | Long-inactive or superseded | Keep only an index/reference unless explicitly recalled |
+
+Promotion happens when an entry is referenced or re-verified. Demotion happens during session-end memory maintenance when an entry has not been referenced across recent sessions. `[permanent]` entries are exempt from automatic demotion.
+
+Budget rule: when approaching the MEMORY.md 200-line prompt budget, prune/archive Cold entries first, then low-confidence Warm entries. Hot entries should remain available unless contradicted by evidence.
+-->
+
 ## Mid-Session Immediate Save
 
 Save memory IMMEDIATELY upon surprising discovery — do not defer to session end.

--- a/.codex/skills/homework/SKILL.md
+++ b/.codex/skills/homework/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: homework
+description: On explicit /homework invocation, analyze the current and linked previous sessions, extract mistakes (찐빠), and report them via omcustomcodex:feedback with a confirmation gate. Auto-activation on session cleanup/session-end signals is OPT-IN (default OFF) — requires an explicit project/user directive. Use when explicitly auditing recent work for harness gaps.
+scope: harness
+user-invocable: true
+argument-hint: "[--dry-run] [--days <n>] [--severity <critical|high|medium|low>]"
+version: 0.1.0
+effort: medium
+---
+
+# Homework — Session Mistake Extractor
+
+> Codex port: use this as the project-local `homework` skill. Reporting routes through `omcustomcodex:feedback`; dry-run writes under `.codex/outputs/`.
+
+On session cleanup ("세션 정리") or `/homework` invocation, analyze the current and linked previous sessions to extract 찐빠 (mistakes: rule violations, scope-creep, hallucinations, premature hypotheses, missed conventions, etc.), then report findings via `omcustomcodex:feedback` with a mandatory user confirmation gate.
+
+This skill is the dedicated entry point for R011's "Session-End Retrospective Feedback (Model-Drafted)" pattern. It formalizes the retrospective workflow that produced issue #1266.
+
+## Usage
+
+```
+/homework                          # Analyze current session, report findings
+/homework --dry-run                # Analyze only, no omcustomcodex:feedback invocation
+/homework --days 3                 # Include linked sessions from last N days
+/homework --severity high          # Filter to critical/high findings only
+```
+
+## Trigger Detection
+
+**Default: OFF for auto-activation.** This skill does NOT auto-run on session cleanup or session-end signals unless explicitly enabled. The default is `false` — silence is a non-trigger.
+
+Activate ONLY when:
+- **Explicit `/homework` invocation** (always runs)
+- **Explicit opt-in**: the user/project has explicitly directed homework to run on session cleanup — e.g., a AGENTS.md directive such as "run homework on every session cleanup", or a settings flag. A one-off explicit request ("회고 돌려줘", "homework 실행") also counts.
+
+If no explicit opt-in exists, treat session-cleanup / session-end phrases ("세션 정리", "숙제", "회고", "끝", "종료", "마무리", "done", "wrap up", "session cleanup", "end session") as **NON-triggers** — do NOT auto-run. You MAY briefly remind the user that `/homework` is available, then proceed with normal session-end handling.
+
+When auto-activation IS explicitly enabled and fires as a session-end signal, this skill runs BEFORE memory-save's MEMORY.md update (R011 session-end self-check order: homework → memory save).
+
+## Workflow
+
+### Phase 1: Trigger Parsing
+
+Parse arguments:
+- `--dry-run`: analyze only, skip Phase 5 (omcustomcodex:feedback invocation)
+- `--days <n>`: extend linked-session search to last N days (default: 0 = current session only)
+- `--severity <level>`: filter output to this severity and above (default: all)
+
+### Phase 2: Session Gathering
+
+#### 2a. Current Session Transcript
+
+Attempt deterministic transcript extraction. Preferred sources (in order):
+
+1. **Grep for rule-violation markers** in the current conversation context:
+   - Safety classifier trip signals: `[Safety]`, `[R001]`, `[Warning]`, classifier denial messages
+   - Self-corrections: "sorry", "I made an error", "let me correct", "이전 답변 수정", "죄송합니다"
+   - Premature hypothesis signals: "I assume", "probably", "should be" followed by a contradiction in a later turn
+   - Interrupt + re-plan events: user corrections, "no", "wrong", "다시", "아니"
+
+2. **Transcript files** (Codex session JSONL):
+   ```bash
+   find ~/.codex/sessions -name "session-*.jsonl" -newer "$(date -v-1d +%Y-%m-%dT00:00:00)" 2>/dev/null | head -5
+   ```
+   Parse `type: "error"`, `type: "correction"`, `type: "feedback"` events.
+
+3. **Fallback**: Rely on the model's recall of the current conversation (impressionistic, lower confidence — mark findings as `[recall]` not `[transcript]`).
+
+#### 2b. Linked Previous Sessions (when `--days` > 0)
+
+Use the `episodic-memory` plugin's `search-conversations` / `episodic-memory:remembering-conversations` to retrieve sessions from the last N days linked to this project. Pass project directory as context.
+
+If `episodic-memory` is unavailable, scan JSONL files:
+```bash
+find ~/.codex/sessions -name "session-*.jsonl" \
+  -newer "$(date -v-${DAYS}d +%Y-%m-%dT00:00:00)" 2>/dev/null
+```
+
+**R020 read-before-characterize**: Do NOT characterize a session's mistakes before reading it. Read the session transcript (or a representative sample) first, then characterize.
+
+### Phase 3: Mistake (찐빠) Analysis
+
+Categorize each finding with the following structure (mirror #1266 format):
+
+```
+찐빠 #N — [{severity}] {short title}
+├── 증상: {what was observed — cite evidence: session line ref or commit SHA}
+├── 근거: {transcript evidence or recall note — always read first per R020}
+├── 원인: {root cause — why did this happen?}
+├── 영향 규칙: {R0xx, R0yy — affected rule IDs}
+└── 제안: {concrete corrective action or harness change}
+```
+
+**Severity scale:**
+
+| Level | Criteria | Examples |
+|-------|----------|---------|
+| Critical | Safety classifier trip, credential exposure, scope-creep into privileged domains, working-tree loss | R001 violation, secret dump, unauthorized infra action |
+| High | Rule violation with downstream impact, hallucinated fact acted upon, premature hypothesis causing permanent change | R020 Parallel Read+Change, wrong root cause → wrong fix |
+| Medium | Process gap, missed convention, advisory rule ignored | R007 header missing, bypassPermissions omitted, count sync missed |
+| Low | Minor style drift, non-impactful oversight | honorific regression, ecomode token waste |
+
+**Mistake categories to look for:**
+
+| Category | Signals |
+|----------|---------|
+| Rule violations (R0xx) | Header missing (R007), tool prefix absent (R008), file write by orchestrator (R010), sequential when parallel required (R009) |
+| Scope-creep | Subagent task expanding beyond its named scope (R010 Subagent Scope-Creep STOP Protocol) |
+| Hallucinated facts | External UI fields stated as fact (R003 Unverifiable External Product UI), in-cluster hostnames, unverified URLs |
+| Premature hypotheses | Diagnosis before reading evidence (R020 Read-Before-Characterize), parallel Read+permanent-change dispatch (R020 Variant) |
+| Missed conventions | Count sync drift (3-way sync), template mirror omitted, bypassPermissions missing |
+| Over-claim completion | [Done] without verification (R020), test-skip masking failures |
+
+**Do NOT over-claim.** If evidence for a finding is weak or based on recall only, mark it `[recall, low-confidence]` and note what would be needed to confirm it. R020 read-before-characterize applies to this analysis itself.
+
+### Phase 4: Draft Feedback Issue
+
+Assemble a feedback issue in Korean using the #1266 format:
+
+```markdown
+**제목**: 세션 회고: {date} 세션 찐빠 {N}건 — {top finding title}
+
+**카테고리**: improvement
+
+**본문**:
+## 세션 회고 — {YYYY-MM-DD}
+
+### 개요
+총 {N}건의 찐빠가 발견되었습니다 (Critical: {c}, High: {h}, Medium: {m}, Low: {l}).
+
+### 찐빠 목록
+
+{찐빠 #1 ~ #N — structured format from Phase 3}
+
+### 하네스 제안 (있는 경우)
+{Concrete skill/rule/hook changes that would prevent recurrence}
+
+---
+*Generated by `/homework` skill (v0.1.0)*
+```
+
+If `--severity` filter is active, include only findings at or above the threshold. Note the filter in the issue body.
+
+If no findings are discovered, output:
+```
+[homework] 이번 세션에서 찐빠를 발견하지 못했습니다. (세션 정상 종료)
+```
+and skip Phase 5.
+
+### Phase 5: Report via omcustomcodex:feedback (Phase 4A gate)
+
+**MUST go through the `omcustomcodex:feedback` skill's Phase 4A preview + confirmation gate.**
+**NEVER auto-submit.** User approval is always required before any GitHub issue is created.
+
+Invoke the `omcustomcodex:feedback` skill with the drafted issue content. The user will see a preview and must confirm before any GitHub issue is created.
+
+```
+[homework] 피드백 이슈 초안을 omcustomcodex:feedback으로 전달합니다.
+아래 미리보기를 확인하고 제출 여부를 결정해 주세요.
+```
+
+If `--dry-run` is active, skip this phase and output the draft directly to the conversation instead.
+
+### Phase 6: Output Summary
+
+```
+[homework] 완료
+├── 분석: {N}건 찐빠 발견 (Critical: {c}, High: {h}, Medium: {m}, Low: {l})
+├── 제출: {이슈 URL | dry-run (미제출) | 사용자 취소}
+└── 다음 액션: {harness 제안 있으면 표시, 없으면 "없음"}
+```
+
+## Options Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dry-run` | off | Analyze only, no omcustomcodex:feedback invocation |
+| `--days <n>` | 0 | Include linked sessions from last N days (0 = current session only) |
+| `--severity <level>` | all | Filter findings to this level and above |
+
+## Rules & Cross-References
+
+| Rule | Relevance |
+|------|-----------|
+| R011 (SHOULD-memory-integration) | This skill is the dedicated entry point for "Session-End Retrospective Feedback (Model-Drafted)". Runs before memory-save MEMORY.md update. |
+| R020 (MUST-completion-verification) | Analysis MUST read transcript evidence before characterizing a mistake. Do NOT characterize before reading (Read-Before-Characterize). Parallel Read + Permanent-Change Dispatch anti-pattern applies here too. |
+| R016 (MUST-continuous-improvement) | Genuine defects/process gaps → feedback issue. The /homework output feeds R016's continuous improvement loop. |
+| R010 (MUST-orchestrator-coordination) | Any file writes in this workflow must be delegated to subagents. This skill orchestrates, never directly writes except to `.codex/outputs/`. |
+| R001 (MUST-safety) | Analysis must not dump credential values, secrets, or PII. Reference sensitive items by name only. |
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `omcustomcodex:feedback` | Reporting channel (Phase 5). Model-invocable with Phase 4A confirmation gate. |
+| `instinct-extractor` | Cross-session failure-pattern mining (complements /homework's single-session focus). For multi-session patterns, run instinct-extractor after homework. |
+| `episodic-memory:search-conversations` | Cross-session retrieval for `--days` mode. |
+| `memory-save` | Runs after /homework at session end when the project opts into that order (R011 order: homework → memory save). |
+
+## Artifact Output
+
+```
+.codex/outputs/sessions/{YYYY-MM-DD}/homework-{HHmmss}.md
+```
+
+If Phase 5 is skipped (`--dry-run`), the draft issue body is written to this artifact path for reference.
+
+## Permission Mode Note
+
+This skill does not spawn subagents directly. If future versions delegate analysis to subagents, ALL Agent tool calls MUST include `mode: "bypassPermissions"` per R010 Universal bypassPermissions.
+
+## Context Fork Note
+
+This skill does NOT use `context: fork`. The fork cap is at 10/12; homework is a single-agent orchestration skill and does not require a forked context.
+
+## Limitations
+
+- **Transcript availability**: Codex session JSONL schema may change; Phase 2a source (1) grep is more resilient than JSONL parsing.
+- **Recall accuracy**: When transcript files are unavailable, findings are marked `[recall]` and confidence is lower.
+- **episodic-memory dependency**: `--days` mode degrades gracefully when the plugin is unavailable (falls back to JSONL scan).
+- **Scope**: This skill analyzes session behavior, not code quality. For code-quality retrospectives, use `dev-review` or `adversarial-review`.

--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -261,6 +261,7 @@ steps:
          - git tag + push
          - gh release create
       4. Close milestone
+         - After closing a milestone, verify by milestone number (not title-only search) and retry once before reporting missing.
       5. Close verify-ready issues with "Fixed in v{version}"
          Label needs-review issues as "Deferred from v{version}"
 

--- a/.codex/skills/research/SKILL.md
+++ b/.codex/skills/research/SKILL.md
@@ -117,6 +117,8 @@ fi
 
 **Action**: `[Pre-flight] WARN: Context usage at {pct}%. 10-team research typically adds 30-40% context. Consider /compact before proceeding, or results may be truncated.`
 
+> **File-absent branch (#1466)**: `$CONTEXT_FILE`가 존재하지 않으면 입력이 측정 불가하다 — `PASS (context budget unmeasured — file absent)`로 보고하고 WARN을 내지 않는다. 파일을 읽지 않고 WARN 상태를 특성화하지 않는다(R020 Read-Before-Characterize). WARN은 파일이 존재하고 `context_pct > 40`일 때만 emit한다.
+
 ### Display Format
 
 ```
@@ -223,6 +225,10 @@ Sensitive-path compatibility note: when delegated work touches `.claude/outputs/
 | Orchestrator only | Main conversation manages all phases (R010) |
 | Ecomode | Auto-activate for team result aggregation (R013) |
 | Intent display | Show research plan before execution (R015) |
+
+## External Quantitative-Fact Source Tagging
+
+Research teams that collect concrete quantitative claims (benchmark numbers, table values, metrics) via WebFetch must tag them in synthesis/report output as `WebFetch-derived (unverified)` unless independently verified from a primary source such as the PDF/original paper. Multiple teams fetching the same URL can share the same WebFetch cache artifact, so agreement across those fetches is not independent ground-truth. Do not write exact load-bearing numbers into persistent issues/artifacts as fact without primary-source verification or an explicit unverified tag (R020, R023).
 
 ## Retrieval-Reasoning Separation
 
@@ -482,3 +488,5 @@ Agent(
 | dag-orchestration | Phase sequencing follows DAG pattern |
 | result-aggregation | Team results formatted per aggregation skill |
 | multi-model-verification | Phase 2 uses multi-model verification pattern |
+
+When spawning agents via the Agent tool during this skill execution, always pass `mode: "bypassPermissions"` when the session uses bypass permissions. The Agent tool default (`acceptEdits`) can cause permission prompts during unattended execution.

--- a/.codex/skills/scout/SKILL.md
+++ b/.codex/skills/scout/SKILL.md
@@ -2,7 +2,7 @@
 name: scout
 description: Analyze external URL to evaluate fit with oh-my-customcodex project and auto-create GitHub issue with verdict
 scope: core
-version: 1.0.0
+version: 1.0.1
 user-invocable: true
 argument-hint: "<url>"
 ---
@@ -33,6 +33,15 @@ Sensitive-path compatibility note: if this skill delegates work that touches `.c
 
 ## Pre-flight Guards
 
+### Pre-flight Execution Checklist (MANDATORY before Phase 1)
+
+**Both guards MUST be executed before entering Phase 1.** Skipping either guard is a workflow violation.
+
+- [ ] Guard 1: URL Validity check passed (abort if invalid)
+- [ ] Guard 2: Duplicate Scout check passed (warn and confirm if duplicate found)
+
+Proceed to Phase 1 only after both checkboxes are satisfied.
+
 ### Guard 1: URL Validity (GATE)
 
 Before any work, validate the URL:
@@ -56,6 +65,8 @@ gh issue list --state all --label "scout:internalize,scout:integrate,scout:skip"
 
 If found: `[Pre-flight] WARN: Similar URL already scouted in issue #N. Proceed anyway? [Y/n]`
 
+> **Why mandatory?** Guard 2 생략으로 인해 동일 도메인 중복 scout 이슈가 생성된 사례 발생. 중복 triage 낭비를 방지하기 위해 Pre-flight 체크리스트로 승격.
+
 ## Display Format
 
 Before execution, show the plan:
@@ -71,6 +82,8 @@ Before execution, show the plan:
 실행하시겠습니까? [Y/n]
 ```
 
+> **암묵 승인 시 필수**: "되면 /scout으로 보고", "실행해줘" 등 묵시적 승인인 경우에도 위 plan 요약을 **반드시 1줄 이상 표시한 뒤 진행**한다. plan 표시 없이 바로 Phase 1으로 진입하지 않는다.
+
 ## Workflow
 
 ### Phase 1: Fetch & Summarize
@@ -81,6 +94,8 @@ Before execution, show the plan:
    - Key technology / methodology
    - Approach and principles
 3. If fetch fails — report error, abort
+
+> **External quantitative-fact source tagging** (#1466): WebFetch가 산출한 구체적 정량 주장(benchmark 수치, table 값, metric)은 이슈 본문에 `WebFetch-derived (unverified)`로 태깅한다 — 검증된 사실로 제시하지 않는다. WebFetch 캐시/요약은 독립 ground-truth가 아니므로, load-bearing 수치는 primary PDF/원문으로 1회 검증하거나 명시적으로 unverified로 표기한다. (R020 Read-Before-Characterize, R023 Verifier Ground-Truth)
 
 ### Phase 2: Load Project Philosophy
 
@@ -96,7 +111,7 @@ Before execution, show the plan:
 
 Spawn 1 sonnet agent with the following analysis prompt.
 
-> **Permission Mode**: When spawning the analysis agent, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+> **MUST**: When spawning the analysis agent, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits` and may interrupt unattended execution.
 
 **Inputs**:
 - Fetched content summary (Phase 1)
@@ -146,6 +161,8 @@ Return a structured verdict:
 **Output**: Structured verdict with rationale.
 
 ### Phase 4: Issue Creation
+
+> **NOTE**: Phase 4 is normally handled by the orchestrator with `gh issue create`. If issue creation is delegated to an agent, that Agent tool call also MUST include `mode: "bypassPermissions"` when the session uses bypass permissions.
 
 1. Ensure scout labels exist (defensive, idempotent):
 ```bash

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.13",
-  "generatedAt": "2026-06-06T04:49:01.519Z",
-  "templateVersion": "0.5.13",
+  "generatorVersion": "0.5.14",
+  "generatedAt": "2026-06-06T05:48:42.717Z",
+  "templateVersion": "0.5.14",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "c0ca0426f234e7859f8f372d287f1103313a28759c15d6a449e589c44ead8b90",
-      "size": 26613,
+      "templateHash": "d75e8027b087e8488effd47c539190937fa1ce70ec5930616f0a60bfe4eb4137",
+      "size": 26819,
       "component": "rules"
     },
     ".codex/rules/MUST-intent-transparency.md": {
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-parallel-execution.md": {
-      "templateHash": "80348744a85decb1904d823de4c810755545f1abc171ff72935ed0361b4f7537",
-      "size": 7849,
+      "templateHash": "af6927bbea99a7efbcd4e7b90b2106b766a21368dbf0efab6424325dd4968b6e",
+      "size": 8529,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ecomode.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-design.md": {
-      "templateHash": "f2b9fb69b55db01e16d097889f4ff29a524e5f85497fc4c2ca5aae5068403052",
-      "size": 24978,
+      "templateHash": "1e381519c8a6411a712d232b7a3174122ccd2f04adacbcc7669452f6eda57e59",
+      "size": 26275,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-teams.md": {
-      "templateHash": "3d9eb8880dafba1a05ead752f9af9ba6edd6823b190078a90b86bbb1da765c7c",
-      "size": 8149,
+      "templateHash": "e16121ca5c210b41ba7f9944c0d4e7b2465e4cf09ccb4f661bf35476077506d9",
+      "size": 8936,
       "component": "rules"
     },
     ".codex/rules/MAY-optimization.md": {
@@ -100,8 +100,8 @@
       "component": "rules"
     },
     ".codex/rules/SHOULD-memory-integration.md": {
-      "templateHash": "420e8419f73965d8c228acdd0d293b9b1119d4f56c25b3b7452718e85188c6f9",
-      "size": 17260,
+      "templateHash": "9894c0af344f9ee40379696a28e0d128fee11257f0362dcbb9b95f8312f2a774",
+      "size": 18747,
       "component": "rules"
     },
     ".codex/rules/MUST-enforcement-policy.md": {
@@ -595,7 +595,7 @@
       "component": "hooks"
     },
     ".codex/hooks/hooks.json": {
-      "templateHash": "0692f65ffe380aa1ccaa49969ba69029e8c37c6fe24d4021f5c5274741d3e396",
+      "templateHash": "2e9cd9eee40db0f1ee84f5329c44c11b6e959916bb915d9aba59eb40ebb52ac4",
       "size": 28853,
       "component": "hooks"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.14] - 2026-06-06
+
+### Added
+- Add the Codex-port `homework` skill with opt-in session-end activation and `omcustomcodex:feedback` confirmation-gate routing for #1467.
+- Add R011 attention-weight memory tiering guidance from the Dual-Brain scout internalization for #1450.
+- Record Claude Code v2.1.159-v2.1.165 compatibility notes for packaged `.claude` templates for #1449, #1451, #1461, #1465, #1469, and #1470.
+
+### Changed
+- Harden scout/research quantitative fact handling, pre-flight execution, and context-budget file-absent reporting for #1452 and #1466.
+- Strengthen R009/R010/R018 and auto-dev release guidance for announce-execution consistency, multi-copy content checks, Agent Teams gate transparency, and milestone verification for #1456, #1460, and #1464.
+
+### Fixed
+- Correct the RTK auto-intercept hook description from R015 to R013 in source and template hooks for #1471.
+
 ## [0.5.13] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-50 agents. 120 skills. 22 rules. One command.
+50 agents. 121 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcustomcodex init
@@ -135,7 +135,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (120)
+### Skills (121)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -288,7 +288,7 @@ your-project/
 │   ├── contexts/               # 4 shared context files
 │   └── ontology/               # Knowledge graph for RAG
 ├── .agents/
-│   └── skills/                 # 120 installed skill modules
+│   └── skills/                 # 121 installed skill modules
 └── guides/                     # 51 reference documents
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -300,7 +300,7 @@ your-project/
 │   ├── contexts/               # 4개 공유 컨텍스트 파일
 │   └── ontology/               # RAG용 지식 그래프
 ├── .agents/
-│   └── skills/                 # 120개 설치 스킬 모듈
+│   └── skills/                 # 121개 설치 스킬 모듈
 └── guides/                     # 49개 레퍼런스 문서
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.13",
+  "version": "0.5.14",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -110,7 +110,7 @@
             "command": "bash .codex/hooks/scripts/rtk-intercept.sh"
           }
         ],
-        "description": "RTK auto-intercept — transparently rewrites CLI commands through RTK proxy when available (R015 advisory)"
+        "description": "RTK auto-intercept — transparently rewrites CLI commands through RTK proxy when available (R013 advisory)"
       },
       {
         "matcher": "tool == \"Bash\" && tool_input.command matches \"(rm|git rm|mv|unlink|codex/rules)\"",

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -75,6 +75,17 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 Agent frontmatter `hooks:` fire when the agent runs as a main-thread agent via `--agent` flag in v2.1.116+. Hook JSON output `terminalSequence` field for desktop notifications, window title changes, and terminal bells without controlling terminal added in v2.1.141+. `claude agents --cwd <path>` for directory-scoped session lists added in v2.1.141+. Background agents launched via `/bg` preserve current permission mode in v2.1.141+. `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` and `ANTHROPIC_WORKSPACE_ID` environment variables added in v2.1.141+ for HTTPS plugin clones and workspace-scoped federation.
 -->
 
+<!-- DETAIL: Claude Compatibility Notes for Packaged `.claude` Templates
+This Codex port ships `.claude` compatibility templates. When updating those templates, account for recent Claude Code behavior even though the active runtime surface is Codex/OMX:
+
+- v2.1.159: no user-facing template action required (internal infrastructure release).
+- v2.1.160: `acceptEdits` prompts for build-tool config writes; grep/egrep/fgrep of a single file can satisfy read-before-edit in Claude Code, but Codex agents should still follow the active Codex read/edit policy.
+- v2.1.161: independent parallel tool calls no longer cancel siblings when one Bash call fails; this supports R009 same-message batching for independent work.
+- v2.1.162: `claude agents --json` includes waiting/blocker metadata and explicit `--tools Grep/Glob` behavior is fixed; compatibility prompts may use those fields when diagnosing stuck Claude sessions.
+- v2.1.163: managed `requiredMinimumVersion`/`requiredMaximumVersion`, `/plugin list`, Stop/SubagentStop `hookSpecificOutput.additionalContext`, and skill command literal `\$` escaping are available. Hook/skill template changes should preserve these affordances.
+- v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation.
+-->
+
 ## Hook Event Types
 
 27 event types documented: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest, PermissionDenied, PostToolUse, PostToolUseFailure, Notification, SubagentStart, SubagentStop, TaskCreated, TaskCompleted, Stop, StopFailure, TeammateIdle, InstructionsLoaded, ConfigChange, CwdChanged, FileChanged, WorktreeCreate, WorktreeRemove, PreCompact, PostCompact, Elicitation, ElicitationResult, PostMessage, SessionEnd. 4 handler types: command, prompt, http, agent. See full reference table via Read tool.

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -48,6 +48,20 @@ Quick rule: explicit user preference for plain subagents wins. Otherwise use Tea
 7. Otherwise, use Agent Teams when collaboration or shared state has material value.
 -->
 
+## Gate Transparency
+
+For 3+ agent dispatches, announce the R018 gate result before spawning (Agent Tool fallback reason or Agent Teams choice).
+
+<!-- DETAIL: Gate Transparency
+When the R018 gate resolves to standalone Agent Tool for a 3+ agent dispatch (for example mechanical disjoint-file editing with no review loop), announce the gate result in one line before spawning: `R018 gate: 3 disjoint-file domains, no review loop → Agent Tool fallback`. Silently selecting Agent Tool on a 3+ agent batch loses the gate-evaluation audit trail.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 3+ 에이전트 병렬 스폰 announce에 게이트 평가 결과 누락 | 스폰 전 한 줄로 Agent Tool 폴백 사유 또는 Agent Teams 선택 사유 명시 |
+
+Origin: #1464.
+-->
+
 ## Spawn Completeness
 
 Spawn all members for a parallel team slice in one message; partial/sequential spawning needs correction.

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -257,7 +257,7 @@ Required check:
 1. Use `rg --files`, `find`, `ls`, or the repository index to prove each existing path.
 2. If a path is missing, locate the current equivalent before delegating.
 3. Include only verified paths in the prompt, or say `create new file: <path>` when creation is intended.
-4. For multi-copy assets, verify all source/template mirrors before assigning the edit.
+4. For multi-copy assets, verify all source/template mirrors before assigning the edit. If the copies are expected to match, check content identity (`cmp`, checksum, or `diff -q`) before delegation; if they intentionally differ, document the canonical source and drift rationale in the prompt.
 
 Do not rely on the delegate to repair stale path guesses in shared workflow, rule, guide, or release tasks.
 

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -30,15 +30,21 @@ Before writing/editing multiple files:
 1. Are files independent? → YES: spawn parallel agents
 2. Using Write/Edit sequentially for 2+ files? → parallelize instead
 3. Specialized agent available? → Use it (not general-purpose)
-4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents**
+4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents; announce 3+ agent gate result**
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
+6. Parallel dispatch announced? → put all announced tool calls in the same message
 
 ### Common Violations to Avoid
 
+<!-- DETAIL: Common Violations Short Examples
 ```
 ❌ WRONG: Write(file1.kt) → Write(file2.kt) → ... (sequential)
 ✓ CORRECT: Agent(agent1→file1.kt) + Agent(agent2→file2.kt) + ... (same message, parallel)
+
+❌ WRONG: Announce "milestone 생성 + 구조 확인 병렬" but dispatch only one tool; run the other next turn (announce-execution mismatch)
+✓ CORRECT: When announcing N parallel tools, include ALL N tool calls in the SAME message as the announcement
 ```
+-->
 
 <!-- DETAIL: Full violation examples (4 pairs)
 ❌ WRONG: Writing files one by one
@@ -57,6 +63,10 @@ Before writing/editing multiple files:
 -->
 
 > **Agent Teams partial spawn** → See R018 (MUST-agent-teams.md) "Spawn Completeness Check".
+
+<!-- DETAIL: v2.1.161 compatibility
+Claude Code parallel tool calls in a single batch are independent — one failed Bash command no longer cancels sibling calls. This lowers the safety cost of R009 announce-execution consistency for independent work.
+-->
 
 ## Execution Rules
 

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -285,6 +285,30 @@ User Model data feeds into intent-detection (R015) and routing skill confidence 
 
 -->
 
+<!-- DETAIL: Attention-Weight Memory Tiering
+> Origin: #1450 (Dual-Brain scout:internalize partial port — attention-weight tiering only)
+
+Memory entries are managed across two orthogonal axes: confidence and attention weight. Confidence answers “how verified is this?”; attention weight answers “how frequently/recently should this be loaded?”.
+
+| Axis | Tag example | Meaning |
+|------|-------------|---------|
+| Confidence | `[confidence: high/medium/low]` | Verification level |
+| Attention Weight | `[tier: hot/warm/cold/archived]` | Loading priority and recency/frequency |
+
+### 4-tier policy
+
+| Tier | Meaning | Handling |
+|------|---------|----------|
+| Hot | Active current-session patterns | Keep near the top of MEMORY.md / active recall |
+| Warm | Recently relevant patterns | Keep in MEMORY.md after Hot entries |
+| Cold | Rarely referenced but still useful | Move to an archive/index when memory budget is tight |
+| Archived | Long-inactive or superseded | Keep only an index/reference unless explicitly recalled |
+
+Promotion happens when an entry is referenced or re-verified. Demotion happens during session-end memory maintenance when an entry has not been referenced across recent sessions. `[permanent]` entries are exempt from automatic demotion.
+
+Budget rule: when approaching the MEMORY.md 200-line prompt budget, prune/archive Cold entries first, then low-confidence Warm entries. Hot entries should remain available unless contradicted by evidence.
+-->
+
 ## Mid-Session Immediate Save
 
 Save memory IMMEDIATELY upon surprising discovery — do not defer to session end.

--- a/templates/.claude/skills/homework/SKILL.md
+++ b/templates/.claude/skills/homework/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: homework
+description: On explicit /homework invocation, analyze the current and linked previous sessions, extract mistakes (찐빠), and report them via omcustomcodex:feedback with a confirmation gate. Auto-activation on session cleanup/session-end signals is OPT-IN (default OFF) — requires an explicit project/user directive. Use when explicitly auditing recent work for harness gaps.
+scope: harness
+user-invocable: true
+argument-hint: "[--dry-run] [--days <n>] [--severity <critical|high|medium|low>]"
+version: 0.1.0
+effort: medium
+---
+
+# Homework — Session Mistake Extractor
+
+> Codex port: use this as the project-local `homework` skill. Reporting routes through `omcustomcodex:feedback`; dry-run writes under `.codex/outputs/`.
+
+On session cleanup ("세션 정리") or `/homework` invocation, analyze the current and linked previous sessions to extract 찐빠 (mistakes: rule violations, scope-creep, hallucinations, premature hypotheses, missed conventions, etc.), then report findings via `omcustomcodex:feedback` with a mandatory user confirmation gate.
+
+This skill is the dedicated entry point for R011's "Session-End Retrospective Feedback (Model-Drafted)" pattern. It formalizes the retrospective workflow that produced issue #1266.
+
+## Usage
+
+```
+/homework                          # Analyze current session, report findings
+/homework --dry-run                # Analyze only, no omcustomcodex:feedback invocation
+/homework --days 3                 # Include linked sessions from last N days
+/homework --severity high          # Filter to critical/high findings only
+```
+
+## Trigger Detection
+
+**Default: OFF for auto-activation.** This skill does NOT auto-run on session cleanup or session-end signals unless explicitly enabled. The default is `false` — silence is a non-trigger.
+
+Activate ONLY when:
+- **Explicit `/homework` invocation** (always runs)
+- **Explicit opt-in**: the user/project has explicitly directed homework to run on session cleanup — e.g., a AGENTS.md directive such as "run homework on every session cleanup", or a settings flag. A one-off explicit request ("회고 돌려줘", "homework 실행") also counts.
+
+If no explicit opt-in exists, treat session-cleanup / session-end phrases ("세션 정리", "숙제", "회고", "끝", "종료", "마무리", "done", "wrap up", "session cleanup", "end session") as **NON-triggers** — do NOT auto-run. You MAY briefly remind the user that `/homework` is available, then proceed with normal session-end handling.
+
+When auto-activation IS explicitly enabled and fires as a session-end signal, this skill runs BEFORE memory-save's MEMORY.md update (R011 session-end self-check order: homework → memory save).
+
+## Workflow
+
+### Phase 1: Trigger Parsing
+
+Parse arguments:
+- `--dry-run`: analyze only, skip Phase 5 (omcustomcodex:feedback invocation)
+- `--days <n>`: extend linked-session search to last N days (default: 0 = current session only)
+- `--severity <level>`: filter output to this severity and above (default: all)
+
+### Phase 2: Session Gathering
+
+#### 2a. Current Session Transcript
+
+Attempt deterministic transcript extraction. Preferred sources (in order):
+
+1. **Grep for rule-violation markers** in the current conversation context:
+   - Safety classifier trip signals: `[Safety]`, `[R001]`, `[Warning]`, classifier denial messages
+   - Self-corrections: "sorry", "I made an error", "let me correct", "이전 답변 수정", "죄송합니다"
+   - Premature hypothesis signals: "I assume", "probably", "should be" followed by a contradiction in a later turn
+   - Interrupt + re-plan events: user corrections, "no", "wrong", "다시", "아니"
+
+2. **Transcript files** (Codex session JSONL):
+   ```bash
+   find ~/.codex/sessions -name "session-*.jsonl" -newer "$(date -v-1d +%Y-%m-%dT00:00:00)" 2>/dev/null | head -5
+   ```
+   Parse `type: "error"`, `type: "correction"`, `type: "feedback"` events.
+
+3. **Fallback**: Rely on the model's recall of the current conversation (impressionistic, lower confidence — mark findings as `[recall]` not `[transcript]`).
+
+#### 2b. Linked Previous Sessions (when `--days` > 0)
+
+Use the `episodic-memory` plugin's `search-conversations` / `episodic-memory:remembering-conversations` to retrieve sessions from the last N days linked to this project. Pass project directory as context.
+
+If `episodic-memory` is unavailable, scan JSONL files:
+```bash
+find ~/.codex/sessions -name "session-*.jsonl" \
+  -newer "$(date -v-${DAYS}d +%Y-%m-%dT00:00:00)" 2>/dev/null
+```
+
+**R020 read-before-characterize**: Do NOT characterize a session's mistakes before reading it. Read the session transcript (or a representative sample) first, then characterize.
+
+### Phase 3: Mistake (찐빠) Analysis
+
+Categorize each finding with the following structure (mirror #1266 format):
+
+```
+찐빠 #N — [{severity}] {short title}
+├── 증상: {what was observed — cite evidence: session line ref or commit SHA}
+├── 근거: {transcript evidence or recall note — always read first per R020}
+├── 원인: {root cause — why did this happen?}
+├── 영향 규칙: {R0xx, R0yy — affected rule IDs}
+└── 제안: {concrete corrective action or harness change}
+```
+
+**Severity scale:**
+
+| Level | Criteria | Examples |
+|-------|----------|---------|
+| Critical | Safety classifier trip, credential exposure, scope-creep into privileged domains, working-tree loss | R001 violation, secret dump, unauthorized infra action |
+| High | Rule violation with downstream impact, hallucinated fact acted upon, premature hypothesis causing permanent change | R020 Parallel Read+Change, wrong root cause → wrong fix |
+| Medium | Process gap, missed convention, advisory rule ignored | R007 header missing, bypassPermissions omitted, count sync missed |
+| Low | Minor style drift, non-impactful oversight | honorific regression, ecomode token waste |
+
+**Mistake categories to look for:**
+
+| Category | Signals |
+|----------|---------|
+| Rule violations (R0xx) | Header missing (R007), tool prefix absent (R008), file write by orchestrator (R010), sequential when parallel required (R009) |
+| Scope-creep | Subagent task expanding beyond its named scope (R010 Subagent Scope-Creep STOP Protocol) |
+| Hallucinated facts | External UI fields stated as fact (R003 Unverifiable External Product UI), in-cluster hostnames, unverified URLs |
+| Premature hypotheses | Diagnosis before reading evidence (R020 Read-Before-Characterize), parallel Read+permanent-change dispatch (R020 Variant) |
+| Missed conventions | Count sync drift (3-way sync), template mirror omitted, bypassPermissions missing |
+| Over-claim completion | [Done] without verification (R020), test-skip masking failures |
+
+**Do NOT over-claim.** If evidence for a finding is weak or based on recall only, mark it `[recall, low-confidence]` and note what would be needed to confirm it. R020 read-before-characterize applies to this analysis itself.
+
+### Phase 4: Draft Feedback Issue
+
+Assemble a feedback issue in Korean using the #1266 format:
+
+```markdown
+**제목**: 세션 회고: {date} 세션 찐빠 {N}건 — {top finding title}
+
+**카테고리**: improvement
+
+**본문**:
+## 세션 회고 — {YYYY-MM-DD}
+
+### 개요
+총 {N}건의 찐빠가 발견되었습니다 (Critical: {c}, High: {h}, Medium: {m}, Low: {l}).
+
+### 찐빠 목록
+
+{찐빠 #1 ~ #N — structured format from Phase 3}
+
+### 하네스 제안 (있는 경우)
+{Concrete skill/rule/hook changes that would prevent recurrence}
+
+---
+*Generated by `/homework` skill (v0.1.0)*
+```
+
+If `--severity` filter is active, include only findings at or above the threshold. Note the filter in the issue body.
+
+If no findings are discovered, output:
+```
+[homework] 이번 세션에서 찐빠를 발견하지 못했습니다. (세션 정상 종료)
+```
+and skip Phase 5.
+
+### Phase 5: Report via omcustomcodex:feedback (Phase 4A gate)
+
+**MUST go through the `omcustomcodex:feedback` skill's Phase 4A preview + confirmation gate.**
+**NEVER auto-submit.** User approval is always required before any GitHub issue is created.
+
+Invoke the `omcustomcodex:feedback` skill with the drafted issue content. The user will see a preview and must confirm before any GitHub issue is created.
+
+```
+[homework] 피드백 이슈 초안을 omcustomcodex:feedback으로 전달합니다.
+아래 미리보기를 확인하고 제출 여부를 결정해 주세요.
+```
+
+If `--dry-run` is active, skip this phase and output the draft directly to the conversation instead.
+
+### Phase 6: Output Summary
+
+```
+[homework] 완료
+├── 분석: {N}건 찐빠 발견 (Critical: {c}, High: {h}, Medium: {m}, Low: {l})
+├── 제출: {이슈 URL | dry-run (미제출) | 사용자 취소}
+└── 다음 액션: {harness 제안 있으면 표시, 없으면 "없음"}
+```
+
+## Options Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dry-run` | off | Analyze only, no omcustomcodex:feedback invocation |
+| `--days <n>` | 0 | Include linked sessions from last N days (0 = current session only) |
+| `--severity <level>` | all | Filter findings to this level and above |
+
+## Rules & Cross-References
+
+| Rule | Relevance |
+|------|-----------|
+| R011 (SHOULD-memory-integration) | This skill is the dedicated entry point for "Session-End Retrospective Feedback (Model-Drafted)". Runs before memory-save MEMORY.md update. |
+| R020 (MUST-completion-verification) | Analysis MUST read transcript evidence before characterizing a mistake. Do NOT characterize before reading (Read-Before-Characterize). Parallel Read + Permanent-Change Dispatch anti-pattern applies here too. |
+| R016 (MUST-continuous-improvement) | Genuine defects/process gaps → feedback issue. The /homework output feeds R016's continuous improvement loop. |
+| R010 (MUST-orchestrator-coordination) | Any file writes in this workflow must be delegated to subagents. This skill orchestrates, never directly writes except to `.codex/outputs/`. |
+| R001 (MUST-safety) | Analysis must not dump credential values, secrets, or PII. Reference sensitive items by name only. |
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `omcustomcodex:feedback` | Reporting channel (Phase 5). Model-invocable with Phase 4A confirmation gate. |
+| `instinct-extractor` | Cross-session failure-pattern mining (complements /homework's single-session focus). For multi-session patterns, run instinct-extractor after homework. |
+| `episodic-memory:search-conversations` | Cross-session retrieval for `--days` mode. |
+| `memory-save` | Runs after /homework at session end when the project opts into that order (R011 order: homework → memory save). |
+
+## Artifact Output
+
+```
+.codex/outputs/sessions/{YYYY-MM-DD}/homework-{HHmmss}.md
+```
+
+If Phase 5 is skipped (`--dry-run`), the draft issue body is written to this artifact path for reference.
+
+## Permission Mode Note
+
+This skill does not spawn subagents directly. If future versions delegate analysis to subagents, ALL Agent tool calls MUST include `mode: "bypassPermissions"` per R010 Universal bypassPermissions.
+
+## Context Fork Note
+
+This skill does NOT use `context: fork`. The fork cap is at 10/12; homework is a single-agent orchestration skill and does not require a forked context.
+
+## Limitations
+
+- **Transcript availability**: Codex session JSONL schema may change; Phase 2a source (1) grep is more resilient than JSONL parsing.
+- **Recall accuracy**: When transcript files are unavailable, findings are marked `[recall]` and confidence is lower.
+- **episodic-memory dependency**: `--days` mode degrades gracefully when the plugin is unavailable (falls back to JSONL scan).
+- **Scope**: This skill analyzes session behavior, not code quality. For code-quality retrospectives, use `dev-review` or `adversarial-review`.

--- a/templates/.claude/skills/research/SKILL.md
+++ b/templates/.claude/skills/research/SKILL.md
@@ -117,6 +117,8 @@ fi
 
 **Action**: `[Pre-flight] WARN: Context usage at {pct}%. 10-team research typically adds 30-40% context. Consider /compact before proceeding, or results may be truncated.`
 
+> **File-absent branch (#1466)**: `$CONTEXT_FILE`가 존재하지 않으면 입력이 측정 불가하다 — `PASS (context budget unmeasured — file absent)`로 보고하고 WARN을 내지 않는다. 파일을 읽지 않고 WARN 상태를 특성화하지 않는다(R020 Read-Before-Characterize). WARN은 파일이 존재하고 `context_pct > 40`일 때만 emit한다.
+
 ### Display Format
 
 ```
@@ -223,6 +225,10 @@ Sensitive-path compatibility note: when delegated work touches `.claude/outputs/
 | Orchestrator only | Main conversation manages all phases (R010) |
 | Ecomode | Auto-activate for team result aggregation (R013) |
 | Intent display | Show research plan before execution (R015) |
+
+## External Quantitative-Fact Source Tagging
+
+Research teams that collect concrete quantitative claims (benchmark numbers, table values, metrics) via WebFetch must tag them in synthesis/report output as `WebFetch-derived (unverified)` unless independently verified from a primary source such as the PDF/original paper. Multiple teams fetching the same URL can share the same WebFetch cache artifact, so agreement across those fetches is not independent ground-truth. Do not write exact load-bearing numbers into persistent issues/artifacts as fact without primary-source verification or an explicit unverified tag (R020, R023).
 
 ## Retrieval-Reasoning Separation
 
@@ -482,3 +488,5 @@ Agent(
 | dag-orchestration | Phase sequencing follows DAG pattern |
 | result-aggregation | Team results formatted per aggregation skill |
 | multi-model-verification | Phase 2 uses multi-model verification pattern |
+
+When spawning agents via the Agent tool during this skill execution, always pass `mode: "bypassPermissions"` when the session uses bypass permissions. The Agent tool default (`acceptEdits`) can cause permission prompts during unattended execution.

--- a/templates/.claude/skills/scout/SKILL.md
+++ b/templates/.claude/skills/scout/SKILL.md
@@ -2,7 +2,7 @@
 name: scout
 description: Analyze external URL to evaluate fit with oh-my-customcodex project and auto-create GitHub issue with verdict
 scope: core
-version: 1.0.0
+version: 1.0.1
 user-invocable: true
 argument-hint: "<url>"
 ---
@@ -33,6 +33,15 @@ Sensitive-path compatibility note: if this skill delegates work that touches `.c
 
 ## Pre-flight Guards
 
+### Pre-flight Execution Checklist (MANDATORY before Phase 1)
+
+**Both guards MUST be executed before entering Phase 1.** Skipping either guard is a workflow violation.
+
+- [ ] Guard 1: URL Validity check passed (abort if invalid)
+- [ ] Guard 2: Duplicate Scout check passed (warn and confirm if duplicate found)
+
+Proceed to Phase 1 only after both checkboxes are satisfied.
+
 ### Guard 1: URL Validity (GATE)
 
 Before any work, validate the URL:
@@ -56,6 +65,8 @@ gh issue list --state all --label "scout:internalize,scout:integrate,scout:skip"
 
 If found: `[Pre-flight] WARN: Similar URL already scouted in issue #N. Proceed anyway? [Y/n]`
 
+> **Why mandatory?** Guard 2 생략으로 인해 동일 도메인 중복 scout 이슈가 생성된 사례 발생. 중복 triage 낭비를 방지하기 위해 Pre-flight 체크리스트로 승격.
+
 ## Display Format
 
 Before execution, show the plan:
@@ -71,6 +82,8 @@ Before execution, show the plan:
 실행하시겠습니까? [Y/n]
 ```
 
+> **암묵 승인 시 필수**: "되면 /scout으로 보고", "실행해줘" 등 묵시적 승인인 경우에도 위 plan 요약을 **반드시 1줄 이상 표시한 뒤 진행**한다. plan 표시 없이 바로 Phase 1으로 진입하지 않는다.
+
 ## Workflow
 
 ### Phase 1: Fetch & Summarize
@@ -81,6 +94,8 @@ Before execution, show the plan:
    - Key technology / methodology
    - Approach and principles
 3. If fetch fails — report error, abort
+
+> **External quantitative-fact source tagging** (#1466): WebFetch가 산출한 구체적 정량 주장(benchmark 수치, table 값, metric)은 이슈 본문에 `WebFetch-derived (unverified)`로 태깅한다 — 검증된 사실로 제시하지 않는다. WebFetch 캐시/요약은 독립 ground-truth가 아니므로, load-bearing 수치는 primary PDF/원문으로 1회 검증하거나 명시적으로 unverified로 표기한다. (R020 Read-Before-Characterize, R023 Verifier Ground-Truth)
 
 ### Phase 2: Load Project Philosophy
 
@@ -96,7 +111,7 @@ Before execution, show the plan:
 
 Spawn 1 sonnet agent with the following analysis prompt.
 
-> **Permission Mode**: When spawning the analysis agent, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+> **MUST**: When spawning the analysis agent, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits` and may interrupt unattended execution.
 
 **Inputs**:
 - Fetched content summary (Phase 1)
@@ -146,6 +161,8 @@ Return a structured verdict:
 **Output**: Structured verdict with rationale.
 
 ### Phase 4: Issue Creation
+
+> **NOTE**: Phase 4 is normally handled by the orchestrator with `gh issue create`. If issue creation is delegated to an agent, that Agent tool call also MUST include `mode: "bypassPermissions"` when the session uses bypass permissions.
 
 1. Ensure scout labels exist (defensive, idempotent):
 ```bash

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.13",
+  "version": "0.5.14",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
@@ -23,7 +23,7 @@
       "name": "skills",
       "path": ".agents/skills",
       "description": "Reusable skill modules (project-scoped repo skills)",
-      "files": 120
+      "files": 121
     },
     {
       "name": "guides",

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-05-30"
-  total_pages: 256
+  total_pages: 257
   total_sources: 243
 
 pages:
@@ -338,6 +338,9 @@ pages:
     - file: skills/help.md
       title: "Help"
       summary: "Show help information for commands, agents, and skills."
+    - file: skills/homework.md
+      title: "Homework"
+      summary: "Session retrospective workflow for explicit opt-in improvement capture."
     - file: skills/idea.md
       title: "Idea"
       summary: "Analyze natural-language ideas against the current codebase and produce issue-ready specs."

--- a/wiki/skills/homework.md
+++ b/wiki/skills/homework.md
@@ -1,0 +1,38 @@
+---
+title: Homework
+type: skill
+updated: 2026-06-06
+sources:
+  - .codex/skills/homework/SKILL.md
+related:
+  - [[feedback]]
+  - [[memory-save]]
+  - [[pipeline]]
+---
+
+# Homework
+
+Session retrospective workflow for capturing reusable improvement opportunities after explicit opt-in.
+
+## Overview
+
+Analyzes the current session transcript and outcomes to identify one concrete, evidence-backed improvement for `oh-my-customcodex`. The Codex port keeps the parent behavior: auto-activation is off by default, the skill runs only when explicitly requested, and feedback submission requires confirmation before creating an issue through `omcustomcodex:feedback`.
+
+## Key Details
+
+- **Scope**: core
+- **User-invocable**: yes
+- **Command**: `/homework`
+- **Effort**: medium
+- **Context**: current session
+
+## Relationships
+
+- **Related skills**: [[feedback]], [[memory-save]], [[pipeline]]
+- **See also**: [[R007]], [[R008]]
+
+## Sources
+
+- `.codex/skills/homework/SKILL.md` — skill definition
+
+---


### PR DESCRIPTION
## Summary
- port the parent `homework` retrospective skill into Codex/OMX source and packaged templates
- add v0.5.14 harness parity notes for Claude Code v2.1.159-v2.1.165 compatibility, memory tiering, gate transparency, and execution consistency
- harden scout/research/pipeline guidance for quantitative source tagging, pre-flight context checks, and milestone retry handling

## Issues
Fixes #1449
Fixes #1450
Fixes #1451
Fixes #1452
Fixes #1454
Fixes #1456
Fixes #1460
Fixes #1461
Fixes #1464
Fixes #1465
Fixes #1466
Fixes #1467
Fixes #1469
Fixes #1470
Fixes #1471

## Verification
- `bash .github/scripts/verify-template-sync.sh` → `Template sync verified: 121 skills, 42 hook scripts, 55 hook matchers`
- `bun run lint` → `Checked 105 files ... No fixes applied`
- `bun run typecheck`
- `bun run build` → `sync-source-lockfile: wrote .omcodex.lock.json (237 files)`
- `bash .github/scripts/verify-version-sync.sh` → `Version sync check passed: 0.5.14`
- `git diff --check`
- `bun run test` → `1834 pass, 0 fail, 5106 expect() calls`
- pre-commit hook repeated stable batches and passed
