### PR TITLE
chore(release): v0.5.21

### DIFF
--- a/.codex/rules/MUST-agent-design.md
+++ b/.codex/rules/MUST-agent-design.md
@@ -24,7 +24,6 @@ tools: [Read, Write, ...]  # Allowed tools
 | `opus` | claude-opus-4-6 | Complex reasoning, architecture |
 | `opusplan` | claude-opus-4-6 + plan mode | Architecture planning with approval gates |
 | `opus47` | claude-opus-4-7 | Latest Opus model, supports xhigh effort |
-
 Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
 <!-- DETAIL: Fallback Models and Thinking Toggle (Claude Code v2.1.166+)
@@ -88,6 +87,7 @@ This Codex port ships `.claude` compatibility templates. When updating those tem
 - v2.1.162: `claude agents --json` includes waiting/blocker metadata and explicit `--tools Grep/Glob` behavior is fixed; compatibility prompts may use those fields when diagnosing stuck Claude sessions.
 - v2.1.163: managed `requiredMinimumVersion`/`requiredMaximumVersion`, `/plugin list`, Stop/SubagentStop `hookSpecificOutput.additionalContext`, and skill command literal `\$` escaping are available. Hook/skill template changes should preserve these affordances.
 - v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation. v2.1.166: fallbackModel availability failover and thinking-disable controls are Claude compatibility settings, not Codex/OMX routing. v2.1.167/v2.1.168: bug-fix-only compatibility confirmation.
+- v2.1.170: Claude compatibility sessions gain access to the `fable` alias (`claude-fable-5`) and fix a VS Code integrated-terminal transcript persistence bug. Skills that rely on transcript replay (for example `homework`) should prefer v2.1.170+ in Claude-template sessions. No Codex runtime model-routing change.
 -->
 
 ## Hook Event Types

--- a/.codex/rules/MUST-agent-teams.md
+++ b/.codex/rules/MUST-agent-teams.md
@@ -8,6 +8,18 @@
 
 Available when `OMCODEX_AGENT_TEAMS=1` or `TeamCreate` / `SendMessage` exists.
 
+## Gate Transparency Scope
+
+R018 gate-transparency announcements apply only when Agent Teams are enabled or callable; otherwise R009 parallel-execution announcements are sufficient.
+
+<!--
+DETAIL: Gate Transparency Scope
+| Runtime state | Required |
+|---------------|----------|
+| Agent Teams enabled/callable | Announce the R018 gate result for qualifying 3+ agent dispatches |
+| Agent Teams disabled/unavailable | Use R009 `[N]` dispatch format and state the fallback only if useful for clarity |
+-->
+
 ## Decision Matrix
 
 | Scenario | Preferred | Reason |

--- a/.codex/rules/MUST-completion-verification.md
+++ b/.codex/rules/MUST-completion-verification.md
@@ -67,6 +67,17 @@ Parallel batches return results together, so a same-batch permanent dispatch pro
 
 Example: do not diagnose `triage-dispatch.yml` from memory, create an issue, and delegate a fix in the same parallel call before reading the workflow. If the read later shows a different root cause, the issue, PR, and commit trail become correction debt even when the eventual code direction is acceptable.
 
+### Proxy Signal vs Canonical Ground-Truth
+
+When diagnosing pipeline or data state, verify the canonical store — the authoritative DB, registry, API, or system-of-record — before characterizing state from a secondary proxy such as a `.txt` artifact, filesystem mtime, cached file, or one ingestion path.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Characterize pipeline health from a filesystem proxy | Query the canonical store first |
+| Generalize one ingestion path's failure to the whole pipeline | Check the final landing store across all relevant paths before alarming or reprocessing |
+
+A single path's failure does not prove the whole multi-path system is down.
+
 ## Degraded-Output Re-Verification Gate
 
 When tool output shows provider instability, buffering, truncation, duplicated chunks, `529`, timeout recovery, or `(no result)` while a permanent action is being considered, treat the current read as degraded. Do not characterize corruption, missing files, stale state, release failure, or data loss from that single degraded read.
@@ -164,6 +175,17 @@ When a user sends a new instruction while work is in progress, completion status
 3. If the new message adds a requirement, add it to the completion contract before closing.
 4. If no conflict exists, continue but explicitly preserve the new requirement in the next verification pass.
 
+### Interrupt ≠ Prior-Request Cancellation
+
+If the first message after an interrupt is ambiguous, do not assume the prior request was cancelled. The user may be continuing a multi-message request, correcting input, or starting a new request. Keep the prior non-destructive context alive and ask once only when the new message cannot be classified as a clear instruction.
+
+**Safety carve-out:** if the interrupted work is destructive or irreversible (`git reset --hard`, `git clean -fd`, broad `rm`, force push, tunnel/DNS/k8s/infra deletion, production state changes), halt first and require explicit re-authorization before resuming. Interrupts retain their emergency-stop value for risky work.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Treat an ambiguous interrupt as cancellation and switch to unrelated work | Preserve context and clarify intent once |
+| Continue destructive work after an ambiguous interrupt | Stop immediately; resume only after explicit re-authorization |
+
 ### Tool-Call Payload Completeness
 
 도구 호출의 required 파라미터는 invoke 전에 확인한다(완료 선언 후가 아니라 호출 시점의 전제조건). announce(prefix)만 출력하고 payload의 required 필드를 누락하는 패턴은 R008 "Required-Parameter Completeness Check"가 canonical owner다. Reference: #1487 / upstream #1324.
@@ -211,6 +233,30 @@ Related memory records:
 - `feedback_github_workflows_inventory.md` — original incident (v0.87.2~v0.88.0 session)
 - `feedback_subagent_pre_existing_claims.md` — subagent false-positive pattern
 -->
+
+## CI Publish-Step Error vs Published-Artifact Ground Truth
+
+A CI publish/deploy step that logs an error has not necessarily failed. The step may recover through a fallback or the error may be non-fatal. Before declaring a publish/release failed, re-running it, rolling it back, or changing release workflow logic, verify the published artifact directly.
+
+| Publish target | Ground-truth check |
+|----------------|--------------------|
+| npm | `npm view <pkg> version` equals expected |
+| GitHub Release | `gh release view <tag>` exists and is not draft |
+| Docker/registry image | image tag or manifest exists |
+| Run outcome | `gh run view <id> --json jobs` conclusions, not one step log line |
+
+## State-Change Claim → Live System Verification
+
+Before closing or marking-done a task that claims an infrastructure/resource state change, verify the actual live system state rather than only the command attempt.
+
+| Claimed state change | Live ground-truth check |
+|----------------------|-------------------------|
+| Service stopped | `launchctl list`, `systemctl status`, or equivalent shows inactive/absent |
+| k8s resource torn down | `kubectl get <resource>` returns NotFound |
+| Container removed | `docker ps -a` does not list it |
+| Process killed | `pgrep`/`ps` check returns empty |
+
+"Issued the teardown" is not evidence that the resource is down.
 
 ## Integration
 

