### PR TITLE
Release v0.5.20

### DIFF
--- a/.codex/hooks/hooks.json
+++ b/.codex/hooks/hooks.json
@@ -103,6 +103,16 @@
         "description": "Block Bash/Write/Edit writes into .claude/ sensitive paths before Claude Code permission prompts fire"
       },
       {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"(^|[[:space:];&|])(status|path|argv)[[:space:]]*=\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/shell-reserved-var-advisor.sh"
+          }
+        ],
+        "description": "Warn on zsh/bash reserved variable assignments such as status=, path=, or argv= before shell execution (R020/#1491)"
+      },
+      {
         "matcher": "tool == \"Bash\"",
         "hooks": [
           {

--- a/.codex/hooks/scripts/shell-reserved-var-advisor.sh
+++ b/.codex/hooks/scripts/shell-reserved-var-advisor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# shell-reserved-var-advisor.sh — advisory guard for zsh/bash special variable assignments.
+# Trigger: PreToolUse (Bash matcher)
+
+set -euo pipefail
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+
+if [ -z "$command" ]; then
+  printf '%s' "$input"
+  exit 0
+fi
+
+# zsh exposes several lowercase special parameters as read-only or semantically
+# dangerous. `status=...` is the frequent footgun in polling snippets; `path`
+# and `argv` are arrays/special parameters. Match assignment starts after common
+# shell separators or whitespace, but do not match safe names like run_status=.
+if printf '%s\n' "$command" | grep -Eq '(^|[[:space:];&|])(status|path|argv)[[:space:]]*='; then
+  echo '[Hook] WARNING: reserved shell variable assignment detected (R020/#1491).' >&2
+  echo '[Hook] Avoid zsh/bash special names: status, path, argv.' >&2
+  echo '[Hook] Use safe names such as run_status, cmd_path, or args before executing.' >&2
+fi
+
+printf '%s' "$input"

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.19",
-  "generatedAt": "2026-06-09T10:51:09.883Z",
-  "templateVersion": "0.5.19",
+  "generatorVersion": "0.5.20",
+  "generatedAt": "2026-06-09T11:06:57.984Z",
+  "templateVersion": "0.5.20",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
@@ -459,6 +459,11 @@
       "size": 2275,
       "component": "hooks"
     },
+    ".codex/hooks/scripts/shell-reserved-var-advisor.sh": {
+      "templateHash": "e40e0fcaa211b1db0ead6a533dc42b95f7aafe41e73862267bf102c0b24c1ee8",
+      "size": 1025,
+      "component": "hooks"
+    },
     ".codex/hooks/scripts/secret-filter.sh": {
       "templateHash": "f9e002664ef091328d059e2dcf703eb30929f47ff59e81fdddd201f24783ab1f",
       "size": 2904,
@@ -595,8 +600,8 @@
       "component": "hooks"
     },
     ".codex/hooks/hooks.json": {
-      "templateHash": "2e9cd9eee40db0f1ee84f5329c44c11b6e959916bb915d9aba59eb40ebb52ac4",
-      "size": 28853,
+      "templateHash": "82380747501959f192c6cef316fa66524461637ead8dcfbc47fcd9ea5299cb4b",
+      "size": 29300,
       "component": "hooks"
     },
     ".codex/contexts/ecomode.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.20] - 2026-06-09
+
+### Added
+- Add a Bash PreToolUse reserved-variable advisor for #1491 so shell snippets that assign zsh/bash special names like `status`, `path`, or `argv` produce an immediate warning with safer replacements.
+
 ## [0.5.19] - 2026-06-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.19",
+  "version": "0.5.20",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -103,6 +103,16 @@
         "description": "Block Bash/Write/Edit writes into .claude/ sensitive paths before Claude Code permission prompts fire"
       },
       {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"(^|[[:space:];&|])(status|path|argv)[[:space:]]*=\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/scripts/shell-reserved-var-advisor.sh"
+          }
+        ],
+        "description": "Warn on zsh/bash reserved variable assignments such as status=, path=, or argv= before shell execution (R020/#1491)"
+      },
+      {
         "matcher": "tool == \"Bash\"",
         "hooks": [
           {

--- a/templates/.claude/hooks/scripts/shell-reserved-var-advisor.sh
+++ b/templates/.claude/hooks/scripts/shell-reserved-var-advisor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# shell-reserved-var-advisor.sh — advisory guard for zsh/bash special variable assignments.
+# Trigger: PreToolUse (Bash matcher)
+
+set -euo pipefail
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+
+if [ -z "$command" ]; then
+  printf '%s' "$input"
+  exit 0
+fi
+
+# zsh exposes several lowercase special parameters as read-only or semantically
+# dangerous. `status=...` is the frequent footgun in polling snippets; `path`
+# and `argv` are arrays/special parameters. Match assignment starts after common
+# shell separators or whitespace, but do not match safe names like run_status=.
+if printf '%s\n' "$command" | grep -Eq '(^|[[:space:];&|])(status|path|argv)[[:space:]]*='; then
+  echo '[Hook] WARNING: reserved shell variable assignment detected (R020/#1491).' >&2
+  echo '[Hook] Avoid zsh/bash special names: status, path, argv.' >&2
+  echo '[Hook] Use safe names such as run_status, cmd_path, or args before executing.' >&2
+fi
+
+printf '%s' "$input"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.19",
+  "version": "0.5.20",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/tests/unit/core/hooks-scripts.test.ts
+++ b/tests/unit/core/hooks-scripts.test.ts
@@ -28,6 +28,7 @@ const STALE_TODO_SCANNER_SCRIPT = join(SCRIPTS_DIR, 'stale-todo-scanner.sh');
 const FEEDBACK_COLLECTOR_SCRIPT = join(SCRIPTS_DIR, 'feedback-collector.sh');
 const SKILL_EXTRACTOR_ANALYZER_SCRIPT = join(SCRIPTS_DIR, 'skill-extractor-analyzer.sh');
 const PLUGIN_CACHE_CHECK_SCRIPT = join(SCRIPTS_DIR, 'plugin-cache-check.sh');
+const SHELL_RESERVED_VAR_ADVISOR_SCRIPT = join(SCRIPTS_DIR, 'shell-reserved-var-advisor.sh');
 
 const STAGE_FILE = '/tmp/.codex-dev-stage';
 
@@ -704,6 +705,41 @@ describe('git-delegation-guard.sh', () => {
     // jq will produce errors on empty input but the script should still exit 0
     const result = await runHookScript(GIT_DELEGATION_GUARD_SCRIPT, '');
     expect(result.exitCode).toBe(0);
+  });
+});
+
+// -------------------------------------------------------------------
+// shell-reserved-var-advisor.sh
+// -------------------------------------------------------------------
+
+describe('shell-reserved-var-advisor.sh', () => {
+  it('warns for zsh reserved status assignment in Bash snippets', async () => {
+    const input = makeBashInput(
+      'run_json=$(gh run view 1 --json status); status=$(echo "$run_json" | jq -r .status)'
+    );
+    const result = await runHookScript(SHELL_RESERVED_VAR_ADVISOR_SCRIPT, input);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(input);
+    expect(result.stderr).toContain('reserved shell variable assignment');
+    expect(result.stderr).toContain('run_status');
+  });
+
+  it('does not warn for safe replacement variable names', async () => {
+    const input = makeBashInput(
+      'run_status=$(echo "$run_json" | jq -r .status); cmd_path=/tmp/out; args="--json"'
+    );
+    const result = await runHookScript(SHELL_RESERVED_VAR_ADVISOR_SCRIPT, input);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(input);
+    expect(result.stderr).not.toContain('reserved shell variable assignment');
+  });
+
+  it('has valid bash syntax', async () => {
+    const result = await bashSyntaxCheck(SHELL_RESERVED_VAR_ADVISOR_SCRIPT);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
   });
 });
 
@@ -1704,6 +1740,7 @@ describe('Script file validation', () => {
     'cwd-change-detector.sh',
     'file-change-validator.sh',
     'plugin-cache-check.sh',
+    'shell-reserved-var-advisor.sh',
   ] as const;
 
   it('all expected scripts should exist in the templates directory', async () => {

--- a/tests/unit/core/hooks-validation.test.ts
+++ b/tests/unit/core/hooks-validation.test.ts
@@ -508,6 +508,40 @@ describe('Hooks Validation', () => {
     });
   });
 
+  describe('Shell reserved variable advisor', () => {
+    it('should register the shell reserved-variable advisor in PreToolUse', async () => {
+      const { parsed } = await loadHooksJson();
+      const data = parsed as HooksStructure;
+      const entries = data.hooks.PreToolUse ?? [];
+
+      const advisorHook = entries.find((entry) =>
+        entry.hooks.some(
+          (hook) =>
+            hook.type === 'command' && hook.command.includes('shell-reserved-var-advisor.sh')
+        )
+      );
+
+      expect(advisorHook).toBeDefined();
+      expect(advisorHook?.matcher).toContain('tool == "Bash"');
+      expect(advisorHook?.matcher).toContain('status|path|argv');
+      expect(advisorHook?.description).toContain('reserved variable');
+    });
+
+    it('should keep source and template shell reserved-variable advisor registration in sync', async () => {
+      const source = JSON.parse(await readFile(SOURCE_HOOKS_FILE, 'utf-8')) as HooksStructure;
+      const template = JSON.parse(await readFile(HOOKS_FILE, 'utf-8')) as HooksStructure;
+      const findAdvisor = (data: HooksStructure) =>
+        (data.hooks.PreToolUse ?? []).find((entry) =>
+          entry.hooks.some(
+            (hook) =>
+              hook.type === 'command' && hook.command.includes('shell-reserved-var-advisor.sh')
+          )
+        );
+
+      expect(findAdvisor(source)).toEqual(findAdvisor(template));
+    });
+  });
+
   describe('Destructive git guard', () => {
     it('should register the destructive git advisory hook in PreToolUse', async () => {
       const { parsed } = await loadHooksJson();


### PR DESCRIPTION
## Summary
- Add a PreToolUse shell reserved-variable advisor for #1491 so assignments to zsh/bash special names (`status`, `path`, `argv`) warn before execution.
- Mirror the advisor in the install templates and lock hook/template parity with tests.
- Bump package/template metadata and changelog to v0.5.20.

Fixes #1491

## Verification
- bun install --frozen-lockfile
- bash .github/scripts/verify-version-sync.sh
- bash .github/scripts/verify-template-sync.sh
- bash .github/scripts/verify-wiki-sync.sh
- bash -n .codex/hooks/scripts/shell-reserved-var-advisor.sh
- bash -n templates/.claude/hooks/scripts/shell-reserved-var-advisor.sh
- jq empty .codex/hooks/hooks.json
- jq empty templates/.claude/hooks/hooks.json
- bun test tests/unit/core/hooks-scripts.test.ts tests/unit/core/hooks-validation.test.ts
- bun run lint
- bun run typecheck
- bun test
- bun run build

## Risk
- Narrow: advisory-only hook exits 0 and does not block shell execution.