### PR TITLE
release: v0.5.15 — auto-dev compression gates

### DIFF
--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -151,7 +151,18 @@ steps:
       - Set compression_mode=lite.
       - Keep a concise implementation plan and local self-review.
       - Still run verify-build.
+      - MANDATORY justification log when replacing a skill stage with integrated analysis:
+        "[compression-mode] lite — skill stage replaced by integrated analysis; scope={n}; low-risk evidence={issue_refs}".
+      - If the justification cannot be stated concretely, do not compress that stage; run the full skill.
+      - For lite deep-verify, if the change set has no structural surface (for example workflow-YAML/docs-only with no agent/skill/guide/rule frontmatter changes), the R017/deep-verify spawn may be skipped and replaced by deterministic self-checks: template parity, multi-copy checksum, YAML parse, and the normal verify-build gate. Log:
+        "[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only".
       - Log: "[compression-mode] lite compression activated (scope={n}, low-risk docs/rules/skills)".
+
+      Cross-tier pre-existing converged artifact substitution:
+      - A triage, plan, deep-plan, or deep-verify step may be satisfied by an existing converged research/plan/verification artifact instead of a fresh skill spawn, even in standard mode.
+      - The artifact must explicitly cover the scoped issue domain, be current for the release scope, and provide output equivalent to the skipped step.
+      - This substitution never applies to implement, verify-build, release, publish, or CI/publish verification.
+      - Log the artifact path or URL and why it is equivalent before substituting.
 
       Otherwise:
       - Set compression_mode=standard.
@@ -238,7 +249,7 @@ steps:
 
   - name: deep-verify
     skill: deep-verify
-    description: "Multi-angle release quality verification — self-review checklist only if compression_mode=docs-only"
+    description: "Multi-angle release quality verification — self-review checklist if compression_mode=docs-only, or deterministic self-check in lite mode when no structural surface changed"
     depends_on: verify-build
 
   - name: release

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.14",
-  "generatedAt": "2026-06-06T05:48:42.717Z",
-  "templateVersion": "0.5.14",
+  "generatorVersion": "0.5.15",
+  "generatedAt": "2026-06-07T23:32:47.341Z",
+  "templateVersion": "0.5.15",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.15] - 2026-06-08
+
+### Changed
+- Port auto-dev compression guidance from upstream release monitors for #1475 and #1476: converged artifact substitution is now explicit, lite-mode skill replacement requires justification, and no-structural-surface deep-verify can use deterministic self-checks.
+
 ## [0.5.14] - 2026-06-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.14",
+  "version": "0.5.15",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.14",
+  "version": "0.5.15",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -74,9 +74,20 @@ steps:
       Gate transparency:
       - Do not add or change labels solely to qualify for docs-only or lite mode.
       - If labels were changed during triage and affect compression eligibility, state that fact in the mode decision.
+      - Whenever a skill stage is replaced by integrated analysis, log a concrete justification:
+        `[compression-mode] lite — skill stage replaced by integrated analysis; scope={n}; low-risk evidence={issue_refs}`.
+      - If the justification cannot be stated concretely, do not compress that stage; run the full skill.
+
+      Cross-tier pre-existing converged artifact substitution:
+      - A triage, plan, deep-plan, or deep-verify step may be satisfied by an existing converged research/plan/verification artifact instead of a fresh skill spawn, even in standard mode.
+      - The artifact must explicitly cover the scoped issue domain, be current for the release scope, and provide output equivalent to the skipped step.
+      - This substitution never applies to implement, verify-build, release, publish, or CI/publish verification.
+      - Log the artifact path or URL and why it is equivalent before substituting.
 
       In docs-only mode, replace heavyweight triage/plan/deep-plan/deep-verify spawns with direct summaries plus local self-review.
       In lite mode, keep a concise implementation plan and local self-review, but still run verify-build.
+      In lite mode deep-verify, if the change set has no structural surface (for example workflow-YAML/docs-only with no agent/skill/guide/rule frontmatter changes), the R017/deep-verify spawn may be skipped and replaced by deterministic self-checks: template parity, multi-copy checksum, YAML parse, and the normal verify-build gate. Log:
+        `[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only`.
       Otherwise use standard mode.
       Output the selected compression_mode for downstream steps.
     description: Evaluate docs-only compression eligibility
@@ -130,7 +141,7 @@ steps:
   - name: verify
     depends_on: verify-build
     skill: deep-verify
-    description: Multi-angle release quality verification; self-review checklist only if compression_mode=docs-only
+    description: Multi-angle release quality verification; self-review checklist if compression_mode=docs-only, or deterministic self-check in lite mode when no structural surface changed
 
   - name: release
     depends_on: verify

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -74,9 +74,20 @@ steps:
       Gate transparency:
       - Do not add or change labels solely to qualify for docs-only or lite mode.
       - If labels were changed during triage and affect compression eligibility, state that fact in the mode decision.
+      - Whenever a skill stage is replaced by integrated analysis, log a concrete justification:
+        `[compression-mode] lite — skill stage replaced by integrated analysis; scope={n}; low-risk evidence={issue_refs}`.
+      - If the justification cannot be stated concretely, do not compress that stage; run the full skill.
+
+      Cross-tier pre-existing converged artifact substitution:
+      - A triage, plan, deep-plan, or deep-verify step may be satisfied by an existing converged research/plan/verification artifact instead of a fresh skill spawn, even in standard mode.
+      - The artifact must explicitly cover the scoped issue domain, be current for the release scope, and provide output equivalent to the skipped step.
+      - This substitution never applies to implement, verify-build, release, publish, or CI/publish verification.
+      - Log the artifact path or URL and why it is equivalent before substituting.
 
       In docs-only mode, replace heavyweight triage/plan/deep-plan/deep-verify spawns with direct summaries plus local self-review.
       In lite mode, keep a concise implementation plan and local self-review, but still run verify-build.
+      In lite mode deep-verify, if the change set has no structural surface (for example workflow-YAML/docs-only with no agent/skill/guide/rule frontmatter changes), the R017/deep-verify spawn may be skipped and replaced by deterministic self-checks: template parity, multi-copy checksum, YAML parse, and the normal verify-build gate. Log:
+        `[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only`.
       Otherwise use standard mode.
       Output the selected compression_mode for downstream steps.
     description: Evaluate docs-only compression eligibility
@@ -130,7 +141,7 @@ steps:
   - name: verify
     depends_on: verify-build
     skill: deep-verify
-    description: Multi-angle release quality verification; self-review checklist only if compression_mode=docs-only
+    description: Multi-angle release quality verification; self-review checklist if compression_mode=docs-only, or deterministic self-check in lite mode when no structural surface changed
 
   - name: release
     depends_on: verify


### PR DESCRIPTION
## Summary
- Port upstream auto-dev compression guidance for #1475 and #1476.
- Require concrete lite-mode substitution justification and add converged-artifact substitution rules.
- Allow deterministic lite deep-verify self-checks only when no structural surface changed.
- Bump package/template metadata to v0.5.15 and update changelog/lockfile.

## Verification
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 1834 pass / 0 fail
- `bun run build`
- `bash .github/scripts/verify-version-sync.sh`
- YAML parse for workflow copies
- `cmp -s workflows/auto-dev.yaml templates/workflows/auto-dev.yaml`

Fixes #1475
Fixes #1476