--- a/.codex/rules/MUST-parallel-execution.md
+++ b/.codex/rules/MUST-parallel-execution.md
@@ -210,6 +210,19 @@ When announcing a parallel dispatch in prose text (not the Agent tool call itsel
 The list form mirrors the tool-call `[N]` prefix pattern and scales better to 3+ concurrent agents.
 -->
 
+<!--
+DETAIL: Parallel Feature Integration Gate
+
+## Parallel Feature Integration Gate
+
+When parallel feature agents edit interdependent code, isolated passes are not enough: run aggregate build plus runtime/smoke verification on the merged worktree before declaring done.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Accept each subagent's isolated pass as release-ready | Re-run aggregate verification on the merged worktree |
+| Skip runtime smoke because every file-domain lane passed | Smoke the integrated feature path or device/browser/app surface |
+-->
+
 ## Result Aggregation
 
 ```

--- a/.codex/rules/MUST-safety.md
+++ b/.codex/rules/MUST-safety.md
@@ -17,6 +17,23 @@
 - Do not rotate, delete, recreate, or replace credentials unless the user explicitly requested that exact credential action.
 - Before irreversible action on shared infrastructure or credentials, reconfirm the target, namespace/account/project, requested scope, rollback path, and user authorization.
 - Stop instead of chaining privileged actions when the next step would affect a different credential, tunnel, namespace, pod, cluster, account, or shared service than the user requested.
+- When a credential/token is needed, ask for the specific value or file before running blind discovery scans (`env | grep`, repo-wide token greps, credential-store dumps). If a classifier blocks a credential action once while a standing user-deny is active, switch to a user-runs command and do not retry by another mechanism.
+
+### Standing User-Deny + Classifier Block
+
+When the user has a standing "do not touch X" constraint and a safety classifier blocks an action on X once, immediately switch to a user-runs command/instruction path. Do not retry the blocked edit, scan, or credential action via another mechanism.
+
+### Infra-Diagnostic File Checks — Metadata, Not Contents
+
+When diagnosing infrastructure or health issues, file checks must stay metadata-only: `ls -la` for existence, size, permissions, and mtime. Do not `cat .env`, inspect credential JSON keys, or read secret contents into the transcript just to confirm configuration exists.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `cat .env` / inspect OAuth or credential keys during a health diagnosis | `ls -la .env` or request the exact value from the user if genuinely needed |
+
+### Infra/Resource Deletion Blast Radius
+
+Before deleting shared infrastructure resources (tunnels, DNS records, k8s resources, load balancers, security groups), enumerate every endpoint, route, selector, target, or rule served by that resource — not only the hostname or object the user named. Prefer reversible disable/detach/stop actions when they satisfy the task.
 
 ## Required Before Destructive Operations
 

--- a/.codex/rules/SHOULD-interaction.md
+++ b/.codex/rules/SHOULD-interaction.md
@@ -26,6 +26,9 @@
 | Clear | Execute immediately |
 | Ambiguous | `[Confirm] Understood "{request}" as {interpretation}. Proceed?` |
 | Risky | `[Warning] This action has {risk}. Continue? Yes: {action} / No: Cancel` |
+| Interrupt (ambiguous first message) | Do not assume the prior request is cancelled. The first message after an interrupt may be continuation, correction, or a new request. If the in-progress action is risky/destructive, apply the Risky row first and halt before clarification. |
+
+Request handling precedence: **Risky > Interrupt > Ambiguous > Clear**. Clear new instructions should still be executed directly; the interrupt row exists only for ambiguous first messages after an interruption.
 
 ## External Product UI Claims
 

--- a/.codex/rules/SHOULD-memory-integration.md
+++ b/.codex/rules/SHOULD-memory-integration.md
@@ -22,6 +22,20 @@ Agent frontmatter `memory: project|user|local` enables persistent memory:
 | `project` | `.codex/agent-memory/<name>/` | Yes |
 | `local` | `.codex/agent-memory-local/<name>/` | No |
 
+<!--
+DETAIL: Project memory root guard
+
+## Subagent `memory: project` Source-Tree Pollution Guard
+
+A subagent working from a subdirectory must not create nested `.codex/agent-memory/` or `.claude/agent-memory/` directories inside source packages.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Accept nested `src/**/.codex/agent-memory/` or `src/**/.claude/agent-memory/` created by a worker | Verify memory writes land at project-root `.codex/` (or template-root `.claude/` for compatibility) and remove nested memory directories before commit |
+
+Before committing subagent work, check for nested memory pollution with a targeted search such as `find . \\( -path '*/src/*/.codex/agent-memory' -o -path '*/src/*/.claude/agent-memory' \\) -print`.
+-->
+
 ## When to Use Searchable MCP Memory
 
 | Scenario | Native | AgentMemory-compatible / omx-memory |

--- a/.codex/rules/SHOULD-verification-ladder.md
+++ b/.codex/rules/SHOULD-verification-ladder.md
@@ -1,0 +1,124 @@
+# [SHOULD] Verification Ladder Rules
+
+> **Priority**: SHOULD | **ID**: R023
+> **Codex port**: `.codex/**` is the active rule/runtime surface; `templates/.claude/**` mirrors compatibility guidance.
+
+## Core Rule
+
+검증은 비용/속도 ladder로 구성한다: **결정론적 검사 → cheap LLM → expensive LLM → human**. 가장 저렴한 tier가 먼저 통과해야 다음 tier로 진행한다. 더 낮은 tier에서 잡을 수 있는 문제를 더 비싼 tier에 보내지 않는다.
+
+## Ladder Tiers
+
+| Tier | 도구 | 비용 | 속도 | 적용 시점 |
+|------|------|------|------|-----------|
+| **1: Deterministic** | hooks, linters, type-check, JSON schema | $0 | <1s | Pre-write, write-time |
+| **2: Cheap LLM** | haiku-based skills (`dev-review`, `action-validator`) | $ | <30s | Per-file review |
+| **3: Expensive LLM** | sonnet/opus skills (`deep-verify`, `adversarial-review`, `multi-model-verification`, `evaluator-optimizer`) | $$$ | 1-5분 | Pre-commit, PR review |
+| **4: Human** | maintainer review | time | hours-days | Final gate, contested decisions |
+
+## Shift-left 원칙
+
+결정론적 단계가 잡을 수 있는 문제는 LLM에 보내지 않는다. LLM 검증은 ambiguous/semantic 문제에 집중한다.
+
+- **좋은 예**: JSON schema 오류 → Tier 1 hook이 차단 → LLM에 미전달
+- **나쁜 예**: 탭/스페이스 혼용 오류 → sonnet으로 전달 → 불필요한 비용 발생
+
+R013 (SHOULD-ecomode)의 "저렴한 검증 우선" 원칙과 정합: ecomode는 출력 토큰을 절약하고, R023은 검증 비용을 절약한다.
+
+## 기존 자산 매핑
+
+| Tier | 자산 | 역할 |
+|------|------|------|
+| **Tier 1** | `.codex/hooks/ (and mirrored templates/.claude/hooks/)` (PreToolUse hooks) | 도구 호출 전 결정론적 차단 |
+| **Tier 1** | `mgr-sauron` (R017 구조 검증) | 에이전트/스킬/가이드 frontmatter 검증 |
+| **Tier 1** | pre-commit configs, linters | 코드 품질 정적 검사 |
+| **Tier 2** | `dev-review` | 파일 단위 haiku 코드 리뷰 |
+| **Tier 2** | `action-validator` | CI/CD 액션 구문 검증 |
+| **Tier 2** | `pre-generation-arch-check` | 생성 전 아키텍처 lite 점검 |
+| **Tier 3** | `deep-verify` | 다단계 품질 검증 (sonnet) |
+| **Tier 3** | `adversarial-review` | 공격자 시각 보안 리뷰 (opus) |
+| **Tier 3** | `multi-model-verification` | 복수 모델 교차 검증 |
+| **Tier 3** | `evaluator-optimizer` | 평가-개선 반복 루프 |
+| **Tier 3** | `worker-reviewer-pipeline` | 구현-리뷰 파이프라인 |
+| **Tier 4** | maintainer manual review | PR approval, final gate |
+
+## R021과의 관계
+
+R021 (MUST-enforcement-policy)과 R023은 **직교**한다. 두 규칙은 서로 다른 차원을 다룬다:
+
+| 규칙 | 질문 | 차원 |
+|------|------|------|
+| **R021** | "어떻게 강제할 것인가?" | Hard block / Soft block / Advisory |
+| **R023** | "어떤 비용으로 검증할 것인가?" | Deterministic / Cheap LLM / Expensive LLM |
+
+같은 도구가 두 규칙에 동시에 속할 수 있다:
+
+- `mgr-sauron`: R021 관점에서 Advisory (PostToolUse hook), R023 관점에서 Tier 1 (구조 검증)
+- `deep-verify`: R021 관점에서 Prompt-based (blocking 없음), R023 관점에서 Tier 3 (expensive LLM)
+- `.codex/hooks/ (and mirrored templates/.claude/hooks/)` stage-blocker: R021 관점에서 Hard Block, R023 관점에서 Tier 1
+
+R021은 위반 시 어떻게 멈출지를, R023은 어떤 순서로 검증할지를 정의한다.
+
+## Self-Check
+
+새 검증 도구 추가 시:
+
+- [ ] 어느 tier에 속하는지 명확한가?
+- [ ] 같은 tier 내 중복 도구는 없는가?
+- [ ] Tier 1에서 잡을 수 있는 문제를 다루는가? (상위 tier 대신 시프트 권고)
+- [ ] Ladder 순서를 문서화했는가? (어떤 검사를 먼저 실행하는지)
+
+## Safety-Signal Rule Authoring — Carve-Out Pre-Check (shift-left)
+
+> Origin: #1353 (인터럽트 룰 #1341의 후속 회고에서 발견된 R001 carve-out 누락) — 인터럽트 룰(R003/R020)을 작성할 때 R001 파괴적-작업 carve-out을 1차 작성에서 빠뜨렸고, Tier 3 적대적 검증이 release-blocking으로 포착해 보정했다. Tier 3가 잡았으나, 같은 결함을 Tier 1(작성 시점 결정론적 점검)로 시프트하면 비용이 낮다.
+
+런타임 안전-신호 동작을 정의하는 룰(인터럽트·취소·halt·중단·emergency-stop 등)을 추가/수정할 때, 작성 단계(Tier 1)에서 다음을 사전 점검한다 — Tier 3 적대적 검증에 의존하기 전에 (이 checklist 같은 메타-룰은 대상 아님):
+
+- [ ] 이 룰이 R001 파괴적·비가역 작업(`git reset --hard`, `clean -fd`, `rm`, 터널/DNS/k8s/인프라 삭제) 컨텍스트에서도 안전한가? (fail-closed carve-out 필요 여부)
+- [ ] "진행/계속(proceed)" 류 지시의 대상이 파괴적 작업의 계속으로 오독될 여지가 없는가?
+- [ ] 안전-신호의 fail-safe 의미(emergency-halt)를 약화시키지 않는가? (stop-first ask-after 우선)
+- [ ] 기존 안전 규칙(R001/R002)과의 우선순위가 명시되어 있는가?
+
+하나라도 불확실하면 **먼저 carve-out을 명시(Tier 1 우선 해결)**하고, 그래도 불확실하면 Tier 3 적대적 검증(`adversarial-review`, `multi-model-verification`)을 통과시킨 뒤 release한다 (ladder 순서 유지). 이는 R023 shift-left 원칙(저렴한 tier 우선)을 룰 작성 자체에 적용한 것이며, R016 룰 작성 워크플로우의 Tier-1 품질 게이트로 동작한다 (R016은 위반 후 룰 업데이트 소유, R023 carve-out은 안전-신호 룰 작성 시 사전 점검 — 직교). Closes #1353.
+
+## Integration
+
+| 규칙 | 상호작용 |
+|------|---------|
+| R009 (Parallel Execution) | Tier 1-2 검사는 독립 파일에 대해 병렬 실행 가능 |
+| R013 (Ecomode) | 컨텍스트 압박 시 Tier 3를 Tier 2로 다운그레이드 고려 |
+| R017 (Sync Verification) | Phase 1-3 검증 단계는 R023 Tier 1-3에 대응 |
+| R021 (Enforcement Policy) | 직교: R021은 blocking 방식, R023은 검증 비용 순서 |
+
+## Workflow Prompt & Verifier Ground-Truth
+
+> Origin: #1266 ③ (High) — a Workflow built the agent prompt as `await agent(prompt) + FACTS`, concatenating the guardrail fact-sheet onto the RETURN VALUE instead of the prompt. The writer never received the facts, hallucinated an in-cluster hostname (`secretary-mcp`), and the adversarial verifier couldn't catch it (the fact was in no source it had).
+
+### Prompt Completion Before Call
+
+Workflow/agent prompts MUST be fully assembled into the prompt string **before** the `agent()` / Agent tool call. Post-call concatenation onto the return value is a footgun — the agent never sees the appended content.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `const r = await agent(prompt) + FACTS` | `const r = await agent(prompt + FACTS)` — assemble first |
+
+### Workflow Script Sanity Check
+
+Before invoking a Workflow script, deterministically verify:
+
+| Check | Why |
+|-------|-----|
+| No unresolved placeholders (`{phase1_summary}`, `TODO`, `<...>`, `{{ }}`) remain in any agent prompt string | An unfilled placeholder reaches the agent verbatim → garbled task |
+| Template-literal / string concatenation produces the intended prompt (assemble-before-call, see above) | Post-call concatenation (`agent(prompt) + FACTS`) silently drops content |
+| Script parses — balanced braces/quotes, valid JS | A syntax error aborts the entire run after partial work |
+
+#### Common Violation (#1271)
+Session 106 follow-up to #1266 ③: a Workflow authoring error recurred — the guardrail fact-sheet was concatenated onto the agent's RETURN VALUE instead of the prompt string, and a placeholder/assembly slip went uncaught because no pre-run sanity check existed. This check is the deterministic Tier-1 guard that catches such slips before the expensive run.
+
+Origin: #1271 (Workflow authoring error recurrence, session 106).
+
+### Verifier Ground-Truth for Cross-Cutting Facts
+
+Cross-cutting facts not verifiable from the primary source (external URLs, in-cluster DNS/hostnames, infra topology) MUST be supplied to the verifier as explicit ground-truth. Otherwise an adversarial verifier cannot distinguish a hallucinated value from a correct one — a verification blind spot.
+
+Cross-reference: R009 (giant-prompt decomposition), `worker-reviewer-pipeline` skill.

--- a/.codex/rules/index.yaml
+++ b/.codex/rules/index.yaml
@@ -124,6 +124,14 @@ rules:
     priority: SHOULD
     scope: all
 
+  # Verification Ladder - SHOULD
+  - id: R023
+    name: verification-ladder
+    title: Verification Ladder Rules
+    path: ./SHOULD-verification-ladder.md
+    priority: SHOULD
+    scope: all
+
   # Agent Teams - MUST (Conditional)
   - id: R018
     name: agent-teams

--- a/.codex/skills/homework/SKILL.md
+++ b/.codex/skills/homework/SKILL.md
@@ -161,6 +161,17 @@ Invoke the `omcustomcodex:feedback` skill with the drafted issue content. The us
 
 If `--dry-run` is active, skip this phase and output the draft directly to the conversation instead.
 
+## Cross-Project Import Compatibility
+
+When `homework` is imported into another project, Phase 5 depends on `omcustomcodex:feedback` being available and model-invocable in that project.
+
+| Condition | Behavior |
+|-----------|----------|
+| `omcustomcodex:feedback` model-invocable | Use the normal Phase 4A preview + confirmation gate |
+| feedback skill missing or model invocation disabled | Fall back to manual submission: present the drafted findings to the user, write the dry-run artifact when possible, and ask the user to file/run the feedback workflow themselves |
+
+Do not silently drop a retrospective because the imported feedback skill cannot be invoked.
+
 ### Phase 6: Output Summary
 
 ```

--- a/.codex/skills/pipeline/workflows/auto-dev.yaml
+++ b/.codex/skills/pipeline/workflows/auto-dev.yaml
@@ -239,6 +239,10 @@ steps:
          - If current FAIL count <= baseline: continue with advisory log "X failures (baseline {n}, delta {d})".
       5. Build verification (if package has build script)
 
+      Documentation/template validation:
+      - For local or CI docs validation, run `bun run .github/scripts/validate-docs.ts --programmatic-only` (or the repo's equivalent validate-docs command with `--programmatic-only`) before assuming a validation failure is an authentication failure.
+      - Treat interactive/auth-dependent validate-docs output as inconclusive until the programmatic-only path has been tried.
+
       For Python/Go/Docker/static-site projects: auto-detect and run equivalent checks.
 
       Halt conditions:
@@ -262,8 +266,13 @@ steps:
       Create a GitHub Release.
 
       1. Version:
-         - No existing tags → v0.1.0
-         - Otherwise: semver bump (patch for bugfix, minor for features)
+         - Version decision (semver) — PATCH-PREFERRED policy from v1.0.0 onward:
+           * No existing tags → v0.1.0.
+           * Previous tag exists → default to patch. When in doubt, patch; do not reflexively bump minor for rule/doc/skill/config/wiki/workflow edits.
+           * patch (DEFAULT): bugfixes, hardening, rule/doc/skill/config/wiki/workflow changes, compatibility notes, and release-process guardrails.
+           * minor: only a genuinely new user-facing capability, such as a new skill/agent/command adding visible surface, not a refinement of an existing one.
+           * major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API) or a deliberate milestone declaration such as v1.0.0.
+           * If a previous tag is ahead of the source version, use the next available skip-version.
          - For npm projects: update `package.json` and `templates/manifest.json`
            to the chosen version in the same commit before tag creation.
          - Promote `CHANGELOG.md` before tag creation: move non-empty

--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,12 +1,12 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.20",
-  "generatedAt": "2026-06-09T11:06:57.984Z",
-  "templateVersion": "0.5.20",
+  "generatorVersion": "0.5.21",
+  "generatedAt": "2026-06-11T05:30:51.850Z",
+  "templateVersion": "0.5.21",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
-      "templateHash": "e6118ddadc11e28e10de7321eea1551a9df51355bac4b7fafa63f02e0118a68b",
-      "size": 3466,
+      "templateHash": "e2690ef49068c522f452b7bc26089687adf98b1039841704dfcac64a6fa8a65b",
+      "size": 3960,
       "component": "rules"
     },
     ".codex/rules/SHOULD-hud-statusline.md": {
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-parallel-execution.md": {
-      "templateHash": "bb4f0b1c6918aa86d1799eaf433b04fb4e576a44f32dd8afdd1b4e2b3c1c7de2",
-      "size": 9616,
+      "templateHash": "1d66343ab484c64cff657ad77e2daf10d88428e5bc86bbdb2b54112f1591bb30",
+      "size": 10189,
       "component": "rules"
     },
     ".codex/rules/SHOULD-ecomode.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-design.md": {
-      "templateHash": "3cbc62c887ae37d931d40e0528aebcdf083fb1c9297de2f5ce5d32614f63e77e",
-      "size": 27111,
+      "templateHash": "80a587b27deea5490069b5e5ccf59f0a298d8e65389ebeab4c755927bf9e56ff",
+      "size": 27425,
       "component": "rules"
     },
     ".codex/rules/MUST-agent-identification.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-agent-teams.md": {
-      "templateHash": "ac62a7d5ba9030991f6b8ad10d3fb6de2344f5cc23067dd3a1d0305c9758411a",
-      "size": 9503,
+      "templateHash": "c4989cdea7a4ec56f4cca436fbce3e67c461154527f610735e288069e30404c3",
+      "size": 10006,
       "component": "rules"
     },
     ".codex/rules/MAY-optimization.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".codex/rules/MUST-safety.md": {
-      "templateHash": "b9533519320a31636dd6e1b4cbe8aa55c4f897ddb8271a2ec8f5e869e02ea0e0",
-      "size": 3594,
+      "templateHash": "58cb7eb515656720ea574a1f253258e1ab3a9324056c989b5eb9db6e192d0ebf",
+      "size": 5130,
       "component": "rules"
     },
     ".codex/rules/MUST-tool-identification.md": {
@@ -99,9 +99,14 @@
       "size": 5883,
       "component": "rules"
     },
+    ".codex/rules/SHOULD-verification-ladder.md": {
+      "templateHash": "0dc2e2a883fac0c4b2af75452060022f10a01f8682a7ed8b3f966971ce15bfd7",
+      "size": 8397,
+      "component": "rules"
+    },
     ".codex/rules/SHOULD-memory-integration.md": {
-      "templateHash": "14711da464d564bd051162b6103a9708e285919484187e0ab8880167dec05350",
-      "size": 19198,
+      "templateHash": "4c36732d85e36e42191d7a780772e3194e3ba6d55a6e9ff68cbec4681233de02",
+      "size": 19962,
       "component": "rules"
     },
     ".codex/rules/MUST-enforcement-policy.md": {
@@ -110,13 +115,13 @@
       "component": "rules"
     },
     ".codex/rules/index.yaml": {
-      "templateHash": "c6eb30e3c9039c35b6af4e2bd4c8ba3a3869f434735ae4869cb875cda68f5c43",
-      "size": 3050,
+      "templateHash": "5bc0f6bedd07d971bc5db4ffce28cca54afbe6c38249d1b975b8f1afea2c263b",
+      "size": 3242,
       "component": "rules"
     },
     ".codex/rules/MUST-completion-verification.md": {
-      "templateHash": "d12ba40d4a71a00cdba0f730732508fe826d6d615bfa6e944f8745841dbb021c",
-      "size": 13869,
+      "templateHash": "30a7e92b5a4aed5bbdc5609c4c877af314a7d3027fa4428da004ca2f6e4be104",
+      "size": 16921,
       "component": "rules"
     },
     ".codex/agents/be-springboot-expert.md": {
@@ -685,8 +690,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "88a59a08610da9132e640e3c5ff9e356c3ec79daa864e31bb5cc583500a20eea",
-      "size": 29166,
+      "templateHash": "f4cc66ed04e933e7c3dd5589d7f1ec524fc4757603ae66fc4baa0c894aea05e6",
+      "size": 30051,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.21] - 2026-06-11
+
+### Added
+- Add R023 verification-ladder guidance and wiki coverage for #1502, including deterministic-first safety-signal rule authoring checks.
+
+### Changed
+- Port the current upstream rule, skill, workflow, and Claude compatibility guardrails for #1501-#1506, including metadata-only infra diagnostics, interrupt/cancellation precedence, Agent Teams transparency scope, memory pollution checks, PATCH-preferred auto-dev release policy, and Claude v2.1.170 Fable/transcript notes.
+- Harden update-command tests so full-suite self-update re-exec mocks cannot pollute non-reexec exit-code assertions.
+
+### Fixed
+- Allow explicit CLI self-update checks to accept live cross-major npm versions for #1507 while continuing to reject implausible fresh cached versions.
+
 ## [0.5.20] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-50 agents. 121 skills. 22 rules. One command.
+50 agents. 121 skills. 23 rules. One command.
 
 ```bash
 npm install -g oh-my-customcodex && cd your-project && omcustomcodex init
@@ -217,15 +217,15 @@ All commands are invoked inside the oh-my-customcodex GPT Codex + OMX session.
 
 ---
 
-### Rules (22)
+### Rules (23)
 
 | Priority | Count | Purpose |
 |----------|-------|---------|
 | **MUST** | 14 | Safety, permissions, agent design, identification, orchestration, verification, completion, enforcement |
-| **SHOULD** | 6 | Interaction, error handling, memory, HUD, ecomode, ontology routing |
+| **SHOULD** | 7 | Interaction, error handling, memory, HUD, ecomode, ontology routing, verification ladder |
 | **MAY** | 1 | Optimization |
 
-Key rules: R010 (orchestrator never writes files), R009 (parallel execution mandatory), R017 (sauron verification before push), R020 (completion verification before declaring done), R021 (advisory-first enforcement model).
+Key rules: R010 (orchestrator never writes files), R009 (parallel execution mandatory), R017 (sauron verification before push), R020 (completion verification before declaring done), R021 (advisory-first enforcement model), R023 (verification ladder).
 
 ---
 
@@ -281,7 +281,7 @@ your-project/
 ├── AGENTS.md                   # Entry point
 ├── .codex/
 │   ├── agents/                 # 50 agent definitions
-│   ├── rules/                  # 22 governance rules (R000-R021)
+│   ├── rules/                  # 23 governance rules (R000-R023)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas
 │   ├── specs/                  # Extracted canonical specs

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -133,7 +133,7 @@ Synchronization verification:
 
 **ID**: R018
 
-Agent Teams integration (conditional - when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`):
+Agent Teams integration (conditional - when Codex/OMX Agent Teams are enabled, for example `OMCODEX_AGENT_TEAMS=1`):
 
 - Mandatory use of Agent Teams for qualifying coordinated tasks
 - Decision matrix for Task tool vs Agent Teams
@@ -198,6 +198,17 @@ Ecomode for efficiency:
 - Aggregation patterns
 - Result compression
 - Activation conditions
+
+### SHOULD-verification-ladder
+
+**ID**: R023
+
+Verification ladder guidance:
+
+- Prefer deterministic checks before LLM review
+- Run safety-signal rule carve-out pre-checks while authoring rules
+- Supply verifier lanes with canonical ground truth for cross-cutting facts
+- Escalate to expensive/human review only after cheaper tiers are exhausted
 
 ## MAY Rules
 
@@ -266,6 +277,7 @@ Rules are stored in `.codex/rules/`:
 ├── SHOULD-memory-integration.md
 ├── SHOULD-hud-statusline.md
 ├── SHOULD-ecomode.md
+├── SHOULD-verification-ladder.md
 └── MAY-optimization.md
 ```
 

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,17 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.170
+
+Published: 2026-06-10.
+
+Source: upstream oh-my-customcode #1352/#1354, Codex port #1504.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Claude Fable 5 is available through the `fable` alias (`claude-fable-5`) | Useful only for packaged Claude compatibility sessions needing mythos-class reasoning; Codex-native subagents continue to use the OMX model contract and `reasoning_effort`. | Document in R006 as Claude-compatibility metadata. Do not change Codex routing defaults. |
+| VS Code integrated-terminal sessions save transcripts correctly and show them in `--resume` | Improves Claude-template workflows that depend on transcript replay, including imported `homework`/retrospective flows. | Prefer Claude Code v2.1.170+ when testing Claude compatibility transcript-dependent skills. No Codex runtime change. |
+
 ## v2.1.168
 
 Published: 2026-06-07.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.20",
+  "version": "0.5.21",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/src/core/self-update.ts
+++ b/src/core/self-update.ts
@@ -165,6 +165,25 @@ function isCacheFresh(cache: SelfUpdateCache, now: number, cacheTtlMs: number): 
   return now - checkedAt < cacheTtlMs;
 }
 
+function readFreshPlausibleCachedVersion(
+  cachePath: string,
+  currentVersion: string,
+  now: number,
+  cacheTtlMs: number
+): string | null {
+  const cache = readCache(cachePath);
+  if (!cache || !isCacheFresh(cache, now, cacheTtlMs)) {
+    return null;
+  }
+
+  const cachedVersion = normalizeVersion(cache.latestVersion);
+  if (!cachedVersion || !isVersionPlausible(currentVersion, cachedVersion)) {
+    return null;
+  }
+
+  return cachedVersion;
+}
+
 /**
  * Fetch latest package version from npm registry via npm CLI.
  */
@@ -261,6 +280,7 @@ export interface ExecuteSelfUpdateOptions {
   /** Bypass self-update-cache.json TTL and always query npm view fresh. */
   forceRefresh?: boolean;
   fetchLatestVersion?: (packageName: string) => string | null;
+  installPackage?: (packageName: string, version: string, silent: boolean) => boolean;
   now?: number;
   argv?: string[];
   env?: NodeJS.ProcessEnv;
@@ -348,7 +368,8 @@ export function executeSelfUpdate(options: ExecuteSelfUpdateOptions = {}): Execu
     console.log(i18n.t('cli.selfUpdate.updatingGlobal', { version: latestVersion }));
   }
 
-  const installed = installGlobalPackage(packageName, latestVersion, options.silent ?? false);
+  const installPackage = options.installPackage || installGlobalPackage;
+  const installed = installPackage(packageName, latestVersion, options.silent ?? false);
 
   if (installed) {
     if (!options.silent) {
@@ -385,23 +406,14 @@ export function checkSelfUpdate(options: SelfUpdateOptions): SelfUpdateCheckResu
     };
   }
 
-  let latestVersion: string | null = null;
-  let usedCache = false;
-  const cache = readCache(cachePath);
-
-  if (cache && isCacheFresh(cache, now, cacheTtlMs)) {
-    const cachedVersion = normalizeVersion(cache.latestVersion);
-    if (isVersionPlausible(currentVersion, cachedVersion)) {
-      latestVersion = cachedVersion;
-      usedCache = true;
-    }
-    // Implausible cached version silently ignored — will re-fetch below
-  }
+  let latestVersion = readFreshPlausibleCachedVersion(cachePath, currentVersion, now, cacheTtlMs);
+  const usedCache = Boolean(latestVersion);
 
   if (!latestVersion) {
     const fetched = fetchLatestVersion(packageName);
-    if (fetched && isVersionPlausible(currentVersion, fetched)) {
-      latestVersion = fetched;
+    const fetchedVersion = fetched ? normalizeVersion(fetched) : '';
+    if (fetchedVersion) {
+      latestVersion = fetchedVersion;
       writeCache(cachePath, latestVersion, now);
     }
   }

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -24,7 +24,6 @@ tools: [Read, Write, ...]  # Allowed tools
 | `opus` | claude-opus-4-6 | Complex reasoning, architecture |
 | `opusplan` | claude-opus-4-6 + plan mode | Architecture planning with approval gates |
 | `opus47` | claude-opus-4-7 | Latest Opus model, supports xhigh effort |
-
 Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
 <!-- DETAIL: Fallback Models and Thinking Toggle (Claude Code v2.1.166+)
@@ -88,6 +87,7 @@ This Codex port ships `.claude` compatibility templates. When updating those tem
 - v2.1.162: `claude agents --json` includes waiting/blocker metadata and explicit `--tools Grep/Glob` behavior is fixed; compatibility prompts may use those fields when diagnosing stuck Claude sessions.
 - v2.1.163: managed `requiredMinimumVersion`/`requiredMaximumVersion`, `/plugin list`, Stop/SubagentStop `hookSpecificOutput.additionalContext`, and skill command literal `\$` escaping are available. Hook/skill template changes should preserve these affordances.
 - v2.1.165: bug-fix/reliability release; no local template change required beyond compatibility confirmation. v2.1.166: fallbackModel availability failover and thinking-disable controls are Claude compatibility settings, not Codex/OMX routing. v2.1.167/v2.1.168: bug-fix-only compatibility confirmation.
+- v2.1.170: Claude compatibility sessions gain access to the `fable` alias (`claude-fable-5`) and fix a VS Code integrated-terminal transcript persistence bug. Skills that rely on transcript replay (for example `homework`) should prefer v2.1.170+ in Claude-template sessions. No Codex runtime model-routing change.
 -->
 
 ## Hook Event Types

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -8,6 +8,18 @@
 
 Available when `OMCODEX_AGENT_TEAMS=1` or `TeamCreate` / `SendMessage` exists.
 
+## Gate Transparency Scope
+
+R018 gate-transparency announcements apply only when Agent Teams are enabled or callable; otherwise R009 parallel-execution announcements are sufficient.
+
+<!--
+DETAIL: Gate Transparency Scope
+| Runtime state | Required |
+|---------------|----------|
+| Agent Teams enabled/callable | Announce the R018 gate result for qualifying 3+ agent dispatches |
+| Agent Teams disabled/unavailable | Use R009 `[N]` dispatch format and state the fallback only if useful for clarity |
+-->
+
 ## Decision Matrix
 
 | Scenario | Preferred | Reason |

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -67,6 +67,17 @@ Parallel batches return results together, so a same-batch permanent dispatch pro
 
 Example: do not diagnose `triage-dispatch.yml` from memory, create an issue, and delegate a fix in the same parallel call before reading the workflow. If the read later shows a different root cause, the issue, PR, and commit trail become correction debt even when the eventual code direction is acceptable.
 
+### Proxy Signal vs Canonical Ground-Truth
+
+When diagnosing pipeline or data state, verify the canonical store — the authoritative DB, registry, API, or system-of-record — before characterizing state from a secondary proxy such as a `.txt` artifact, filesystem mtime, cached file, or one ingestion path.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Characterize pipeline health from a filesystem proxy | Query the canonical store first |
+| Generalize one ingestion path's failure to the whole pipeline | Check the final landing store across all relevant paths before alarming or reprocessing |
+
+A single path's failure does not prove the whole multi-path system is down.
+
 ## Degraded-Output Re-Verification Gate
 
 When tool output shows provider instability, buffering, truncation, duplicated chunks, `529`, timeout recovery, or `(no result)` while a permanent action is being considered, treat the current read as degraded. Do not characterize corruption, missing files, stale state, release failure, or data loss from that single degraded read.
@@ -164,6 +175,17 @@ When a user sends a new instruction while work is in progress, completion status
 3. If the new message adds a requirement, add it to the completion contract before closing.
 4. If no conflict exists, continue but explicitly preserve the new requirement in the next verification pass.
 
+### Interrupt ≠ Prior-Request Cancellation
+
+If the first message after an interrupt is ambiguous, do not assume the prior request was cancelled. The user may be continuing a multi-message request, correcting input, or starting a new request. Keep the prior non-destructive context alive and ask once only when the new message cannot be classified as a clear instruction.
+
+**Safety carve-out:** if the interrupted work is destructive or irreversible (`git reset --hard`, `git clean -fd`, broad `rm`, force push, tunnel/DNS/k8s/infra deletion, production state changes), halt first and require explicit re-authorization before resuming. Interrupts retain their emergency-stop value for risky work.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Treat an ambiguous interrupt as cancellation and switch to unrelated work | Preserve context and clarify intent once |
+| Continue destructive work after an ambiguous interrupt | Stop immediately; resume only after explicit re-authorization |
+
 ### Tool-Call Payload Completeness
 
 도구 호출의 required 파라미터는 invoke 전에 확인한다(완료 선언 후가 아니라 호출 시점의 전제조건). announce(prefix)만 출력하고 payload의 required 필드를 누락하는 패턴은 R008 "Required-Parameter Completeness Check"가 canonical owner다. Reference: #1487 / upstream #1324.
@@ -211,6 +233,30 @@ Related memory records:
 - `feedback_github_workflows_inventory.md` — original incident (v0.87.2~v0.88.0 session)
 - `feedback_subagent_pre_existing_claims.md` — subagent false-positive pattern
 -->
+
+## CI Publish-Step Error vs Published-Artifact Ground Truth
+
+A CI publish/deploy step that logs an error has not necessarily failed. The step may recover through a fallback or the error may be non-fatal. Before declaring a publish/release failed, re-running it, rolling it back, or changing release workflow logic, verify the published artifact directly.
+
+| Publish target | Ground-truth check |
+|----------------|--------------------|
+| npm | `npm view <pkg> version` equals expected |
+| GitHub Release | `gh release view <tag>` exists and is not draft |
+| Docker/registry image | image tag or manifest exists |
+| Run outcome | `gh run view <id> --json jobs` conclusions, not one step log line |
+
+## State-Change Claim → Live System Verification
+
+Before closing or marking-done a task that claims an infrastructure/resource state change, verify the actual live system state rather than only the command attempt.
+
+| Claimed state change | Live ground-truth check |
+|----------------------|-------------------------|
+| Service stopped | `launchctl list`, `systemctl status`, or equivalent shows inactive/absent |
+| k8s resource torn down | `kubectl get <resource>` returns NotFound |
+| Container removed | `docker ps -a` does not list it |
+| Process killed | `pgrep`/`ps` check returns empty |
+
+"Issued the teardown" is not evidence that the resource is down.
 
 ## Integration
 

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -210,6 +210,19 @@ When announcing a parallel dispatch in prose text (not the Agent tool call itsel
 The list form mirrors the tool-call `[N]` prefix pattern and scales better to 3+ concurrent agents.
 -->
 
+<!--
+DETAIL: Parallel Feature Integration Gate
+
+## Parallel Feature Integration Gate
+
+When parallel feature agents edit interdependent code, isolated passes are not enough: run aggregate build plus runtime/smoke verification on the merged worktree before declaring done.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Accept each subagent's isolated pass as release-ready | Re-run aggregate verification on the merged worktree |
+| Skip runtime smoke because every file-domain lane passed | Smoke the integrated feature path or device/browser/app surface |
+-->
+
 ## Result Aggregation
 
 ```

--- a/templates/.claude/rules/MUST-safety.md
+++ b/templates/.claude/rules/MUST-safety.md
@@ -17,6 +17,23 @@
 - Do not rotate, delete, recreate, or replace credentials unless the user explicitly requested that exact credential action.
 - Before irreversible action on shared infrastructure or credentials, reconfirm the target, namespace/account/project, requested scope, rollback path, and user authorization.
 - Stop instead of chaining privileged actions when the next step would affect a different credential, tunnel, namespace, pod, cluster, account, or shared service than the user requested.
+- When a credential/token is needed, ask for the specific value or file before running blind discovery scans (`env | grep`, repo-wide token greps, credential-store dumps). If a classifier blocks a credential action once while a standing user-deny is active, switch to a user-runs command and do not retry by another mechanism.
+
+### Standing User-Deny + Classifier Block
+
+When the user has a standing "do not touch X" constraint and a safety classifier blocks an action on X once, immediately switch to a user-runs command/instruction path. Do not retry the blocked edit, scan, or credential action via another mechanism.
+
+### Infra-Diagnostic File Checks — Metadata, Not Contents
+
+When diagnosing infrastructure or health issues, file checks must stay metadata-only: `ls -la` for existence, size, permissions, and mtime. Do not `cat .env`, inspect credential JSON keys, or read secret contents into the transcript just to confirm configuration exists.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `cat .env` / inspect OAuth or credential keys during a health diagnosis | `ls -la .env` or request the exact value from the user if genuinely needed |
+
+### Infra/Resource Deletion Blast Radius
+
+Before deleting shared infrastructure resources (tunnels, DNS records, k8s resources, load balancers, security groups), enumerate every endpoint, route, selector, target, or rule served by that resource — not only the hostname or object the user named. Prefer reversible disable/detach/stop actions when they satisfy the task.
 
 ## Required Before Destructive Operations
 

--- a/templates/.claude/rules/SHOULD-interaction.md
+++ b/templates/.claude/rules/SHOULD-interaction.md
@@ -26,6 +26,9 @@
 | Clear | Execute immediately |
 | Ambiguous | `[Confirm] Understood "{request}" as {interpretation}. Proceed?` |
 | Risky | `[Warning] This action has {risk}. Continue? Yes: {action} / No: Cancel` |
+| Interrupt (ambiguous first message) | Do not assume the prior request is cancelled. The first message after an interrupt may be continuation, correction, or a new request. If the in-progress action is risky/destructive, apply the Risky row first and halt before clarification. |
+
+Request handling precedence: **Risky > Interrupt > Ambiguous > Clear**. Clear new instructions should still be executed directly; the interrupt row exists only for ambiguous first messages after an interruption.
 
 ## External Product UI Claims
 

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -22,6 +22,20 @@ Agent frontmatter `memory: project|user|local` enables persistent memory:
 | `project` | `.codex/agent-memory/<name>/` | Yes |
 | `local` | `.codex/agent-memory-local/<name>/` | No |
 
+<!--
+DETAIL: Project memory root guard
+
+## Subagent `memory: project` Source-Tree Pollution Guard
+
+A subagent working from a subdirectory must not create nested `.codex/agent-memory/` or `.claude/agent-memory/` directories inside source packages.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Accept nested `src/**/.codex/agent-memory/` or `src/**/.claude/agent-memory/` created by a worker | Verify memory writes land at project-root `.codex/` (or template-root `.claude/` for compatibility) and remove nested memory directories before commit |
+
+Before committing subagent work, check for nested memory pollution with a targeted search such as `find . \\( -path '*/src/*/.codex/agent-memory' -o -path '*/src/*/.claude/agent-memory' \\) -print`.
+-->
+
 ## When to Use Searchable MCP Memory
 
 | Scenario | Native | AgentMemory-compatible / omx-memory |

--- a/templates/.claude/rules/SHOULD-verification-ladder.md
+++ b/templates/.claude/rules/SHOULD-verification-ladder.md
@@ -1,0 +1,124 @@
+# [SHOULD] Verification Ladder Rules
+
+> **Priority**: SHOULD | **ID**: R023
+> **Codex port**: `.codex/**` is the active rule/runtime surface; `templates/.claude/**` mirrors compatibility guidance.
+
+## Core Rule
+
+검증은 비용/속도 ladder로 구성한다: **결정론적 검사 → cheap LLM → expensive LLM → human**. 가장 저렴한 tier가 먼저 통과해야 다음 tier로 진행한다. 더 낮은 tier에서 잡을 수 있는 문제를 더 비싼 tier에 보내지 않는다.
+
+## Ladder Tiers
+
+| Tier | 도구 | 비용 | 속도 | 적용 시점 |
+|------|------|------|------|-----------|
+| **1: Deterministic** | hooks, linters, type-check, JSON schema | $0 | <1s | Pre-write, write-time |
+| **2: Cheap LLM** | haiku-based skills (`dev-review`, `action-validator`) | $ | <30s | Per-file review |
+| **3: Expensive LLM** | sonnet/opus skills (`deep-verify`, `adversarial-review`, `multi-model-verification`, `evaluator-optimizer`) | $$$ | 1-5분 | Pre-commit, PR review |
+| **4: Human** | maintainer review | time | hours-days | Final gate, contested decisions |
+
+## Shift-left 원칙
+
+결정론적 단계가 잡을 수 있는 문제는 LLM에 보내지 않는다. LLM 검증은 ambiguous/semantic 문제에 집중한다.
+
+- **좋은 예**: JSON schema 오류 → Tier 1 hook이 차단 → LLM에 미전달
+- **나쁜 예**: 탭/스페이스 혼용 오류 → sonnet으로 전달 → 불필요한 비용 발생
+
+R013 (SHOULD-ecomode)의 "저렴한 검증 우선" 원칙과 정합: ecomode는 출력 토큰을 절약하고, R023은 검증 비용을 절약한다.
+
+## 기존 자산 매핑
+
+| Tier | 자산 | 역할 |
+|------|------|------|
+| **Tier 1** | `.codex/hooks/ (and mirrored templates/.claude/hooks/)` (PreToolUse hooks) | 도구 호출 전 결정론적 차단 |
+| **Tier 1** | `mgr-sauron` (R017 구조 검증) | 에이전트/스킬/가이드 frontmatter 검증 |
+| **Tier 1** | pre-commit configs, linters | 코드 품질 정적 검사 |
+| **Tier 2** | `dev-review` | 파일 단위 haiku 코드 리뷰 |
+| **Tier 2** | `action-validator` | CI/CD 액션 구문 검증 |
+| **Tier 2** | `pre-generation-arch-check` | 생성 전 아키텍처 lite 점검 |
+| **Tier 3** | `deep-verify` | 다단계 품질 검증 (sonnet) |
+| **Tier 3** | `adversarial-review` | 공격자 시각 보안 리뷰 (opus) |
+| **Tier 3** | `multi-model-verification` | 복수 모델 교차 검증 |
+| **Tier 3** | `evaluator-optimizer` | 평가-개선 반복 루프 |
+| **Tier 3** | `worker-reviewer-pipeline` | 구현-리뷰 파이프라인 |
+| **Tier 4** | maintainer manual review | PR approval, final gate |
+
+## R021과의 관계
+
+R021 (MUST-enforcement-policy)과 R023은 **직교**한다. 두 규칙은 서로 다른 차원을 다룬다:
+
+| 규칙 | 질문 | 차원 |
+|------|------|------|
+| **R021** | "어떻게 강제할 것인가?" | Hard block / Soft block / Advisory |
+| **R023** | "어떤 비용으로 검증할 것인가?" | Deterministic / Cheap LLM / Expensive LLM |
+
+같은 도구가 두 규칙에 동시에 속할 수 있다:
+
+- `mgr-sauron`: R021 관점에서 Advisory (PostToolUse hook), R023 관점에서 Tier 1 (구조 검증)
+- `deep-verify`: R021 관점에서 Prompt-based (blocking 없음), R023 관점에서 Tier 3 (expensive LLM)
+- `.codex/hooks/ (and mirrored templates/.claude/hooks/)` stage-blocker: R021 관점에서 Hard Block, R023 관점에서 Tier 1
+
+R021은 위반 시 어떻게 멈출지를, R023은 어떤 순서로 검증할지를 정의한다.
+
+## Self-Check
+
+새 검증 도구 추가 시:
+
+- [ ] 어느 tier에 속하는지 명확한가?
+- [ ] 같은 tier 내 중복 도구는 없는가?
+- [ ] Tier 1에서 잡을 수 있는 문제를 다루는가? (상위 tier 대신 시프트 권고)
+- [ ] Ladder 순서를 문서화했는가? (어떤 검사를 먼저 실행하는지)
+
+## Safety-Signal Rule Authoring — Carve-Out Pre-Check (shift-left)
+
+> Origin: #1353 (인터럽트 룰 #1341의 후속 회고에서 발견된 R001 carve-out 누락) — 인터럽트 룰(R003/R020)을 작성할 때 R001 파괴적-작업 carve-out을 1차 작성에서 빠뜨렸고, Tier 3 적대적 검증이 release-blocking으로 포착해 보정했다. Tier 3가 잡았으나, 같은 결함을 Tier 1(작성 시점 결정론적 점검)로 시프트하면 비용이 낮다.
+
+런타임 안전-신호 동작을 정의하는 룰(인터럽트·취소·halt·중단·emergency-stop 등)을 추가/수정할 때, 작성 단계(Tier 1)에서 다음을 사전 점검한다 — Tier 3 적대적 검증에 의존하기 전에 (이 checklist 같은 메타-룰은 대상 아님):
+
+- [ ] 이 룰이 R001 파괴적·비가역 작업(`git reset --hard`, `clean -fd`, `rm`, 터널/DNS/k8s/인프라 삭제) 컨텍스트에서도 안전한가? (fail-closed carve-out 필요 여부)
+- [ ] "진행/계속(proceed)" 류 지시의 대상이 파괴적 작업의 계속으로 오독될 여지가 없는가?
+- [ ] 안전-신호의 fail-safe 의미(emergency-halt)를 약화시키지 않는가? (stop-first ask-after 우선)
+- [ ] 기존 안전 규칙(R001/R002)과의 우선순위가 명시되어 있는가?
+
+하나라도 불확실하면 **먼저 carve-out을 명시(Tier 1 우선 해결)**하고, 그래도 불확실하면 Tier 3 적대적 검증(`adversarial-review`, `multi-model-verification`)을 통과시킨 뒤 release한다 (ladder 순서 유지). 이는 R023 shift-left 원칙(저렴한 tier 우선)을 룰 작성 자체에 적용한 것이며, R016 룰 작성 워크플로우의 Tier-1 품질 게이트로 동작한다 (R016은 위반 후 룰 업데이트 소유, R023 carve-out은 안전-신호 룰 작성 시 사전 점검 — 직교). Closes #1353.
+
+## Integration
+
+| 규칙 | 상호작용 |
+|------|---------|
+| R009 (Parallel Execution) | Tier 1-2 검사는 독립 파일에 대해 병렬 실행 가능 |
+| R013 (Ecomode) | 컨텍스트 압박 시 Tier 3를 Tier 2로 다운그레이드 고려 |
+| R017 (Sync Verification) | Phase 1-3 검증 단계는 R023 Tier 1-3에 대응 |
+| R021 (Enforcement Policy) | 직교: R021은 blocking 방식, R023은 검증 비용 순서 |
+
+## Workflow Prompt & Verifier Ground-Truth
+
+> Origin: #1266 ③ (High) — a Workflow built the agent prompt as `await agent(prompt) + FACTS`, concatenating the guardrail fact-sheet onto the RETURN VALUE instead of the prompt. The writer never received the facts, hallucinated an in-cluster hostname (`secretary-mcp`), and the adversarial verifier couldn't catch it (the fact was in no source it had).
+
+### Prompt Completion Before Call
+
+Workflow/agent prompts MUST be fully assembled into the prompt string **before** the `agent()` / Agent tool call. Post-call concatenation onto the return value is a footgun — the agent never sees the appended content.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `const r = await agent(prompt) + FACTS` | `const r = await agent(prompt + FACTS)` — assemble first |
+
+### Workflow Script Sanity Check
+
+Before invoking a Workflow script, deterministically verify:
+
+| Check | Why |
+|-------|-----|
+| No unresolved placeholders (`{phase1_summary}`, `TODO`, `<...>`, `{{ }}`) remain in any agent prompt string | An unfilled placeholder reaches the agent verbatim → garbled task |
+| Template-literal / string concatenation produces the intended prompt (assemble-before-call, see above) | Post-call concatenation (`agent(prompt) + FACTS`) silently drops content |
+| Script parses — balanced braces/quotes, valid JS | A syntax error aborts the entire run after partial work |
+
+#### Common Violation (#1271)
+Session 106 follow-up to #1266 ③: a Workflow authoring error recurred — the guardrail fact-sheet was concatenated onto the agent's RETURN VALUE instead of the prompt string, and a placeholder/assembly slip went uncaught because no pre-run sanity check existed. This check is the deterministic Tier-1 guard that catches such slips before the expensive run.
+
+Origin: #1271 (Workflow authoring error recurrence, session 106).
+
+### Verifier Ground-Truth for Cross-Cutting Facts
+
+Cross-cutting facts not verifiable from the primary source (external URLs, in-cluster DNS/hostnames, infra topology) MUST be supplied to the verifier as explicit ground-truth. Otherwise an adversarial verifier cannot distinguish a hallucinated value from a correct one — a verification blind spot.
+
+Cross-reference: R009 (giant-prompt decomposition), `worker-reviewer-pipeline` skill.

--- a/templates/.claude/rules/index.yaml
+++ b/templates/.claude/rules/index.yaml
@@ -124,6 +124,14 @@ rules:
     priority: SHOULD
     scope: all
 
+  # Verification Ladder - SHOULD
+  - id: R023
+    name: verification-ladder
+    title: Verification Ladder Rules
+    path: ./SHOULD-verification-ladder.md
+    priority: SHOULD
+    scope: all
+
   # Agent Teams - MUST (Conditional)
   - id: R018
     name: agent-teams

--- a/templates/.claude/skills/homework/SKILL.md
+++ b/templates/.claude/skills/homework/SKILL.md
@@ -161,6 +161,17 @@ Invoke the `omcustomcodex:feedback` skill with the drafted issue content. The us
 
 If `--dry-run` is active, skip this phase and output the draft directly to the conversation instead.
 
+## Cross-Project Import Compatibility
+
+When `homework` is imported into another project, Phase 5 depends on `omcustomcodex:feedback` being available and model-invocable in that project.
+
+| Condition | Behavior |
+|-----------|----------|
+| `omcustomcodex:feedback` model-invocable | Use the normal Phase 4A preview + confirmation gate |
+| feedback skill missing or model invocation disabled | Fall back to manual submission: present the drafted findings to the user, write the dry-run artifact when possible, and ask the user to file/run the feedback workflow themselves |
+
+Do not silently drop a retrospective because the imported feedback skill cannot be invoked.
+
 ### Phase 6: Output Summary
 
 ```

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -2,6 +2,17 @@
 
 This guide records Claude Code release-note impact that affects the Claude compatibility template. The Codex-native runtime still uses `.codex/**` and OMX as the primary surface.
 
+## v2.1.170
+
+Published: 2026-06-10.
+
+Source: upstream oh-my-customcode #1352/#1354, Codex port #1504.
+
+| Change | Impact on oh-my-customcodex | Action |
+|--------|------------------------------|--------|
+| Claude Fable 5 is available through the `fable` alias (`claude-fable-5`) | Useful only for packaged Claude compatibility sessions needing mythos-class reasoning; Codex-native subagents continue to use the OMX model contract and `reasoning_effort`. | Document in R006 as Claude-compatibility metadata. Do not change Codex routing defaults. |
+| VS Code integrated-terminal sessions save transcripts correctly and show them in `--resume` | Improves Claude-template workflows that depend on transcript replay, including imported `homework`/retrospective flows. | Prefer Claude Code v2.1.170+ when testing Claude compatibility transcript-dependent skills. No Codex runtime change. |
+
 ## v2.1.168
 
 Published: 2026-06-07.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,17 +1,17 @@
 {
-  "version": "0.5.20",
+  "version": "0.5.21",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-06-06T00:00:00.000Z",
+  "lastUpdated": "2026-06-11T00:00:00.000Z",
   "components": [
     {
       "name": "rules",
       "path": ".codex/rules",
       "description": "Agent behavior rules and guidelines",
-      "files": 22
+      "files": 23
     },
     {
       "name": "agents",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -140,6 +140,10 @@ steps:
       6. Halt if current failures exceed baseline; otherwise report pass/fail counts and delta.
       7. Run `bun run build` when available.
 
+      Documentation/template validation:
+      - For local or CI docs validation, run `bun run .github/scripts/validate-docs.ts --programmatic-only` (or the repo's equivalent validate-docs command with `--programmatic-only`) before assuming a validation failure is an authentication failure.
+      - Treat interactive/auth-dependent validate-docs output as inconclusive until the programmatic-only path has been tried.
+
       Halt on lint errors, typecheck errors, new test failures, build failure, or lockfile drift.
     description: Auto-detected build + test verification with mandatory bun test baseline delta guard
 
@@ -155,6 +159,13 @@ steps:
 
       Required version preflight for npm package releases:
       - Determine NEW_VERSION before creating a release branch, PR, or tag.
+      - Version decision (semver) — PATCH-PREFERRED policy from v1.0.0 onward:
+        * No existing tags → v0.1.0.
+        * Previous tag exists → default to patch. When in doubt, patch; do not reflexively bump minor for rule/doc/skill/config/wiki/workflow edits.
+        * patch (DEFAULT): bugfixes, hardening, rule/doc/skill/config/wiki/workflow changes, compatibility notes, and release-process guardrails.
+        * minor: only a genuinely new user-facing capability, such as a new skill/agent/command adding visible surface, not a refinement of an existing one.
+        * major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API) or a deliberate milestone declaration such as v1.0.0.
+        * If a previous tag is ahead of the source version, use the next available skip-version.
       - Update `package.json` and `templates/manifest.json` to NEW_VERSION in the same commit.
       - Promote `CHANGELOG.md` before the release PR/tag: move non-empty `## [Unreleased]` entries into `## [NEW_VERSION] - YYYY-MM-DD`, then re-create an empty `## [Unreleased]` section above it.
       - If `CHANGELOG.md` has no user/package-visible entry for NEW_VERSION, add a concise release summary before continuing instead of relying on GitHub auto-generated release notes.

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -9,6 +9,8 @@ describe('update command', () => {
   let tempDir: string;
   let originalCwd: string;
   let originalExit: typeof process.exit;
+  let originalOmcodexSkipSelfUpdate: string | undefined;
+  let originalOmcustomSkipSelfUpdate: string | undefined;
   let exitCode: number | undefined;
 
   // Console spies
@@ -23,6 +25,15 @@ describe('update command', () => {
 
     // Initialize i18n for tests that assert on log content
     await initI18n('en');
+
+    // Default update-command tests exercise external project updates, not the
+    // CLI package re-exec path. Guard self-update by default so leaked
+    // self-update module mocks or a newer npm version cannot call process.exit(0)
+    // and pollute "no error exit" assertions in full-suite runs.
+    originalOmcodexSkipSelfUpdate = process.env.OMCODEX_SKIP_SELF_UPDATE;
+    originalOmcustomSkipSelfUpdate = process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    process.env.OMCODEX_SKIP_SELF_UPDATE = 'true';
+    process.env.OMCUSTOM_SKIP_SELF_UPDATE = 'true';
 
     // Spy on process.exit
     originalExit = process.exit;
@@ -44,6 +55,18 @@ describe('update command', () => {
 
     // Restore process.exit
     process.exit = originalExit;
+
+    // Restore self-update guard env vars
+    if (originalOmcodexSkipSelfUpdate === undefined) {
+      delete process.env.OMCODEX_SKIP_SELF_UPDATE;
+    } else {
+      process.env.OMCODEX_SKIP_SELF_UPDATE = originalOmcodexSkipSelfUpdate;
+    }
+    if (originalOmcustomSkipSelfUpdate === undefined) {
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    } else {
+      process.env.OMCUSTOM_SKIP_SELF_UPDATE = originalOmcustomSkipSelfUpdate;
+    }
 
     // Restore console methods
     consoleLogSpy.mockRestore();
@@ -1660,6 +1683,7 @@ describe('update command', () => {
     beforeEach(() => {
       originalEnv = { ...process.env };
       // Ensure re-exec guard is NOT set by default
+      delete process.env.OMCODEX_SKIP_SELF_UPDATE;
       delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
     });
 
@@ -1862,6 +1886,9 @@ describe('update command', () => {
 
   describe('exitWithChildStatus signal handling (#867)', () => {
     it('should exit 128+15 (143) when child terminated by SIGTERM (#867)', async () => {
+      delete process.env.OMCODEX_SKIP_SELF_UPDATE;
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+
       const spawnSyncMock = mock(() => ({
         status: null,
         signal: 'SIGTERM' as NodeJS.Signals,
@@ -1919,6 +1946,8 @@ describe('update command', () => {
     });
 
     it('should warn and skip re-exec when process.argv[1] is empty (#867)', async () => {
+      delete process.env.OMCODEX_SKIP_SELF_UPDATE;
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
       process.argv = ['node'];
 
       const spawnSyncMock = mock(() => ({ status: 0, pid: 999, signal: null }));
@@ -1974,6 +2003,7 @@ describe('update command', () => {
 
     beforeEach(() => {
       originalEnv = { ...process.env };
+      delete process.env.OMCODEX_SKIP_SELF_UPDATE;
       delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
     });
 

--- a/tests/unit/core/self-update.test.ts
+++ b/tests/unit/core/self-update.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ExecuteSelfUpdateOptions, SelfUpdateOptions } from '../../../src/core/self-update.js';
@@ -205,6 +205,58 @@ describe('self-update module', () => {
       expect(result.checked).toBe(true);
       expect(result.updateAvailable).toBe(true);
       expect(result.latestVersion).toBe('1.1.0');
+      expect(result.usedCache).toBe(false);
+    });
+
+    it('should accept live fetched cross-major version and write cache (#1507)', () => {
+      const cachePath = createCachePath('cache-live-cross-major.json');
+      const now = Date.now();
+
+      const result = checkSelfUpdate({
+        currentVersion: '0.5.20',
+        packageName: 'test-package',
+        cachePath,
+        fetchLatestVersion: () => '1.0.0',
+        now,
+      });
+
+      expect(result.checked).toBe(true);
+      expect(result.updateAvailable).toBe(true);
+      expect(result.latestVersion).toBe('1.0.0');
+      expect(result.usedCache).toBe(false);
+
+      const cache = JSON.parse(readFileSync(cachePath, 'utf-8')) as { latestVersion: string };
+      expect(cache.latestVersion).toBe('1.0.0');
+    });
+
+    it('should ignore a fresh cached cross-major version and refetch (#1507)', () => {
+      const cachePath = createCachePath('cache-fresh-cross-major.json');
+      const now = Date.now();
+
+      writeFileSync(
+        cachePath,
+        JSON.stringify({
+          checkedAt: new Date(now - 1000).toISOString(),
+          latestVersion: '1.0.0',
+        }),
+        'utf-8'
+      );
+
+      let fetchCalls = 0;
+      const result = checkSelfUpdate({
+        currentVersion: '0.5.20',
+        cachePath,
+        cacheTtlMs: 24 * 60 * 60 * 1000,
+        fetchLatestVersion: () => {
+          fetchCalls += 1;
+          return '0.5.21';
+        },
+        now,
+      });
+
+      expect(fetchCalls).toBe(1);
+      expect(result.checked).toBe(true);
+      expect(result.latestVersion).toBe('0.5.21');
       expect(result.usedCache).toBe(false);
     });
 
@@ -603,6 +655,30 @@ describe('self-update module', () => {
       const result = executeSelfUpdate(options);
 
       expect(result.updated).toBe(false);
+    });
+
+    it('should reach install path for live cross-major update (#1507)', () => {
+      const installCalls: Array<{ packageName: string; version: string; silent: boolean }> = [];
+
+      const result = executeSelfUpdate({
+        currentVersion: '0.5.20',
+        packageName: 'test-package',
+        cachePath: createCachePath('exec-cache-live-cross-major.json'),
+        fetchLatestVersion: () => '1.0.0',
+        installPackage: (packageName, version, silent) => {
+          installCalls.push({ packageName, version, silent });
+          return true;
+        },
+        silent: true,
+        now: Date.now(),
+        argv: ['node', '/usr/local/bin/omcustomcodex'],
+        env: {},
+      });
+
+      expect(installCalls).toEqual([
+        { packageName: 'test-package', version: '1.0.0', silent: true },
+      ]);
+      expect(result).toEqual({ updated: true, fromVersion: '0.5.20', toVersion: '1.0.0' });
     });
 
     it('should return updated=false when already at latest version', () => {

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-05-30"
-  total_pages: 258
+  total_pages: 259
   total_sources: 244
 
 pages:
@@ -655,6 +655,9 @@ pages:
     - file: rules/r022.md
       title: "R022: Wiki Sync Rules"
       summary: "When agents, skills, rules, or guides change, corresponding wiki pages should be updated"
+    - file: rules/r023.md
+      title: "R023: Verification Ladder Rules"
+      summary: "Verification should run as a cost/speed ladder: deterministic checks, cheap LLM review, expensive LLM review, then human review"
 
   guides:
     - file: guides/airflow.md

--- a/wiki/rules/r001.md
+++ b/wiki/rules/r001.md
@@ -1,9 +1,9 @@
 ---
 title: "R001: Safety Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-06-11
 sources:
-  - .claude/rules/MUST-safety.md
+  - .codex/rules/MUST-safety.md
 related:
   - [[r002]]
   - [[r004]]
@@ -47,13 +47,19 @@ Prevents agents from performing irreversible or dangerous actions such as exposi
 
 ## Enforcement
 
-Prompt-based (CLAUDE.md + rules/) per [[r021]]. Some specific patterns enforced by `stage-blocker` hard-block hook.
+Prompt-based (AGENTS.md + .codex/rules/) per [[r021]]. Some specific patterns enforced by `stage-blocker` hard-block hook.
 
 ## Relationships
 
 - **Related rules**: [[r002]], [[r004]], [[r010]]
 - **Affects**: All agents with Bash or WebFetch access
 
+## Infra-Diagnostic Metadata and Standing-Deny Guards
+
+- **Infra-diagnostic metadata only**: during health or infrastructure diagnosis, check secret-bearing files with metadata commands such as `ls -la`; do not read `.env`, OAuth, kube, or credential JSON contents into the transcript just to prove existence.
+- **Standing user-deny + classifier block**: when the user has a standing "do not touch X" constraint and a safety classifier blocks an action on X once, stop retrying and switch to a user-runs command/instruction path.
+- **Infra deletion blast radius**: before tunnel, DNS, k8s, load-balancer, or security-group deletion, enumerate every served endpoint/route/selector/rule and prefer reversible disable/detach actions.
+
 ## Sources
 
-- `.claude/rules/MUST-safety.md` — rule definition
+- `.codex/rules/MUST-safety.md` — rule definition

--- a/wiki/rules/r003.md
+++ b/wiki/rules/r003.md
@@ -1,9 +1,9 @@
 ---
 title: "R003: Interaction Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-06-11
 sources:
-  - .claude/rules/SHOULD-interaction.md
+  - .codex/rules/SHOULD-interaction.md
 related:
   - [[r000]]
   - [[r004]]
@@ -48,13 +48,21 @@ Ensures consistent, actionable communication. Responses should be brief and spec
 
 ## Enforcement
 
-Prompt-based (CLAUDE.md + rules/) per [[r021]]. Advisory only.
+Prompt-based (AGENTS.md + .codex/rules/) per [[r021]]. Advisory only.
 
 ## Relationships
 
 - **Related rules**: [[r000]], [[r004]], [[r013]], [[r020]]
 - **Affects**: All agent responses, status reporting across all workflows
 
+## Request Handling: Interrupt Row and Precedence
+
+| Type | Action |
+|------|--------|
+| Interrupt (ambiguous first message) | Do not assume the prior request is cancelled. The first post-interrupt message may be continuation, correction, or a new request. If the in-progress action is destructive/risky, apply the Risky row first and halt. |
+
+Request handling precedence: **Risky > Interrupt > Ambiguous > Clear**. Clear new instructions still execute directly; this row only protects ambiguous post-interrupt messages.
+
 ## Sources
 
-- `.claude/rules/SHOULD-interaction.md` — rule definition
+- `.codex/rules/SHOULD-interaction.md` — rule definition

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -1,7 +1,7 @@
 ---
 title: "R006: Agent Design Rules"
 type: rule
-updated: 2026-04-24
+updated: 2026-06-11
 sources:
   - .codex/rules/MUST-agent-design.md
 related:
@@ -102,6 +102,10 @@ Prompt-based + mgr-sauron R017 verification. mgr-creator enforces frontmatter va
 - **Enforced by**: `mgr-creator` (creation), `mgr-sauron` ([[r017]])
 - **Related rules**: [[r007]], [[r010]], [[r017]], [[r022]]
 - **Affects**: All 48 agents, 112 skill directories
+
+## Claude Compatibility Model Alias Note
+
+Claude Code v2.1.170 adds access to `claude-fable-5` via the `fable` alias and fixes a VS Code integrated-terminal transcript persistence bug. In this Codex port, `fable` is documentation for packaged Claude compatibility templates only; Codex-native agents continue to follow the OMX model contract and `reasoning_effort` routing.
 
 ## Sources
 

--- a/wiki/rules/r009.md
+++ b/wiki/rules/r009.md
@@ -1,7 +1,7 @@
 ---
 title: "R009: Parallel Execution Rules"
 type: rule
-updated: 2026-06-09
+updated: 2026-06-11
 sources:
   - .codex/rules/MUST-parallel-execution.md
 related:
@@ -67,6 +67,10 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 
 - **Related rules**: [[r008]], [[r010]], [[r018]]
 - **Affects**: All multi-task operations, batch workflows, research skills
+
+## Parallel Feature Integration Gate
+
+Per-subagent "build green" does not prove integrated runtime correctness. When parallel feature agents edit interdependent code (shared singletons, navigation stacks, API contracts, shared config, generated/template mirrors), the orchestrator must run an aggregate build plus runtime/smoke verification after merging all lanes and before declaring done.
 
 ## Sources
 

--- a/wiki/rules/r011.md
+++ b/wiki/rules/r011.md
@@ -32,3 +32,7 @@ Native auto-memory (agent frontmatter `memory` field) is the primary persistence
 | MEMORY.md updates | sys-memory-keeper |
 | Searchable MCP save | Orchestrator |
 | Session-end check | Orchestrator |
+
+## Subagent `memory: project` Source-Tree Pollution Guard
+
+Subagents working from source subdirectories must not create nested `.codex/agent-memory/` or `.claude/agent-memory/` directories inside source packages. Project memory resolves to the repository root memory surface. Before commit, search for nested memory directories and remove source-tree pollution.

--- a/wiki/rules/r018.md
+++ b/wiki/rules/r018.md
@@ -1,7 +1,7 @@
 ---
 title: "R018: Agent Teams Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-06-11
 sources:
   - .codex/rules/MUST-agent-teams.md
 related:
@@ -12,7 +12,7 @@ related:
 
 # R018: Agent Teams Rules
 
-When Agent Teams is enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), qualifying collaborative tasks MUST use Agent Teams instead of sequential Agent tool calls.
+When Codex/OMX Agent Teams are enabled (for example `OMCODEX_AGENT_TEAMS=1` or callable team tools), qualifying collaborative tasks MUST use Agent Teams instead of sequential standalone Agent calls.
 
 ## Overview
 
@@ -61,6 +61,10 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 
 - **Related rules**: [[r009]], [[r010]]
 - **Affects**: `/research`, `/deep-plan`, multi-issue release workflows, code review cycles
+
+## Gate Transparency Scope
+
+R018 gate-transparency announcements apply only when Agent Teams are enabled or callable in the current runtime. If teams are disabled/unavailable, R009 `[N]` parallel dispatch formatting is sufficient and a 3+ standalone-agent batch is not itself a gate-transparency violation.
 
 ## Sources
 

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -1,7 +1,7 @@
 ---
 title: "R020: Completion Verification Rules"
 type: rule
-updated: 2026-06-09
+updated: 2026-06-11
 sources:
   - .codex/rules/MUST-completion-verification.md
 related:
@@ -125,6 +125,20 @@ Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]]
 
 - **Related rules**: [[r003]], [[r008]], [[r010]], [[r017]], [[r021]]
 - **Affects**: All task completion declarations across all agents and workflows
+
+## Interrupt ≠ Prior-Request Cancellation
+
+If the first message after an interrupt is ambiguous, do not assume the prior request was cancelled. Preserve non-destructive prior context and clarify once when the new message cannot be classified as clear continuation/correction/new work.
+
+**Safety carve-out:** if interrupted work is destructive or irreversible (`git reset --hard`, `git clean -fd`, broad `rm`, force push, tunnel/DNS/k8s/infra deletion, production state changes), halt first and require explicit re-authorization before resuming.
+
+## Proxy Signal vs Canonical Ground-Truth
+
+When diagnosing pipeline or data state, verify the canonical store (authoritative DB/system-of-record) before characterizing state from a secondary proxy such as a `.txt` artifact, filesystem mtime, or one ingestion path. A single path failure does not prove the whole pipeline is blocked.
+
+## State-Change Claim → Live System Verification
+
+Before closing or marking-done a task that claims an infrastructure/resource state change, verify the live state, not just the attempted command. "Issued the teardown" is not proof that a service, k8s resource, container, or process is actually gone.
 
 ## Sources
 

--- a/wiki/rules/r023.md
+++ b/wiki/rules/r023.md
@@ -1,0 +1,82 @@
+---
+title: "R023: Verification Ladder Rules"
+type: rule
+updated: 2026-06-11
+sources:
+  - .codex/rules/SHOULD-verification-ladder.md
+related:
+  - [[r021]]
+  - [[r013]]
+  - [[r009]]
+  - [[r017]]
+  - [[deep-verify]]
+  - [[adversarial-review]]
+  - [[dev-review]]
+---
+
+# R023: Verification Ladder Rules
+
+검증을 비용/속도 사다리로 구성한다. 결정론적 검사가 먼저 통과해야 LLM 검토로 이어진다.
+
+## Overview
+
+가장 저렴한 tier가 잡을 수 있는 오류를 비싼 tier로 보내지 않는다는 shift-left 원칙. hooks와 linter가 잡을 수 있는 문제를 sonnet/opus에 보내는 것은 낭비다. [[r013]] ecomode의 출력 토큰 절약과 직교적으로 검증 비용을 절약한다.
+
+## Priority
+
+**SHOULD** — advisory. 새 검증 도구 추가 시 tier 분류가 권장된다.
+
+## Ladder Tiers
+
+| Tier | 도구 | 비용 | 속도 | 적용 시점 |
+|------|------|------|------|-----------|
+| **1: Deterministic** | hooks, linters, type-check, JSON schema | $0 | <1s | Pre-write, write-time |
+| **2: Cheap LLM** | haiku-based skills (`dev-review`, `action-validator`) | $ | <30s | Per-file review |
+| **3: Expensive LLM** | sonnet/opus skills (`deep-verify`, `adversarial-review`, `multi-model-verification`) | $$$ | 1-5분 | Pre-commit, PR review |
+| **4: Human** | maintainer review | time | hours-days | Final gate |
+
+## Asset Mapping
+
+| Tier | 자산 |
+|------|------|
+| Tier 1 | `.codex/hooks/` PreToolUse hooks, `mgr-sauron` (R017 구조 검증), pre-commit linters |
+| Tier 2 | [[dev-review]], [[action-validator]], `pre-generation-arch-check` |
+| Tier 3 | [[deep-verify]], [[adversarial-review]], `multi-model-verification`, `evaluator-optimizer`, `worker-reviewer-pipeline` |
+| Tier 4 | maintainer PR approval |
+
+## Relationship with R021
+
+[[r021]]과 **직교**: R021은 위반 시 어떻게 멈출지(Hard Block / Advisory)를 정의하고, R023은 어떤 비용 순서로 검증할지를 정의한다. 같은 도구가 두 규칙에 동시에 속할 수 있다 — `mgr-sauron`은 R021 관점에서 Advisory, R023 관점에서 Tier 1이다.
+
+## Integration
+
+- **[[r009]]**: Tier 1-2 검사는 독립 파일에 대해 병렬 실행 가능
+- **[[r013]]**: 컨텍스트 압박 시 Tier 3를 Tier 2로 다운그레이드 고려
+- **[[r017]]**: Phase 1-3 검증 단계가 R023 Tier 1-3에 대응
+- **[[r021]]**: 직교 — blocking 방식 vs 검증 비용 순서
+
+## Safety-Signal Rule Authoring — Carve-Out Pre-Check (shift-left)
+
+**트리거**: 런타임 안전-신호 동작을 정의하는 룰(인터럽트·취소·halt·중단 등)을 새로 작성하거나 수정할 때 적용한다. 이 checklist 자체 같은 메타-룰이나 구조/형식 변경에는 적용하지 않는다.
+
+해당 룰 작성 시 Tier 3(적대적 검증)이 잡는 결함을 Tier 1(작성 시점)으로 시프트하기 위한 사전 점검. 불확실한 경우 이 Tier 1 pre-check를 먼저 통과한 뒤 Tier 3 검증으로 진행한다(ladder 순서 유지).
+
+새 안전-신호 룰을 작성하거나 기존 룰을 수정하기 전, 아래 4개 질문을 통과해야 한다:
+
+| 점검 항목 | 질문 |
+|-----------|------|
+| Fail-closed 필요 여부 | 이 신호가 오독되면 파괴적 작업이 계속 실행되는가? |
+| "진행" 오독 여지 | 룰 문구에서 신호가 "계속" 허가로 읽힐 수 있는가? |
+| Fail-safe 약화 여부 | 기존 fail-safe 조건(R001/R002 우선순위)을 약화하는가? |
+| R001/R002 우선순위 명시 | R001 파괴적-작업 carve-out이 이 룰보다 우선함을 명시했는가? |
+
+모든 항목 통과 전까지 룰을 병합하지 않는다. 이 pre-check가 없으면 Tier 3 적대적 검증이 뒤늦게 결함을 발견하게 된다.
+
+**[[r016]]과 직교**: R016은 위반 *후* 룰을 업데이트하는 반응적 루프이고, 이 R023 carve-out pre-check는 룰을 *작성할 때* 수행하는 사전 점검이다. 두 규칙은 서로 다른 시점을 다루며 충돌하지 않는다.
+
+> Origin: #1353 — #1341(FSD 인터럽트 오인 회고)의 후속 회고에서 발견된 R001 carve-out 누락. FSD 인터럽트 처리 룰 초안에서 "인터럽트 = 취소 오인"이 Tier 3 검증에서만 잡혔다. 작성 시점 Tier 1 사전 점검으로 시프트.
+
+## Sources
+
+- `.codex/rules/SHOULD-verification-ladder.md` — rule definition
+- `guides/compound-ai-workflow/README.md` — 원칙 3 (Verification Ladders) 컨텍스트

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -140,6 +140,10 @@ steps:
       6. Halt if current failures exceed baseline; otherwise report pass/fail counts and delta.
       7. Run `bun run build` when available.
 
+      Documentation/template validation:
+      - For local or CI docs validation, run `bun run .github/scripts/validate-docs.ts --programmatic-only` (or the repo's equivalent validate-docs command with `--programmatic-only`) before assuming a validation failure is an authentication failure.
+      - Treat interactive/auth-dependent validate-docs output as inconclusive until the programmatic-only path has been tried.
+
       Halt on lint errors, typecheck errors, new test failures, build failure, or lockfile drift.
     description: Auto-detected build + test verification with mandatory bun test baseline delta guard
 
@@ -155,6 +159,13 @@ steps:
 
       Required version preflight for npm package releases:
       - Determine NEW_VERSION before creating a release branch, PR, or tag.
+      - Version decision (semver) — PATCH-PREFERRED policy from v1.0.0 onward:
+        * No existing tags → v0.1.0.
+        * Previous tag exists → default to patch. When in doubt, patch; do not reflexively bump minor for rule/doc/skill/config/wiki/workflow edits.
+        * patch (DEFAULT): bugfixes, hardening, rule/doc/skill/config/wiki/workflow changes, compatibility notes, and release-process guardrails.
+        * minor: only a genuinely new user-facing capability, such as a new skill/agent/command adding visible surface, not a refinement of an existing one.
+        * major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API) or a deliberate milestone declaration such as v1.0.0.
+        * If a previous tag is ahead of the source version, use the next available skip-version.
       - Update `package.json` and `templates/manifest.json` to NEW_VERSION in the same commit.
       - Promote `CHANGELOG.md` before the release PR/tag: move non-empty `## [Unreleased]` entries into `## [NEW_VERSION] - YYYY-MM-DD`, then re-create an empty `## [Unreleased]` section above it.
       - If `CHANGELOG.md` has no user/package-visible entry for NEW_VERSION, add a concise release summary before continuing instead of relying on GitHub auto-generated release notes.


### PR DESCRIPTION
## Summary
- Fix explicit CLI self-update so live npm fetches can advance across major versions while stale/implausible cached versions are still ignored.
- Port current upstream rule, skill, workflow, wiki, and Claude compatibility guardrails for the v0.5.21 auto-dev scope.
- Bump package and template manifest metadata to `0.5.21` and promote the changelog.

Closes #1501
Closes #1502
Closes #1503
Closes #1504
Closes #1505
Closes #1506
Closes #1507

## Verification
- `bash .github/scripts/verify-version-sync.sh`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 1850 pass, 0 fail
- `bun run build`
- `bash .github/scripts/verify-wiki-sync.sh`
- `bun .github/scripts/validate-docs.ts --programmatic-only`
- Pre-commit stable batches passed during commit

## Release
- Version: `0.5.21`
- Branch: `release/v0.5.21`
