### PR TITLE
release: v0.5.16 — compatibility guidance and OMX diagnostics

### DIFF
--- a/.codex/rules/MAY-optimization.md
+++ b/.codex/rules/MAY-optimization.md
@@ -4,6 +4,8 @@
 
 ## Efficiency
 
+> **Tool availability note**: On first exploration, do not assume a specific tool surface is available without confirming the current session's tool set. Prefer the available native repository inspection tools; fall back to bounded shell `find`/`grep`/`rg` when higher-level glob/search tools are unavailable.
+
 | Strategy | When | Example |
 |----------|------|---------|
 | Parallel | 3+ independent I/O tasks | Read multiple files simultaneously |
@@ -42,6 +44,11 @@ Inspired by [ouroboros PR #353](https://github.com/Q00/ouroboros/pull/353) capab
 | Repetitive tasks, clear bottleneck, measurable gain | One-time tasks, already fast, complexity > benefit |
 
 Readability > Optimization. No optimization without measurement.
+
+
+### Measure-Before-Adopt Gate
+
+For new workflow heuristics, TIDE-style discovery shortcuts, or routing optimizations, measure before adoption. A small proof-of-concept that fails its confidence gate should be recorded as deferred rather than promoted into default guidance. Future adoption needs a broader multi-session corpus or deterministic benchmark evidence, not a single-session impression.
 
 ## Context Optimization via HTML Comments (v2.1.72+)
 

--- a/.codex/rules/MUST-agent-design.md
+++ b/.codex/rules/MUST-agent-design.md
@@ -27,6 +27,10 @@ tools: [Read, Write, ...]  # Allowed tools
 
 Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
+<!-- DETAIL: Fallback Models and Thinking Toggle (Claude Code v2.1.166+)
+Claude compatibility settings can declare up to three `fallbackModel` entries tried in order when the primary Claude model is overloaded or unavailable. `--fallback-model` also applies to interactive Claude sessions. Treat this as platform availability failover, not Codex-native model routing or outcome-based escalation. Claude Code v2.1.166+ also supports disabling default thinking with `MAX_THINKING_TOKENS=0`, `--thinking disabled`, or the per-model thinking toggle. Codex-native agents continue to use the OMX model contract and `reasoning_effort` routing.
+-->
+
 ### Optional Frontmatter
 
 Key optional fields: `memory`, `effort`, `skills`, `soul`, `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations`, `domain`, `disableSkillShellExecution`. Supported since CC v2.1.63+. See full optional frontmatter via Read tool.
@@ -83,7 +87,7 @@ This Codex port ships `.claude` compatibility templates. When updating those tem
 - v2.1.161: independent parallel tool calls no longer cancel siblings when one Bash call fails; this supports R009 same-message batching for independent work.
 - v2.1.162: `claude agents --json` includes waiting/blocker metadata and explicit `--tools Grep/Glob` behavior is fixed; compatibility prompts may use those fields when diagnosing stuck Claude sessions.
 - v2.1.163: managed `requiredMinimumVersion`/`requiredMaximumVersion`, `/plugin list`, Stop/SubagentStop `hookSpecificOutput.additionalContext`, and skill command literal `\$` escaping are available. Hook/skill template changes should preserve these affordances.
-- v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation.
+- v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation. v2.1.166: fallbackModel availability failover and thinking-disable controls are Claude compatibility settings, not Codex/OMX routing. v2.1.167/v2.1.168: bug-fix-only compatibility confirmation.
 -->
 
 ## Hook Event Types

--- a/.codex/rules/MUST-agent-teams.md
+++ b/.codex/rules/MUST-agent-teams.md
@@ -33,6 +33,10 @@ When enabled and criteria match, Agent Teams is required.
 
 Do not confuse these mechanisms.
 
+<!-- DETAIL: Cross-Session Relay Authority Hardening (Claude Code v2.1.166+)
+Claude Code v2.1.166+ no longer propagates user authority through cross-session relays: permission requests relayed from another session are refused, and auto mode blocks them. A relayed message from session A cannot grant session B permissions the user did not authorize in session B. This hardens `send_message` / peer relay against privilege escalation. Intra-session Agent Teams `SendMessage` is unaffected, but privileged actions still require authority in the receiving session.
+-->
+
 ## Self-Check Before Agent Tool
 
 Quick rule: explicit user preference for plain subagents wins. Otherwise use Teams for 3+ agents, review cycles, shared state, complex debugging, dynamic creation, or multi-issue batches; use Agent Tool for 1-2 simple tasks, sequential scaffolding, or mechanical disjoint-file batches with explicit scopes.

--- a/.codex/rules/MUST-permissions.md
+++ b/.codex/rules/MUST-permissions.md
@@ -42,6 +42,19 @@ Current guidance:
 - For `.claude/**` or `templates/.claude/**`, direct writes are acceptable when the target Claude Code runtime is new enough and the session is running with `bypassPermissions`.
 - Treat the old `/tmp/{skill}-{timestamp}.md` wrapper flow as a historical fallback only for older Claude Code versions, non-bypass sessions, or interactive runs that still surface a protected-path prompt.
 
+
+## Deny Rule Glob Patterns (Claude Code v2.1.166+)
+
+Claude Code compatibility templates may rely on v2.1.166+ deny-rule glob behavior:
+
+| Position | Glob support |
+|----------|-------------|
+| Deny rule tool-name | Supported; `"*"` denies all tools |
+| Allow rule tool-name | MCP tool-name globs only; non-MCP globs are rejected |
+| Unknown tool in deny rule | Startup warning |
+
+Use `"*"` deny rules only for Claude compatibility settings that intentionally enforce deny-by-default, then add explicit allow rules. This is separate from Codex/OMX sandbox policy and the advisory tool-tier table above.
+
 ## Permission Request Format
 
 ```

--- a/.codex/rules/MUST-safety.md
+++ b/.codex/rules/MUST-safety.md
@@ -37,6 +37,22 @@ Treat these commands as destructive even when they look like routine cleanup:
 
 Advisory hooks may warn on these patterns, but warnings do not replace the approval and preservation requirements.
 
+
+### Pre-Delegation Blast-Radius Enumeration
+
+Before delegating any destructive git command from the table above, enumerate the exact discard targets and present them for explicit approval. Do not delegate destructive operations from a paraphrase such as "discard local changes" without showing what will be lost.
+
+Required evidence before delegation:
+
+| Scope | Command |
+|-------|---------|
+| Modified/staged tracked files | `git status --short` |
+| Uncommitted diff size | `git diff --stat` and `git diff --stat --cached` |
+| Stash contents, when relevant | `git stash show --stat` |
+| Untracked files at risk, for clean | `git clean -nd` |
+
+Prefer non-destructive alternatives such as `git stash` when the user's goal can be met without permanent loss.
+
 ## On Violation
 
 1. Stop all operations

--- a/.codex/rules/SHOULD-memory-integration.md
+++ b/.codex/rules/SHOULD-memory-integration.md
@@ -39,6 +39,10 @@ If both backend families are available, warn before writing. Dual-write is accep
 
 -->
 
+<!-- DETAIL: Safety Feedback Memory
+When a session exposes a safety-relevant correction (credential handling, destructive git blast radius, privileged-scope chaining, or permission-boundary mistakes), write the durable lesson with confidence metadata instead of leaving it only in chat. Record what was verified, what behavior should change, and the source issue/session when available. Do not store secrets or raw credential material in memory.
+-->
+
 ## Best Practices
 
 - Consult memory before starting work

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.15",
-  "generatedAt": "2026-06-07T23:32:47.341Z",
-  "templateVersion": "0.5.15",
+  "generatorVersion": "0.5.16",
+  "generatedAt": "2026-06-09T08:14:38.512Z",
+  "templateVersion": "0.5.16",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-design.md": {
-      "templateHash": "1e381519c8a6411a712d232b7a3174122ccd2f04adacbcc7669452f6eda57e59",
-      "size": 26275,
+      "templateHash": "3cbc62c887ae37d931d40e0528aebcdf083fb1c9297de2f5ce5d32614f63e77e",
+      "size": 27111,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
@@ -65,13 +65,13 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-teams.md": {
-      "templateHash": "e16121ca5c210b41ba7f9944c0d4e7b2465e4cf09ccb4f661bf35476077506d9",
-      "size": 8936,
+      "templateHash": "ac62a7d5ba9030991f6b8ad10d3fb6de2344f5cc23067dd3a1d0305c9758411a",
+      "size": 9503,
       "component": "rules"
     },
     ".codex/rules/MAY-optimization.md": {
-      "templateHash": "f1dbc5a7b454c5ac6431efacf2e5ad1ea58f9ad7c40c21951cd5a70da4827030",
-      "size": 2301,
+      "templateHash": "8cb51c43439dcc15276a6408adb2e746617f870051b3dd3285e6a453e3b42ed8",
+      "size": 3011,
       "component": "rules"
     },
     ".codex/rules/MUST-continuous-improvement.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-permissions.md": {
-      "templateHash": "43064c0f6154354c83b6764ff5f20f6b0498f4bd0c9579e3b8dfdc58a3c82dd5",
-      "size": 3272,
+      "templateHash": "d8b3e14c3b28dc27d03979e920edc76be257931fbbf07b1d4241069a4a81510f",
+      "size": 3876,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ontology-rag-routing.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-safety.md": {
-      "templateHash": "8c0600348ab83eb536b4d5911834429b53dc71e123248f046a0188696a755cd1",
-      "size": 2836,
+      "templateHash": "b9533519320a31636dd6e1b4cbe8aa55c4f897ddb8271a2ec8f5e869e02ea0e0",
+      "size": 3594,
       "component": "rules"
     },
     ".codex/rules/MUST-tool-identification.md": {
@@ -100,8 +100,8 @@
       "component": "rules"
     },
     ".codex/rules/SHOULD-memory-integration.md": {
-      "templateHash": "9894c0af344f9ee40379696a28e0d128fee11257f0362dcbb9b95f8312f2a774",
-      "size": 18747,
+      "templateHash": "14711da464d564bd051162b6103a9708e285919484187e0ab8880167dec05350",
+      "size": 19198,
       "component": "rules"
     },
     ".codex/rules/MUST-enforcement-policy.md": {
@@ -680,8 +680,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "a9d4ed24068ad42aeef56dfc685aa65250c9bae7cd34fb0eba77913da82306d8",
-      "size": 26670,
+      "templateHash": "88a59a08610da9132e640e3c5ff9e356c3ec79daa864e31bb5cc583500a20eea",
+      "size": 29166,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/docs/superpowers/plans/2026-06-09-v0.5.16-release.md
+++ b/docs/superpowers/plans/2026-06-09-v0.5.16-release.md
@@ -1,0 +1,42 @@
+# v0.5.16 Auto-Dev Release Plan
+
+## Scope
+
+| Issue | Priority | Effort | Decision | Local surface |
+|-------|----------|--------|----------|---------------|
+| #1479 | P1 | S | Port parent `oh-my-customcode v0.174.0` Claude Code v2.1.166 compatibility notes | R002/R006/R018 rules, Claude compatibility guide |
+| #1482 | P2 | S | Port `oh-my-codex v0.18.11` repo-owned guidance parity | Generated AGENTS OMX command routing, doctor OMX model lane diagnostics |
+| #1474 | P2 | XS | Cover as superseded rule-hardening context while same rule surface is open | R001/R005/R011 rules |
+| #1481 | P3 | — | Defer/watch; no concrete repo-owned implementation surface selected | None |
+
+## Compression Mode
+
+`compression_mode=lite`.
+
+Rationale:
+- Scope is 3 issues or fewer after adding #1474 as same-surface superseded context.
+- Changes are release-monitor documentation, rule text, generated guidance, and a small diagnostic check.
+- No package dependency, migration, or security-sensitive runtime behavior is added.
+- `verify-build` remains mandatory.
+
+## Implementation Plan
+
+1. Mirror Claude Code v2.1.166 compatibility notes into source/template rules:
+   - deny-rule glob patterns in R002;
+   - `fallbackModel` and thinking-disable controls in R006;
+   - cross-session relay authority hardening in R018.
+2. Mirror v2.1.167/v2.1.168 as no-op compatibility confirmations in the Claude Code compatibility guide.
+3. Add #1474 same-surface hardening notes:
+   - destructive-git blast-radius enumeration;
+   - tool-availability and measure-before-adopt optimization guidance;
+   - safety-feedback memory persistence.
+4. Add generated AGENTS guidance that `omx explore` is deprecated and not the preferred lookup surface.
+5. Add `omcustomcodex doctor` OMX model lane diagnostics for frontier/spark routing overrides.
+6. Verify template parity, targeted tests, full tests, typecheck, lint, and build.
+
+## Release Notes Draft
+
+- Added Claude Code v2.1.166-v2.1.168 compatibility notes while preserving Codex/OMX as the active runtime boundary.
+- Added `omcustomcodex doctor` diagnostics for explicit OMX frontier/spark model lane overrides.
+- Clarified generated AGENTS routing so `omx explore` remains deprecated and normal Codex inspection is preferred.
+- Ported prior rule hardening around destructive git blast radius, measure-before-adopt, tool availability, and safety feedback memory.

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,39 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.168
+
+Published: 2026-06-07.
+
+Source: upstream oh-my-customcode #1315, Codex port #1479.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Bug-fix/reliability release after the v2.1.166 compatibility surface | No new repo-owned template, agent, skill, hook, or rule behavior was identified beyond the v2.1.166 notes. | Record as compatibility-confirmed; do not add speculative runtime behavior. |
+
+## v2.1.167
+
+Published: 2026-06-07.
+
+Source: upstream oh-my-customcode #1313, Codex port #1479.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Bug-fix/reliability release after the v2.1.166 compatibility surface | No new repo-owned template, agent, skill, hook, or rule behavior was identified beyond the v2.1.166 notes. | Record as compatibility-confirmed; do not add speculative runtime behavior. |
+
+## v2.1.166
+
+Published: 2026-06-07.
+
+Source: upstream oh-my-customcode #1314/#1316, Codex port #1479.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Deny rules support glob patterns in the tool-name position, including `"*"` to deny all tools; allow-rule globs remain limited to MCP tool-name globs | Relevant to Claude compatibility settings and permission debugging. Codex/OMX sandboxing remains the active runtime boundary for this package. | Port R002 compatibility note; do not treat Claude settings globs as Codex policy. |
+| `fallbackModel` supports up to three ordered fallback models and `--fallback-model` applies to interactive sessions | Useful Claude platform availability failover. It is distinct from per-agent `model:` metadata, the `model-escalation` skill, and Codex-native model routing. | Port R006 note; keep Codex child agents on the OMX model contract and `reasoning_effort`. |
+| `MAX_THINKING_TOKENS=0`, `--thinking disabled`, and per-model thinking toggles can disable default thinking | Claude compatibility sessions can reduce thinking overhead for low-effort work. | Document as Claude-only compatibility; do not infer Codex reasoning behavior. |
+| Cross-session relayed `SendMessage` no longer carries user authority; relayed permission requests are refused and auto mode blocks them | Hardens peer-relay workflows against privilege escalation between Claude sessions. Intra-session Agent Teams are unaffected. | Port R018 note and keep privileged actions scoped to the receiving session. |
+
 ## v2.1.158
 
 Published: 2026-05-30.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.15",
+  "version": "0.5.16",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -613,6 +613,50 @@ export async function checkOmx(): Promise<CheckResult> {
 }
 
 /**
+ * Check configured OMX model lane routing hints.
+ *
+ * This diagnostic is intentionally observational: OMX owns the runtime model
+ * contract, while oh-my-customcodex surfaces obvious lane drift in doctor output.
+ */
+export function checkOmxModelRouting(): CheckResult {
+  const frontierModel = process.env.OMX_DEFAULT_FRONTIER_MODEL?.trim() || null;
+  const sparkModel =
+    process.env.OMX_DEFAULT_SPARK_MODEL?.trim() || process.env.OMX_SPARK_MODEL?.trim() || null;
+  const usingLegacySpark = !process.env.OMX_DEFAULT_SPARK_MODEL?.trim() && Boolean(sparkModel);
+
+  if (!frontierModel && !sparkModel) {
+    return {
+      name: 'OMX model lanes',
+      status: 'pass',
+      message: 'OMX model lane routing uses runtime defaults (no explicit env override)',
+      fixable: false,
+    };
+  }
+
+  const details = [
+    `frontier=${frontierModel ?? 'runtime-default'}`,
+    `spark=${sparkModel ?? 'runtime-default'}`,
+  ];
+
+  if (usingLegacySpark) {
+    details.push('legacy OMX_SPARK_MODEL detected; prefer OMX_DEFAULT_SPARK_MODEL');
+  }
+
+  const sameExplicitLane =
+    frontierModel !== null && sparkModel !== null && frontierModel === sparkModel;
+
+  return {
+    name: 'OMX model lanes',
+    status: sameExplicitLane ? 'warn' : 'pass',
+    message: sameExplicitLane
+      ? `OMX Spark/model lane routing uses the same explicit model for frontier and spark (${frontierModel})`
+      : 'OMX Spark/model lane routing overrides detected',
+    fixable: false,
+    details,
+  };
+}
+
+/**
  * Check if contexts directory exists
  * @param targetDir - Target directory
  * @returns Check result
@@ -1003,6 +1047,7 @@ async function runAllChecks(
     checkRtk(),
     checkCodex(),
     checkOmx(),
+    checkOmxModelRouting(),
   ]);
 
   // Framework version drift check (always runs when the harness rc file exists)

--- a/templates/.claude/rules/MAY-optimization.md
+++ b/templates/.claude/rules/MAY-optimization.md
@@ -4,6 +4,8 @@
 
 ## Efficiency
 
+> **Tool availability note**: On first exploration, do not assume a specific tool surface is available without confirming the current session's tool set. Prefer the available native repository inspection tools; fall back to bounded shell `find`/`grep`/`rg` when higher-level glob/search tools are unavailable.
+
 | Strategy | When | Example |
 |----------|------|---------|
 | Parallel | 3+ independent I/O tasks | Read multiple files simultaneously |
@@ -42,6 +44,11 @@ Inspired by [ouroboros PR #353](https://github.com/Q00/ouroboros/pull/353) capab
 | Repetitive tasks, clear bottleneck, measurable gain | One-time tasks, already fast, complexity > benefit |
 
 Readability > Optimization. No optimization without measurement.
+
+
+### Measure-Before-Adopt Gate
+
+For new workflow heuristics, TIDE-style discovery shortcuts, or routing optimizations, measure before adoption. A small proof-of-concept that fails its confidence gate should be recorded as deferred rather than promoted into default guidance. Future adoption needs a broader multi-session corpus or deterministic benchmark evidence, not a single-session impression.
 
 ## Context Optimization via HTML Comments (v2.1.72+)
 

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -27,6 +27,10 @@ tools: [Read, Write, ...]  # Allowed tools
 
 Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
+<!-- DETAIL: Fallback Models and Thinking Toggle (Claude Code v2.1.166+)
+Claude compatibility settings can declare up to three `fallbackModel` entries tried in order when the primary Claude model is overloaded or unavailable. `--fallback-model` also applies to interactive Claude sessions. Treat this as platform availability failover, not Codex-native model routing or outcome-based escalation. Claude Code v2.1.166+ also supports disabling default thinking with `MAX_THINKING_TOKENS=0`, `--thinking disabled`, or the per-model thinking toggle. Codex-native agents continue to use the OMX model contract and `reasoning_effort` routing.
+-->
+
 ### Optional Frontmatter
 
 Key optional fields: `memory`, `effort`, `skills`, `soul`, `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations`, `domain`, `disableSkillShellExecution`. Supported since CC v2.1.63+. See full optional frontmatter via Read tool.
@@ -83,7 +87,7 @@ This Codex port ships `.claude` compatibility templates. When updating those tem
 - v2.1.161: independent parallel tool calls no longer cancel siblings when one Bash call fails; this supports R009 same-message batching for independent work.
 - v2.1.162: `claude agents --json` includes waiting/blocker metadata and explicit `--tools Grep/Glob` behavior is fixed; compatibility prompts may use those fields when diagnosing stuck Claude sessions.
 - v2.1.163: managed `requiredMinimumVersion`/`requiredMaximumVersion`, `/plugin list`, Stop/SubagentStop `hookSpecificOutput.additionalContext`, and skill command literal `\$` escaping are available. Hook/skill template changes should preserve these affordances.
-- v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation.
+- v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation. v2.1.166: fallbackModel availability failover and thinking-disable controls are Claude compatibility settings, not Codex/OMX routing. v2.1.167/v2.1.168: bug-fix-only compatibility confirmation.
 -->
 
 ## Hook Event Types

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -33,6 +33,10 @@ When enabled and criteria match, Agent Teams is required.
 
 Do not confuse these mechanisms.
 
+<!-- DETAIL: Cross-Session Relay Authority Hardening (Claude Code v2.1.166+)
+Claude Code v2.1.166+ no longer propagates user authority through cross-session relays: permission requests relayed from another session are refused, and auto mode blocks them. A relayed message from session A cannot grant session B permissions the user did not authorize in session B. This hardens `send_message` / peer relay against privilege escalation. Intra-session Agent Teams `SendMessage` is unaffected, but privileged actions still require authority in the receiving session.
+-->
+
 ## Self-Check Before Agent Tool
 
 Quick rule: explicit user preference for plain subagents wins. Otherwise use Teams for 3+ agents, review cycles, shared state, complex debugging, dynamic creation, or multi-issue batches; use Agent Tool for 1-2 simple tasks, sequential scaffolding, or mechanical disjoint-file batches with explicit scopes.

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -42,6 +42,19 @@ Current guidance:
 - For `.claude/**` or `templates/.claude/**`, direct writes are acceptable when the target Claude Code runtime is new enough and the session is running with `bypassPermissions`.
 - Treat the old `/tmp/{skill}-{timestamp}.md` wrapper flow as a historical fallback only for older Claude Code versions, non-bypass sessions, or interactive runs that still surface a protected-path prompt.
 
+
+## Deny Rule Glob Patterns (Claude Code v2.1.166+)
+
+Claude Code compatibility templates may rely on v2.1.166+ deny-rule glob behavior:
+
+| Position | Glob support |
+|----------|-------------|
+| Deny rule tool-name | Supported; `"*"` denies all tools |
+| Allow rule tool-name | MCP tool-name globs only; non-MCP globs are rejected |
+| Unknown tool in deny rule | Startup warning |
+
+Use `"*"` deny rules only for Claude compatibility settings that intentionally enforce deny-by-default, then add explicit allow rules. This is separate from Codex/OMX sandbox policy and the advisory tool-tier table above.
+
 ## Permission Request Format
 
 ```

--- a/templates/.claude/rules/MUST-safety.md
+++ b/templates/.claude/rules/MUST-safety.md
@@ -37,6 +37,22 @@ Treat these commands as destructive even when they look like routine cleanup:
 
 Advisory hooks may warn on these patterns, but warnings do not replace the approval and preservation requirements.
 
+
+### Pre-Delegation Blast-Radius Enumeration
+
+Before delegating any destructive git command from the table above, enumerate the exact discard targets and present them for explicit approval. Do not delegate destructive operations from a paraphrase such as "discard local changes" without showing what will be lost.
+
+Required evidence before delegation:
+
+| Scope | Command |
+|-------|---------|
+| Modified/staged tracked files | `git status --short` |
+| Uncommitted diff size | `git diff --stat` and `git diff --stat --cached` |
+| Stash contents, when relevant | `git stash show --stat` |
+| Untracked files at risk, for clean | `git clean -nd` |
+
+Prefer non-destructive alternatives such as `git stash` when the user's goal can be met without permanent loss.
+
 ## On Violation
 
 1. Stop all operations

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -39,6 +39,10 @@ If both backend families are available, warn before writing. Dual-write is accep
 
 -->
 
+<!-- DETAIL: Safety Feedback Memory
+When a session exposes a safety-relevant correction (credential handling, destructive git blast radius, privileged-scope chaining, or permission-boundary mistakes), write the durable lesson with confidence metadata instead of leaving it only in chat. Record what was verified, what behavior should change, and the source issue/session when available. Do not store secrets or raw credential material in memory.
+-->
+
 ## Best Practices
 
 - Consult memory before starting work

--- a/templates/AGENTS.md.en
+++ b/templates/AGENTS.md.en
@@ -137,6 +137,12 @@ project/
 +-- guides/                      # Reference docs (51 topics)
 ```
 
+## OMX Command Routing
+
+- `omx explore` is deprecated and must not be recommended for new repository lookup work. Use normal Codex repository inspection tools/subagents for file, symbol, pattern, relationship, and implementation discovery.
+- `USE_OMX_EXPLORE_CMD` is compatibility-only for legacy callers; truthy values do not make `omx explore` preferred.
+- Use `omx sparkshell -- <command>` only when the operator explicitly wants shell-native read-only evidence, bounded verification, or a tmux-pane summary.
+
 ## Orchestration
 
 Orchestration is handled by routing skills in the main conversation:

--- a/templates/AGENTS.md.ko
+++ b/templates/AGENTS.md.ko
@@ -137,6 +137,12 @@ project/
 +-- guides/                      # 레퍼런스 문서 (51 토픽)
 ```
 
+## OMX 명령 라우팅
+
+- `omx explore`는 deprecated 상태이며 새 저장소 조회 작업에 권장하지 않습니다. 파일, 심볼, 패턴, 관계, 구현 탐색에는 일반 Codex 저장소 검사 도구/서브에이전트를 사용합니다.
+- `USE_OMX_EXPLORE_CMD`는 레거시 호출자 호환용일 뿐이며 truthy 값이어도 `omx explore`가 선호 경로가 되지 않습니다.
+- `omx sparkshell -- <command>`는 사용자가 shell-native 읽기 전용 근거, 제한된 검증, tmux-pane 요약을 명시적으로 원할 때만 사용합니다.
+
 ## 오케스트레이션
 
 오케스트레이션은 메인 대화의 라우팅 스킬로 처리됩니다:

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,39 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.168
+
+Published: 2026-06-07.
+
+Source: upstream oh-my-customcode #1315, Codex port #1479.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Bug-fix/reliability release after the v2.1.166 compatibility surface | No new repo-owned template, agent, skill, hook, or rule behavior was identified beyond the v2.1.166 notes. | Record as compatibility-confirmed; do not add speculative runtime behavior. |
+
+## v2.1.167
+
+Published: 2026-06-07.
+
+Source: upstream oh-my-customcode #1313, Codex port #1479.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Bug-fix/reliability release after the v2.1.166 compatibility surface | No new repo-owned template, agent, skill, hook, or rule behavior was identified beyond the v2.1.166 notes. | Record as compatibility-confirmed; do not add speculative runtime behavior. |
+
+## v2.1.166
+
+Published: 2026-06-07.
+
+Source: upstream oh-my-customcode #1314/#1316, Codex port #1479.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Deny rules support glob patterns in the tool-name position, including `"*"` to deny all tools; allow-rule globs remain limited to MCP tool-name globs | Relevant to Claude compatibility settings and permission debugging. Codex/OMX sandboxing remains the active runtime boundary for this package. | Port R002 compatibility note; do not treat Claude settings globs as Codex policy. |
+| `fallbackModel` supports up to three ordered fallback models and `--fallback-model` applies to interactive sessions | Useful Claude platform availability failover. It is distinct from per-agent `model:` metadata, the `model-escalation` skill, and Codex-native model routing. | Port R006 note; keep Codex child agents on the OMX model contract and `reasoning_effort`. |
+| `MAX_THINKING_TOKENS=0`, `--thinking disabled`, and per-model thinking toggles can disable default thinking | Claude compatibility sessions can reduce thinking overhead for low-effort work. | Document as Claude-only compatibility; do not infer Codex reasoning behavior. |
+| Cross-session relayed `SendMessage` no longer carries user authority; relayed permission requests are refused and auto mode blocks them | Hardens peer-relay workflows against privilege escalation between Claude sessions. Intra-session Agent Teams are unaffected. | Port R018 note and keep privileged actions scoped to the receiving session. |
+
 ## v2.1.158
 
 Published: 2026-05-30.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.15",
+  "version": "0.5.16",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/tests/unit/cli/doctor-omx.test.ts
+++ b/tests/unit/cli/doctor-omx.test.ts
@@ -234,3 +234,59 @@ describe('doctor OMX baseline checks', () => {
     expect(result.message).toContain('omx api available');
   });
 });
+
+describe('doctor OMX model lane diagnostics', () => {
+  const originalFrontier = process.env.OMX_DEFAULT_FRONTIER_MODEL;
+  const originalSpark = process.env.OMX_DEFAULT_SPARK_MODEL;
+  const originalLegacySpark = process.env.OMX_SPARK_MODEL;
+
+  afterEach(() => {
+    if (originalFrontier === undefined) delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+    else process.env.OMX_DEFAULT_FRONTIER_MODEL = originalFrontier;
+    if (originalSpark === undefined) delete process.env.OMX_DEFAULT_SPARK_MODEL;
+    else process.env.OMX_DEFAULT_SPARK_MODEL = originalSpark;
+    if (originalLegacySpark === undefined) delete process.env.OMX_SPARK_MODEL;
+    else process.env.OMX_SPARK_MODEL = originalLegacySpark;
+    mock.restore();
+  });
+
+  it('reports runtime defaults when model lane env overrides are absent', async () => {
+    delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+    delete process.env.OMX_DEFAULT_SPARK_MODEL;
+    delete process.env.OMX_SPARK_MODEL;
+
+    const { checkOmxModelRouting } = await import('../../../src/cli/doctor.js');
+    const result = checkOmxModelRouting();
+
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('runtime defaults');
+  });
+
+  it('warns when frontier and spark lanes are explicitly collapsed to one model', async () => {
+    process.env.OMX_DEFAULT_FRONTIER_MODEL = 'gpt-5.5';
+    process.env.OMX_DEFAULT_SPARK_MODEL = 'gpt-5.5';
+    delete process.env.OMX_SPARK_MODEL;
+
+    const { checkOmxModelRouting } = await import('../../../src/cli/doctor.js');
+    const result = checkOmxModelRouting();
+
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('Spark/model lane routing');
+    expect(result.details).toContain('frontier=gpt-5.5');
+    expect(result.details).toContain('spark=gpt-5.5');
+  });
+
+  it('reports legacy spark env compatibility without failing doctor', async () => {
+    process.env.OMX_DEFAULT_FRONTIER_MODEL = 'gpt-5.5';
+    delete process.env.OMX_DEFAULT_SPARK_MODEL;
+    process.env.OMX_SPARK_MODEL = 'gpt-5.3-codex-spark';
+
+    const { checkOmxModelRouting } = await import('../../../src/cli/doctor.js');
+    const result = checkOmxModelRouting();
+
+    expect(result.status).toBe('pass');
+    expect(result.details).toContain(
+      'legacy OMX_SPARK_MODEL detected; prefer OMX_DEFAULT_SPARK_MODEL'
+    );
+  });
+});

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -606,6 +606,18 @@ describe('Template Validation', () => {
   });
 
   describe('Codex init guidance', () => {
+    it('keeps deprecated omx explore out of preferred generated guidance', async () => {
+      const agentsKo = await readFile(join(TEMPLATES_DIR, 'AGENTS.md.ko'), 'utf-8');
+      const agentsEn = await readFile(join(TEMPLATES_DIR, 'AGENTS.md.en'), 'utf-8');
+
+      for (const content of [agentsKo, agentsEn]) {
+        expect(content).toContain('omx explore');
+        expect(content).toContain('deprecated');
+        expect(content).toContain('USE_OMX_EXPLORE_CMD');
+        expect(content).toContain('omx sparkshell -- <command>');
+      }
+    });
+
     it('does not present Claude Code plugins as required Codex init steps', async () => {
       const initSource = await readFile(
         resolve(import.meta.dir, '../../../src/cli/init.ts'),
@@ -627,7 +639,7 @@ describe('Template Validation', () => {
   });
 
   describe('Claude Code version compatibility guidance', () => {
-    it('mirrors the v2.1.139 through v2.1.156 compatibility guide into templates', async () => {
+    it('mirrors the v2.1.139 through v2.1.168 compatibility guide into templates', async () => {
       const projectRoot = resolve(import.meta.dir, '../../..');
       const guidePath = 'guides/claude-code/15-version-compatibility.md';
       const sourceGuide = await readFile(join(projectRoot, guidePath), 'utf-8');
@@ -651,6 +663,11 @@ describe('Template Validation', () => {
         'v2.1.153',
         'v2.1.154',
         'v2.1.156',
+        'v2.1.157',
+        'v2.1.158',
+        'v2.1.166',
+        'v2.1.167',
+        'v2.1.168',
       ]) {
         expect(templateGuide).toContain(version);
       }
@@ -673,6 +690,10 @@ describe('Template Validation', () => {
       expect(templateGuide).toContain('skipLfs');
       expect(templateGuide).toContain('Opus 4.8');
       expect(templateGuide).toContain('Dynamic Workflows');
+      expect(templateGuide).toContain('fallbackModel');
+      expect(templateGuide).toContain('MAX_THINKING_TOKENS=0');
+      expect(templateGuide).toContain('Cross-session relayed `SendMessage`');
+      expect(templateGuide).toContain('deny all tools');
       expect(templateGuide).toContain('Agent tool malformed parsing');
     });
 
@@ -726,6 +747,12 @@ describe('Template Validation', () => {
     it('keeps formal Korean and completion rules mirrored into templates', async () => {
       const projectRoot = resolve(import.meta.dir, '../../..');
       const mirroredRules = [
+        'MUST-permissions.md',
+        'MUST-agent-design.md',
+        'MUST-agent-teams.md',
+        'MUST-safety.md',
+        'MAY-optimization.md',
+        'SHOULD-memory-integration.md',
         'MUST-language-policy.md',
         'MUST-agent-identification.md',
         'MUST-tool-identification.md',
@@ -769,6 +796,35 @@ describe('Template Validation', () => {
       expect(r020).toContain('Diagnostic Hypothesis Verification');
       expect(r020).toContain('Test-Skip Is Not Completion');
       expect(r020).toContain('Parallel Read + Permanent-Change Dispatch');
+
+      const permissionsRule = await readFile(
+        join(projectRoot, '.codex/rules/MUST-permissions.md'),
+        'utf-8'
+      );
+      const agentDesignRule = await readFile(
+        join(projectRoot, '.codex/rules/MUST-agent-design.md'),
+        'utf-8'
+      );
+      const agentTeamsRule = await readFile(
+        join(projectRoot, '.codex/rules/MUST-agent-teams.md'),
+        'utf-8'
+      );
+      const safetyRule = await readFile(join(projectRoot, '.codex/rules/MUST-safety.md'), 'utf-8');
+      const optimizationRule = await readFile(
+        join(projectRoot, '.codex/rules/MAY-optimization.md'),
+        'utf-8'
+      );
+      const memoryRule = await readFile(
+        join(projectRoot, '.codex/rules/SHOULD-memory-integration.md'),
+        'utf-8'
+      );
+
+      expect(permissionsRule).toContain('Deny Rule Glob Patterns');
+      expect(agentDesignRule).toContain('Fallback Models and Thinking Toggle');
+      expect(agentTeamsRule).toContain('Cross-Session Relay Authority Hardening');
+      expect(safetyRule).toContain('Pre-Delegation Blast-Radius Enumeration');
+      expect(optimizationRule).toContain('Measure-Before-Adopt Gate');
+      expect(memoryRule).toContain('Safety Feedback Memory');
 
       const r017 = await readFile(
         join(projectRoot, '.codex/rules/MUST-sync-verification.md'),


### PR DESCRIPTION
## Summary
- Bump package/template manifest to `0.5.16` for the next release unit.
- Port upstream-monitor compatibility findings into mirrored Claude Code rules and compatibility guides.
- Add generated AGENTS guidance that keeps `omx explore` deprecated and frames `omx sparkshell` as explicit shell-native read-only evidence/verification tooling.
- Add `omcustomcodex doctor` diagnostics for OMX frontier/spark model lane drift and legacy `OMX_SPARK_MODEL` compatibility.

## Scope
- Closes #1479
- Closes #1482
- Closes #1474
- Defers #1481 as watch-only upstream Codex runtime tracking.

## Validation
- `bun install`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 1838 pass / 0 fail
- `bun run build`
- `bash .github/scripts/verify-template-sync.sh`
- `bash .github/scripts/verify-wiki-sync.sh`
- `bash .github/scripts/verify-version-sync.sh`
- `git diff --check`
- `npm view oh-my-customcodex version --silent` — 0.5.15

## Release notes
- Release candidate: `v0.5.16`
- Current npm published version before this PR: `0.5.15`
- Publication/tagging intentionally left for post-merge release flow.
