### PR TITLE
Release v0.5.19

### DIFF
--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -85,8 +85,10 @@ Before invoking or registering generated workflow code, run a Tier-1 sanity pass
 
 1. Search for unresolved placeholders, malformed identifiers, and known dead-line patterns.
 2. Assemble the exact script body before execution; do not concatenate facts or guardrails after the call starts.
-3. Run the language parser or the narrowest no-side-effect syntax check available.
-4. If syntax validation is unavailable, read the generated body back and perform a focused self-review before launch.
+3. For compound shell verification or release gates, start the script with `set -euo pipefail`; `set -o pipefail` alone does not stop later sequential gates after an earlier command fails.
+4. For zsh/bash snippets, avoid reserved or special variable names such as `status`, `path`, and `argv`; use `run_status`, `cmd_path`, `args`, or similarly specific names.
+5. Run the language parser or the narrowest no-side-effect syntax check available.
+6. If syntax validation is unavailable, read the generated body back and perform a focused self-review before launch.
 
 This check is mandatory for workflow scripts that will run automation, mutate GitHub state, or gate a release.
 

--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -222,6 +222,11 @@ steps:
       - If a scoped issue is added or materially changed after verify-build starts, reset this phase and re-run the full verify-build gate for the new aggregate scope.
       - Do not proceed to release from a verify-build result collected before the latest scoped implementation change.
 
+      Shell execution discipline:
+      - Run compound verification commands under `set -euo pipefail` so lint, typecheck, tests, and build halt on the first failed gate.
+      - Do not rely on `set -o pipefail` alone for sequential verification chains.
+      - Avoid reserved shell variable names in polling or status snippets (`status`, `path`, `argv`); use `run_status`, `cmd_path`, or `args` instead.
+
       For Node/Bun projects (this repo):
       1. bun install — verify lockfile sync (halt on lockfile drift)
       2. bun run lint (if package.json has lint script)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,16 +309,44 @@ jobs:
       # Publish to npm (skip if already exists)
       - name: Publish to npm
         if: steps.npm_check.outputs.exists == 'false'
+        shell: bash
         run: |
-          npm publish --ignore-scripts --provenance --access public 2>&1 || {
-            EXIT_CODE=$?
-            # Check if failure is due to version already existing (race condition with local publish)
-            if npm view oh-my-customcodex@${{ steps.npm_check.outputs.version }} version 2>/dev/null; then
-              echo "::notice::Version ${{ steps.npm_check.outputs.version }} was published externally (race condition). Continuing."
-            else
-              exit $EXIT_CODE
+          set -euo pipefail
+
+          VERSION="${{ steps.npm_check.outputs.version }}"
+          MAX_PUBLISH_ATTEMPTS=3
+
+          for ((attempt=1; attempt<=MAX_PUBLISH_ATTEMPTS; attempt++)); do
+            log_file=$(mktemp)
+            echo "::group::npm publish attempt ${attempt}/${MAX_PUBLISH_ATTEMPTS}"
+            set +e
+            npm publish --ignore-scripts --provenance --access public 2>&1 | tee "${log_file}"
+            publish_exit=${PIPESTATUS[0]}
+            set -e
+            echo "::endgroup::"
+
+            if [ "${publish_exit}" -eq 0 ]; then
+              rm -f "${log_file}"
+              exit 0
             fi
-          }
+
+            # Check if failure is due to version already existing (race condition with local publish)
+            if npm view oh-my-customcodex@${VERSION} version 2>/dev/null; then
+              echo "::notice::Version ${VERSION} was published externally (race condition). Continuing."
+              rm -f "${log_file}"
+              exit 0
+            fi
+
+            if grep -qE 'TLOG_CREATE_ENTRY_ERROR|rekor\.sigstore\.dev|Invalid response body.*aborted' "${log_file}" && [ "${attempt}" -lt "${MAX_PUBLISH_ATTEMPTS}" ]; then
+              echo "::warning::npm provenance/Rekor transient publish failure detected; retrying after 30 seconds."
+              rm -f "${log_file}"
+              sleep 30
+              continue
+            fi
+
+            rm -f "${log_file}"
+            exit "${publish_exit}"
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.18",
-  "generatedAt": "2026-06-09T10:31:01.121Z",
-  "templateVersion": "0.5.18",
+  "generatorVersion": "0.5.19",
+  "generatedAt": "2026-06-09T10:51:09.883Z",
+  "templateVersion": "0.5.19",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "6e9f8a404a1611573c4b74e1dbe0888306975de24872cfa7c946a7a17c69a224",
-      "size": 13508,
+      "templateHash": "d12ba40d4a71a00cdba0f730732508fe826d6d615bfa6e944f8745841dbb021c",
+      "size": 13869,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.19] - 2026-06-09
+
+### Changed
+- Harden auto-dev and release workflow reliability for #1489: compound verify-build shell guidance now requires `set -euo pipefail`, workflow sanity checks call out zsh/bash reserved variable names, and npm provenance/Rekor transient publish errors retry automatically before failing.
+
 ## [0.5.18] - 2026-06-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.18",
+  "version": "0.5.19",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -85,8 +85,10 @@ Before invoking or registering generated workflow code, run a Tier-1 sanity pass
 
 1. Search for unresolved placeholders, malformed identifiers, and known dead-line patterns.
 2. Assemble the exact script body before execution; do not concatenate facts or guardrails after the call starts.
