### PR TITLE
release: v0.5.18 — port upstream rule hardening

### DIFF
--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -162,6 +162,10 @@ When a user sends a new instruction while work is in progress, completion status
 3. If the new message adds a requirement, add it to the completion contract before closing.
 4. If no conflict exists, continue but explicitly preserve the new requirement in the next verification pass.
 
+### Tool-Call Payload Completeness
+
+도구 호출의 required 파라미터는 invoke 전에 확인한다(완료 선언 후가 아니라 호출 시점의 전제조건). announce(prefix)만 출력하고 payload의 required 필드를 누락하는 패턴은 R008 "Required-Parameter Completeness Check"가 canonical owner다. Reference: #1487 / upstream #1324.
+
 ## Completion Contract Format — [Contract] + [Done] with criterion/evidence pairs. See template via Read tool.
 
 <!-- DETAIL: Completion Contract Format

--- a/.codex/rules/MUST-parallel-execution.md
+++ b/.codex/rules/MUST-parallel-execution.md
@@ -34,6 +34,19 @@ Before writing/editing multiple files:
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
 6. Parallel dispatch announced? → put all announced tool calls in the same message
 
+### LLM Batch Output Token Budget
+
+For N-item structured LLM batches, pre-compute output tokens and chunk variable-size lists (default ≤40 items); raising `max_tokens` alone is not enough. Reference: #1486 / upstream #1321 and #1320.
+
+<!-- DETAIL: LLM Batch Output Token Budget
+The giant-prompt heuristic governs input tokens. The symmetric output-side rule: when a single LLM call processes N items (scoring/classifying/extracting) and must emit structured output (for example JSON) per item, pre-compute the output budget = N × per-item output tokens before the call. Exceeding `max_tokens` truncates the response mid-structure, so the call can appear to succeed while JSON parsing fails.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Single batch call over a variable-size list with a fixed small `max_tokens` | Chunk into bounded batches (default ≤40 items), constrain per-item output length, and set `max_tokens` to fit one chunk |
+| Raising `max_tokens` alone | Insufficient — it only defers the failure as the list grows. Chunking is the invariant fix. |
+-->
+
 ### Common Violations to Avoid
 
 <!-- DETAIL: Common Violations Short Examples

--- a/.codex/rules/MUST-tool-identification.md
+++ b/.codex/rules/MUST-tool-identification.md
@@ -50,6 +50,18 @@ Incorrect parallel: tool_call(url1), tool_call(url2), tool_call(cmd) — no iden
 Correct parallel: list ALL [agent][model] → Tool/Fetching/Running lines FIRST, then all tool_calls
 -->
 
+
+### Required-Parameter Completeness Check
+
+R008 prefix(announce)와 실제 도구 호출은 분리된 단계다. prefix를 출력한 뒤 호출 payload에서 도구 스키마상 required 파라미터를 누락하면 호출이 실패하거나 빈 동작이 된다. 호출 직전, prefix 존재뿐 아니라 required 파라미터가 모두 채워졌는지 확인한다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `[agent][model] → Tool: AskUserQuestion` prefix만 출력하고 `questions` 파라미터 없이/빈 배열로 호출 | prefix + `questions` 배열(최소 1개) 모두 채워 호출 |
+| announce 후 payload의 required 필드 누락 (announce-payload separation gap) | announce와 동일 메시지에서 required 필드 완비 호출 |
+
+Cross-reference: R020 (action-completeness precondition — invoke 전에 required 파라미터 확인). Reference issue: #1487 / upstream #1324 (AskUserQuestion `questions` 누락 재발 방지).
+
 ## Models
 
 | Model | Use |
