### PR TITLE
Release v1.0.0

### DIFF
--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.5.22",
-  "generatedAt": "2026-06-11T05:59:48.467Z",
-  "templateVersion": "0.5.22",
+  "generatorVersion": "1.0.0",
+  "generatedAt": "2026-06-11T09:54:26.954Z",
+  "templateVersion": "1.0.0",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e2690ef49068c522f452b7bc26089687adf98b1039841704dfcac64a6fa8a65b",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-11
+
+### Changed
+- Promote oh-my-customcodex to the 1.0.0 stable release line after the v0.5.22 Codex/OMX harness sync.
+- Preserve the v0.5.22 feature set and release workflow while publishing the first stable semver major.
+
 ## [0.5.22] - 2026-06-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.5.22",
+  "version": "1.0.0",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.5.22",
+  "version": "1.0.0",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-06-11T00:00:00.000Z",
+  "lastUpdated": "2026-06-11",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Release scope

Release `oh-my-customcodex@1.0.0` as the first stable semver major.

This is a version-only stable promotion from the verified v0.5.22 feature set:

- `package.json`: `1.0.0`
- `templates/manifest.json`: `1.0.0`
- `.omcodex.lock.json`: generated with template/generator `1.0.0`
- `CHANGELOG.md`: adds the `1.0.0` release entry

No runtime behavior changes are intended in this PR.

## Verification

- `bun run build`
- `bash .github/scripts/verify-version-sync.sh`
- `bash .github/scripts/verify-template-sync.sh`
- `bash .github/scripts/verify-wiki-sync.sh`
- `bun .github/scripts/validate-docs.ts --programmatic-only`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 1850 pass / 0 fail
- `npm pack --dry-run` — package `oh-my-customcodex@1.0.0`, 415 files, 1.0 MB tarball
- `git diff --check`
- Pre-commit hook: typecheck, lint, stable test batches all passed

## Release path

After merge to `develop`, `auto-tag.yml` should create `v1.0.0` on the merge commit and `release.yml` should publish npm, GitHub Packages, and GitHub Release.