-3. Run the language parser or the narrowest no-side-effect syntax check available.
-4. If syntax validation is unavailable, read the generated body back and perform a focused self-review before launch.
+3. For compound shell verification or release gates, start the script with `set -euo pipefail`; `set -o pipefail` alone does not stop later sequential gates after an earlier command fails.
+4. For zsh/bash snippets, avoid reserved or special variable names such as `status`, `path`, and `argv`; use `run_status`, `cmd_path`, `args`, or similarly specific names.
+5. Run the language parser or the narrowest no-side-effect syntax check available.
+6. If syntax validation is unavailable, read the generated body back and perform a focused self-review before launch.
 
 This check is mandatory for workflow scripts that will run automation, mutate GitHub state, or gate a release.
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.18",
+  "version": "0.5.19",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -126,6 +126,11 @@ steps:
       - If a scoped issue is added or materially changed after verify-build starts, reset this phase and re-run the full verify-build gate for the new aggregate scope.
       - Do not proceed to release from a verify-build result collected before the latest scoped implementation change.
 
+      Shell execution discipline:
+      - Run compound verification commands under `set -euo pipefail` so lint, typecheck, tests, and build halt on the first failed gate.
+      - Do not rely on `set -o pipefail` alone for sequential verification chains.
+      - Avoid reserved shell variable names in polling or status snippets (`status`, `path`, `argv`); use `run_status`, `cmd_path`, or `args` instead.
+
       For Node/Bun projects:
       1. Run `bun install` and halt on lockfile drift.
       2. Run `bun run lint` when available.

--- a/tests/unit/core/release-workflow.test.ts
+++ b/tests/unit/core/release-workflow.test.ts
@@ -62,6 +62,18 @@ describe('release.yml — publish safeguards', () => {
     expect(content).toContain('run: bash .github/scripts/verify-version-sync.sh');
   });
 
+  it('should retry transient npm provenance Rekor publish failures before failing', async () => {
+    const content = await readWorkflow();
+
+    expect(content).toContain('MAX_PUBLISH_ATTEMPTS=3');
+    expect(content).toContain('TLOG_CREATE_ENTRY_ERROR');
+    expect(content).toContain('rekor\\.sigstore\\.dev');
+    expect(content).toContain('Invalid response body.*aborted');
+    expect(content).toContain('npm provenance/Rekor transient publish failure detected');
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions bash snippet assertion
+    expect(content).toContain('publish_exit=${PIPESTATUS[0]}');
+  });
+
   it('should fail release publish when CHANGELOG lacks the tagged version section', async () => {
     const content = await readWorkflow();
 

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -1119,6 +1119,8 @@ describe('Template Validation', () => {
         expect(content).toContain('labels.md');
         expect(content).toContain('milestone');
         expect(content).toContain('compression_mode');
+        expect(content).toContain('set -euo pipefail');
+        expect(content).toContain('reserved shell variable names');
         expect(content).toContain('bun test');
         expect(content).toContain('baseline');
       }

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -79,6 +79,11 @@ Do not batch diagnostic `Read` or log inspection with permanent issue/fix dispat
 
 R009 parallel execution applies only to independent tasks. Diagnostic evidence and the permanent change that depends on it are sequential, not independent. This prevents stale or speculative issue, PR, and commit records when the later read reveals a different root cause.
 
+
+## Workflow Script Sanity Check
+
+Generated workflow and release shell snippets must be sanity-checked before execution or registration. Compound verification gates should start with `set -euo pipefail`, because `set -o pipefail` alone does not halt later sequential checks after an earlier command fails. zsh/bash snippets must also avoid reserved or special variable names such as `status`, `path`, and `argv`; use specific names like `run_status`, `cmd_path`, or `args`.
+
 ## Test-Skip Is Not Completion
 
 Skipping tests, lowering coverage thresholds, narrowing the test command, or marking suites as TODO can be temporary containment only. Completion still requires a linked issue, owner, reproduction command, precise skipped scope, and a follow-up that restores the skipped coverage.

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -126,6 +126,11 @@ steps:
       - If a scoped issue is added or materially changed after verify-build starts, reset this phase and re-run the full verify-build gate for the new aggregate scope.
       - Do not proceed to release from a verify-build result collected before the latest scoped implementation change.
 
+      Shell execution discipline:
+      - Run compound verification commands under `set -euo pipefail` so lint, typecheck, tests, and build halt on the first failed gate.
+      - Do not rely on `set -o pipefail` alone for sequential verification chains.
+      - Avoid reserved shell variable names in polling or status snippets (`status`, `path`, `argv`); use `run_status`, `cmd_path`, or `args` instead.
+
       For Node/Bun projects:
       1. Run `bun install` and halt on lockfile drift.
       2. Run `bun run lint` when available.


### PR DESCRIPTION
## Summary
- Fixes #1489 by requiring strict shell execution guidance in auto-dev verify-build prompts.
- Documents R020 shell sanity checks for  and zsh/bash reserved variable avoidance across source/template/wiki mirrors.
- Adds bounded npm provenance/Rekor retry handling to the release workflow while preserving the already-published race check.
- Bumps package/template version to 0.5.19 and promotes the changelog entry.

## Verification
- bun install --frozen-lockfile
- bash .github/scripts/verify-version-sync.sh
- bash .github/scripts/verify-template-sync.sh
- bash .github/scripts/verify-wiki-sync.sh
- ruby YAML parse for release/auto-dev workflows
- bun test tests/unit/core/release-workflow.test.ts tests/unit/core/template-validation.test.ts
- bun run lint
- bun run typecheck
- bun test
- bun run build
- pre-commit stable batches

Fixes #1489