@@ -99,6 +111,31 @@ matches the spawn announcement:
   [1] lang-golang-expert:sonnet → Go code review
   [2] lang-python-expert:sonnet → Python code review
 ```
+
+## Tier-3 Interaction Tool Prefix (MANDATORY)
+
+R008 "every tool call" applies to Tier-3 interaction tools too — not only file/exec tools. Applying the `[agent][model] → Tool:` prefix to Bash/Read/Agent while omitting it on `AskUserQuestion`, `TodoWrite`, `EnterPlanMode`, `ExitPlanMode`, `request_user_input`, or equivalent structured-question tools is a violation.
+
+| Tool | R008 prefix required? |
+|------|----------------------|
+| AskUserQuestion / `request_user_input` / structured question | YES — `[agent][model] → Tool: AskUserQuestion` or equivalent before the call |
+| TodoWrite / `update_plan` | YES |
+| EnterPlanMode / ExitPlanMode | YES |
+| Skill | NO separate R008 prefix — identified via the R007 integrated header instead |
+
+Skill invocation is the one exception: it is identified through the R007 integrated identification block (`┌─ Agent: {agent} → {skill-name}`), not a standalone R008 tool prefix.
+
+Reference issue: #1486 / upstream #1321 (AskUserQuestion prefix omission); complements #1487 required-payload completeness.
+
+## Multi-Turn Self-Check
+
+도구 호출 전 매번 확인한다:
+
+1. 이 호출 위에 `[agent-name][model] → Tool: <tool-name>` 라인이 있는가?
+2. agent-name과 model이 현재 컨텍스트와 일치하는가?
+3. 이 호출에 도구 스키마상 required 파라미터가 모두 채워져 있는가? 예: AskUserQuestion/request_user_input 계열은 `questions` 배열이 비어 있지 않아야 한다. prefix(announce)만 출력하고 실제 호출 payload의 required 필드를 누락하면 안 된다.
+
+체크 실패 시 즉시 prefix/필수 파라미터를 보완한 후 호출.
 
 ## Example
 

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.17",
-  "generatedAt": "2026-06-09T08:39:52.996Z",
-  "templateVersion": "0.5.17",
+  "generatorVersion": "0.5.18",
+  "generatedAt": "2026-06-09T10:31:01.121Z",
+  "templateVersion": "0.5.18",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-parallel-execution.md": {
-      "templateHash": "af6927bbea99a7efbcd4e7b90b2106b766a21368dbf0efab6424325dd4968b6e",
-      "size": 8529,
+      "templateHash": "bb4f0b1c6918aa86d1799eaf433b04fb4e576a44f32dd8afdd1b4e2b3c1c7de2",
+      "size": 9616,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ecomode.md": {
@@ -95,8 +95,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-tool-identification.md": {
-      "templateHash": "aec6cc7e8feedce4922d939916d346483ebf583d52c7262d4388709923c990ce",
-      "size": 3266,
+      "templateHash": "e765102bc192bf4fb7ceab7add4f994c998c4fa6fae6d4c24f25a6fc66e12ec9",
+      "size": 5883,
       "component": "rules"
     },
     ".codex/rules/SHOULD-memory-integration.md": {
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "308097247642a506ccff4dac9409e5a3f1bb02bb59ca9bc25688a57b8fc436e3",
-      "size": 13150,
+      "templateHash": "6e9f8a404a1611573c4b74e1dbe0888306975de24872cfa7c946a7a17c69a224",
+      "size": 13508,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.18] - 2026-06-09
+
+### Changed
+- Port upstream v0.175.0/v0.176.0 rule hardening for #1486 and #1487: R008 now covers Tier-3 interaction-tool prefixes plus required-parameter payload completeness, R009 requires output-token budgeting for structured LLM batches, and R020 cross-references tool-call payload completeness.
+
 ## [0.5.17] - 2026-06-09
 
 ### Added

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -74,8 +74,9 @@ Agent identification in responses:
 
 Tool usage identification:
 
-- Every tool call must be prefixed with agent
-- Format: `[agent-name] -> Tool: <tool-name>`
+- Every tool call must be prefixed with agent/model identification
+- Format: `[agent-name][model] → Tool: <tool-name>`
+- Required tool payload fields must be complete before invocation
 - Clear tracking of operations
 
 ### MUST-parallel-execution

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.17",
+  "version": "0.5.18",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -162,6 +162,10 @@ When a user sends a new instruction while work is in progress, completion status
 3. If the new message adds a requirement, add it to the completion contract before closing.
 4. If no conflict exists, continue but explicitly preserve the new requirement in the next verification pass.
 
+### Tool-Call Payload Completeness
+
+도구 호출의 required 파라미터는 invoke 전에 확인한다(완료 선언 후가 아니라 호출 시점의 전제조건). announce(prefix)만 출력하고 payload의 required 필드를 누락하는 패턴은 R008 "Required-Parameter Completeness Check"가 canonical owner다. Reference: #1487 / upstream #1324.
+
 ## Completion Contract Format — [Contract] + [Done] with criterion/evidence pairs. See template via Read tool.
 
 <!-- DETAIL: Completion Contract Format

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -34,6 +34,19 @@ Before writing/editing multiple files:
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
 6. Parallel dispatch announced? → put all announced tool calls in the same message
 
+### LLM Batch Output Token Budget
+
+For N-item structured LLM batches, pre-compute output tokens and chunk variable-size lists (default ≤40 items); raising `max_tokens` alone is not enough. Reference: #1486 / upstream #1321 and #1320.
+
+<!-- DETAIL: LLM Batch Output Token Budget
+The giant-prompt heuristic governs input tokens. The symmetric output-side rule: when a single LLM call processes N items (scoring/classifying/extracting) and must emit structured output (for example JSON) per item, pre-compute the output budget = N × per-item output tokens before the call. Exceeding `max_tokens` truncates the response mid-structure, so the call can appear to succeed while JSON parsing fails.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Single batch call over a variable-size list with a fixed small `max_tokens` | Chunk into bounded batches (default ≤40 items), constrain per-item output length, and set `max_tokens` to fit one chunk |
+| Raising `max_tokens` alone | Insufficient — it only defers the failure as the list grows. Chunking is the invariant fix. |
+-->
+
 ### Common Violations to Avoid
 
 <!-- DETAIL: Common Violations Short Examples

--- a/templates/.claude/rules/MUST-tool-identification.md
+++ b/templates/.claude/rules/MUST-tool-identification.md
@@ -50,6 +50,18 @@ Incorrect parallel: tool_call(url1), tool_call(url2), tool_call(cmd) — no iden
 Correct parallel: list ALL [agent][model] → Tool/Fetching/Running lines FIRST, then all tool_calls
 -->
 
+
+### Required-Parameter Completeness Check
+
+R008 prefix(announce)와 실제 도구 호출은 분리된 단계다. prefix를 출력한 뒤 호출 payload에서 도구 스키마상 required 파라미터를 누락하면 호출이 실패하거나 빈 동작이 된다. 호출 직전, prefix 존재뿐 아니라 required 파라미터가 모두 채워졌는지 확인한다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `[agent][model] → Tool: AskUserQuestion` prefix만 출력하고 `questions` 파라미터 없이/빈 배열로 호출 | prefix + `questions` 배열(최소 1개) 모두 채워 호출 |
+| announce 후 payload의 required 필드 누락 (announce-payload separation gap) | announce와 동일 메시지에서 required 필드 완비 호출 |
+
+Cross-reference: R020 (action-completeness precondition — invoke 전에 required 파라미터 확인). Reference issue: #1487 / upstream #1324 (AskUserQuestion `questions` 누락 재발 방지).
+
 ## Models
 
 | Model | Use |
@@ -99,6 +111,31 @@ matches the spawn announcement:
   [1] lang-golang-expert:sonnet → Go code review
   [2] lang-python-expert:sonnet → Python code review
 ```
+
+## Tier-3 Interaction Tool Prefix (MANDATORY)
+
+R008 "every tool call" applies to Tier-3 interaction tools too — not only file/exec tools. Applying the `[agent][model] → Tool:` prefix to Bash/Read/Agent while omitting it on `AskUserQuestion`, `TodoWrite`, `EnterPlanMode`, `ExitPlanMode`, `request_user_input`, or equivalent structured-question tools is a violation.
+
+| Tool | R008 prefix required? |
+|------|----------------------|
+| AskUserQuestion / `request_user_input` / structured question | YES — `[agent][model] → Tool: AskUserQuestion` or equivalent before the call |
+| TodoWrite / `update_plan` | YES |
+| EnterPlanMode / ExitPlanMode | YES |
+| Skill | NO separate R008 prefix — identified via the R007 integrated header instead |
+
+Skill invocation is the one exception: it is identified through the R007 integrated identification block (`┌─ Agent: {agent} → {skill-name}`), not a standalone R008 tool prefix.
+
+Reference issue: #1486 / upstream #1321 (AskUserQuestion prefix omission); complements #1487 required-payload completeness.
+
+## Multi-Turn Self-Check
+
+도구 호출 전 매번 확인한다:
+
+1. 이 호출 위에 `[agent-name][model] → Tool: <tool-name>` 라인이 있는가?
+2. agent-name과 model이 현재 컨텍스트와 일치하는가?
+3. 이 호출에 도구 스키마상 required 파라미터가 모두 채워져 있는가? 예: AskUserQuestion/request_user_input 계열은 `questions` 배열이 비어 있지 않아야 한다. prefix(announce)만 출력하고 실제 호출 payload의 required 필드를 누락하면 안 된다.
+
+체크 실패 시 즉시 prefix/필수 파라미터를 보완한 후 호출.
 
 ## Example
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.17",
+  "version": "0.5.18",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/wiki/rules/r008.md
+++ b/wiki/rules/r008.md
@@ -1,13 +1,14 @@
 ---
 title: "R008: Tool Identification Rules"
 type: rule
-updated: 2026-05-20
+updated: 2026-06-09
 sources:
   - .codex/rules/MUST-tool-identification.md
 related:
   - [[r007]]
   - [[r009]]
   - [[r010]]
+  - [[r020]]
   - [[r021]]
 ---
 
@@ -35,6 +36,10 @@ Tool identification pairs with [[r007]] (agent identification) to create full tr
 
 **Short response discipline:** Quick diagnostics and brief checks are not exempt. If a visible response will be followed by a tool call, show the `[agent][model] → Tool` and target prefix before the call even when the natural-language update is one sentence.
 
+**Required-parameter completeness:** Prefix/announce and the actual tool payload are separate obligations. Before invoking a tool, verify all schema-required parameters are present. Canonical example: `AskUserQuestion`/structured-question calls must include a non-empty `questions` array; a prefix without required payload fields is not a valid R008-compliant call.
+
+**Tier-3 interaction tools:** R008 applies to interaction/planning tools too (`AskUserQuestion`, `request_user_input`, `TodoWrite`/`update_plan`, `EnterPlanMode`, `ExitPlanMode`). Skill invocation is the exception because the R007 integrated header identifies the skill surface.
+
 **Tool category verbs:**
 
 | Category | Tools | Verb |
@@ -58,7 +63,7 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 
 ## Relationships
 
-- **Related rules**: [[r007]], [[r009]], [[r010]]
+- **Related rules**: [[r007]], [[r009]], [[r010]], [[r020]]
 - **Affects**: All tool calls across all agents
 
 ## Sources

--- a/wiki/rules/r009.md
+++ b/wiki/rules/r009.md
@@ -1,7 +1,7 @@
 ---
 title: "R009: Parallel Execution Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-06-09
 sources:
   - .codex/rules/MUST-parallel-execution.md
 related:
@@ -41,6 +41,8 @@ Parallel execution maximizes throughput and reduces wall-clock time. Before spaw
 | Orchestrator | Must stay singleton, never parallelized |
 
 **Adaptive parallel splitting:** When an agent takes 2x+ longer than peers, spawn independent follow-up tasks immediately without canceling the stalled agent.
+
+**LLM batch output budget:** For N-item scoring/classification/extraction calls that emit structured output, pre-compute N × per-item output tokens before the call. Chunk variable-size lists (default ≤40 items) and constrain per-item output rather than only raising `max_tokens`, because mid-JSON truncation can look like a successful call until parsing fails.
 
 Detailed detection, stability, and announcement examples are preserved in HTML `DETAIL` blocks in the source rule and can be loaded with a direct Read when needed.
 

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -1,11 +1,12 @@
 ---
 title: "R020: Completion Verification Rules"
 type: rule
-updated: 2026-05-29
+updated: 2026-06-09
 sources:
   - .codex/rules/MUST-completion-verification.md
 related:
   - [[r003]]
+  - [[r008]]
   - [[r010]]
   - [[r017]]
   - [[r021]]
@@ -62,6 +63,10 @@ False completion declarations erode trust and cause downstream failures. "Ran th
 | "Subagent reported pre-existing" | Not verified against baseline | Compare develop branch directly |
 | "Continued old plan after user interrupt" | Newest instruction has priority | Re-rank work and update completion contract before closing |
 
+## Tool-Call Payload Completeness
+
+Tool-call completion includes payload completeness at invocation time. Do not treat "I announced the tool" or "I attempted the call" as sufficient when schema-required fields are missing. R008 owns the canonical required-parameter check; R020 cross-checks that such malformed calls are not counted as verified progress or completion evidence.
+
 ## Diagnostic Hypothesis Verification
 
 When a diagnosis would cause a permanent workflow, rule, template, or release-process change, the diagnosis must be treated as a hypothesis until directly verified. Record the symptom, proposed root cause, direct evidence, and at least one plausible alternative before merging the permanent change.
@@ -113,7 +118,7 @@ Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]]
 
 ## Relationships
 
-- **Related rules**: [[r003]], [[r010]], [[r017]], [[r021]]
+- **Related rules**: [[r003]], [[r008]], [[r010]], [[r017]], [[r021]]
 - **Affects**: All task completion declarations across all agents and workflows
 
 ## Sources


### PR DESCRIPTION
## 개요

#1486/#1487 upstream release monitor 이슈를 처리합니다. parent v0.175.0/v0.176.0 규칙 강화 내용을 Codex 포트 표면에 반영하고 0.5.18 릴리스 메타데이터를 승격했습니다.

## 변경 사항

- R008: Tier-3 interaction tool prefix 의무 및 required-parameter payload completeness 추가
- R009: 구조화 LLM batch output token budget/chunking guidance 추가
- R020: tool-call payload completeness cross-reference 추가
- `.codex` source, `templates/.claude` mirror, wiki rule pages, reference docs, lockfile, package/manifest version, CHANGELOG 동기화

## 검증

- `bun install --frozen-lockfile`
- `bash .github/scripts/verify-version-sync.sh`
- `bash .github/scripts/verify-template-sync.sh`
- `bash .github/scripts/verify-wiki-sync.sh`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 1841 pass / 0 fail
- `bun run build`
- pre-commit stable batches — pass

Fixes #1486
Fixes #1487