### PR TITLE
Release v1.0.3 upstream compatibility notes

### DIFF
--- a/.omcodex.lock.json
+++ b/.omcodex.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.2",
-  "generatedAt": "2026-06-14T05:45:46.606Z",
-  "templateVersion": "1.0.2",
+  "generatorVersion": "1.0.3",
+  "generatedAt": "2026-06-16T22:47:34.215Z",
+  "templateVersion": "1.0.3",
   "files": {
     ".codex/rules/SHOULD-interaction.md": {
       "templateHash": "e2690ef49068c522f452b7bc26089687adf98b1039841704dfcac64a6fa8a65b",
@@ -750,8 +750,8 @@
       "component": "guides"
     },
     "guides/openai-codex/01-version-compatibility.md": {
-      "templateHash": "d2969da14fa3dbe649f06080debdcd94db1f482ce001b90dfe146d3a34ecdff3",
-      "size": 4329,
+      "templateHash": "b81efe22a1b9597c9cb1ee7078b8af91fe53adfe5fd3fc8ad14e870680dd2ed3",
+      "size": 6752,
       "component": "guides"
     },
     "guides/openai-codex/index.yaml": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-06-17
+
+### Changed
+- Record upstream `Yeachan-Heo/oh-my-codex` v0.18.12 compatibility review for #1520 as no source-port required in this package.
+- Record OpenAI Codex `rust-v0.140.0` compatibility impacts for #1522 across source/template/wiki guidance, including `/usage`, native `/goal`, `/delete`, `/import`, unified `@` mentions, credential storage, and MCP/plugin reliability notes.
+
 ## [1.0.2] - 2026-06-14
 
 ### Added

--- a/docs/superpowers/plans/2026-06-17-v1.0.3-release.md
+++ b/docs/superpowers/plans/2026-06-17-v1.0.3-release.md
@@ -1,0 +1,63 @@
+# v1.0.3 Auto-Dev Release Plan — Upstream Codex/OMX compatibility review
+
+Date: 2026-06-17
+Sources: auto-dev release-monitor issues #1520 and #1522.
+
+## Scope
+
+| Issue | Priority | Effort | Decision | Local surface |
+| --- | --- | --- | --- | --- |
+| #1520 | P2 | XS | Review `Yeachan-Heo/oh-my-codex` v0.18.12 and record no source-port requirement for this package. | Release plan and changelog |
+| #1522 | P2 | S | Record OpenAI Codex `rust-v0.140.0` runtime compatibility impacts. | `guides/openai-codex/**`, templates, wiki guide, changelog |
+
+## Compression Mode
+
+`compression_mode=lite`.
+
+Rationale:
+
+- Scope size is 2 issues.
+- Changes are release-monitor documentation, compatibility notes, wiki/template mirror updates, and release metadata.
+- No TypeScript runtime behavior, dependency change, migration, or security-sensitive implementation is required.
+- Full verify-build remains mandatory before release.
+
+## Upstream Review: #1520 / oh-my-codex v0.18.12
+
+Upstream v0.18.12 is a patch release focused on release-workflow reconciliation, automation/planning gates, plugin guidance preservation, HUD/session cleanup, Windows hook/state robustness, and publication readiness evidence.
+
+Codex-port decision:
+
+- No direct source port is required in `oh-my-customcodex` for this release unit.
+- The changed upstream implementation surfaces (`src/autopilot/**`, `src/ralplan/**`, `src/hud/**`, `src/state/**`, plugin native hook wiring, and npm release workflow internals) belong to the OMX runtime package, not this child package's shipped templates or CLI.
+- The portable guidance relevant to this repo is already represented in the active AGENTS/runtime contract: `ralplan` planning gates, `omx question` deep-interview handling, explicit native subagent `agent_type`, plugin/skill guidance preservation, and metadata-only credential handling.
+- Raising `MINIMUM_OMX_VERSION` above 0.18.0 is not required because this package does not depend on a v0.18.12-only API in source or tests.
+
+## OpenAI Codex Review: #1522 / rust-v0.140.0
+
+Record the release-note impact in the OpenAI Codex compatibility guide:
+
+- `/usage` daily/weekly/cumulative token views are runtime evidence, not a package telemetry contract.
+- Native `/goal` large input/image preservation reinforces keeping `omcustomcodex:goal` namespaced and durable artifacts explicit.
+- `codex delete`/`/delete` remains destructive and must stay explicitly user-authorized.
+- `/import` is a Codex migration helper; it does not replace `omcustomcodex init/update` template sync.
+- Unified `@` mentions, credential storage, SQLite recovery, MCP/plugin fixes, stale hook cleanup, and non-TTY interrupt handling require no package migration.
+
+## Implementation Notes
+
+1. Add `rust-v0.140.0` to `guides/openai-codex/01-version-compatibility.md`.
+2. Mirror the guide update to `templates/guides/openai-codex/01-version-compatibility.md`.
+3. Update `wiki/guides/openai-codex.md` and refresh `wiki/.source-hashes.json`.
+4. Promote `CHANGELOG.md` to v1.0.3 and bump package/template/lock metadata.
+5. Close #1520 and #1522 after release verification with `Fixed in v1.0.3` evidence.
+
+## Verification
+
+- `bash .github/scripts/verify-version-sync.sh`
+- `bash .github/scripts/verify-template-sync.sh`
+- `bash .github/scripts/verify-wiki-sync.sh`
+- `bun run .github/scripts/validate-docs.ts --programmatic-only`
+- `bun install`
+- `bun run lint`
+- `bun run typecheck`
+- `bun test`
+- `bun run build`

--- a/guides/openai-codex/01-version-compatibility.md
+++ b/guides/openai-codex/01-version-compatibility.md
@@ -2,6 +2,20 @@
 
 This guide records OpenAI Codex release-note impact decisions for oh-my-customcodex. Use it for Codex/OMX runtime compatibility notes; keep Claude-only release notes in `guides/claude-code/15-version-compatibility.md`.
 
+## rust-v0.140.0 / CLI 0.140.0
+
+Source: upstream OpenAI Codex release `rust-v0.140.0`, Codex-port issue #1522.
+
+| Change | Impact on oh-my-customcodex | Action |
+| --- | --- | --- |
+| `/usage` adds daily, weekly, and cumulative account token activity views | Useful runtime cost signal, but not a packaged `omcustomcodex` telemetry contract. | Keep Codex usage evidence source-specific; continue using OMX/status/trace or local command evidence for package workflows. |
+| Native `/goal` preserves oversized text, large pasted blocks, and image attachments, including remote app-server sessions | Reduces data loss in Codex-native goal tracking while this package keeps its namespaced `omcustomcodex:goal` workflow. | Do not shadow native `/goal`; keep long objective handoff text in artifacts when package workflows need durable release evidence. |
+| `codex delete`, `/delete`, and app-server `thread/delete` can permanently delete sessions with safeguards and subagent cleanup | Destructive lifecycle operation outside this package's installed template surface. | Treat permanent thread deletion as an explicit user-authorized runtime action; do not automate it from package skills. |
+| `/import` selectively imports setup, project configuration, and recent chats from Claude Code | Helpful migration path for operators moving Claude context into Codex. | Keep `omcustomcodex init/update` as the package-owned template path; mention import only as a Codex runtime migration helper, not as a replacement for template sync. |
+| Typing `@` opens a unified mentions menu for files, plugins, and skills | Matches connector/plugin/skill routing vocabulary in current instructions. | No template change; continue to prefer exact file, plugin, and skill references when a task depends on them. |
+| Managed Amazon Bedrock API-key auth and encrypted local storage for CLI/MCP OAuth credentials | Improves Codex credential handling but does not change this package's credential boundary. | Keep R001 metadata-only credential diagnostics; never read or echo stored credential values. |
+| SQLite recovery, MCP startup/auth fixes, remote plugin uninstall fixes, update-dismissal persistence, stale hook cleanup, and interruptible non-TTY background commands | Runtime reliability improvements that reduce false blockers during package workflows. | No package dependency or config migration required beyond this compatibility record. |
+
 ## rust-v0.139.0 / CLI 0.139.0
 
 Source: upstream OpenAI Codex release `rust-v0.139.0`, Codex-port issue #1498.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",

--- a/templates/guides/openai-codex/01-version-compatibility.md
+++ b/templates/guides/openai-codex/01-version-compatibility.md
@@ -2,6 +2,20 @@
 
 This guide records OpenAI Codex release-note impact decisions for oh-my-customcodex. Use it for Codex/OMX runtime compatibility notes; keep Claude-only release notes in `guides/claude-code/15-version-compatibility.md`.
 
+## rust-v0.140.0 / CLI 0.140.0
+
+Source: upstream OpenAI Codex release `rust-v0.140.0`, Codex-port issue #1522.
+
+| Change | Impact on oh-my-customcodex | Action |
+| --- | --- | --- |
+| `/usage` adds daily, weekly, and cumulative account token activity views | Useful runtime cost signal, but not a packaged `omcustomcodex` telemetry contract. | Keep Codex usage evidence source-specific; continue using OMX/status/trace or local command evidence for package workflows. |
+| Native `/goal` preserves oversized text, large pasted blocks, and image attachments, including remote app-server sessions | Reduces data loss in Codex-native goal tracking while this package keeps its namespaced `omcustomcodex:goal` workflow. | Do not shadow native `/goal`; keep long objective handoff text in artifacts when package workflows need durable release evidence. |
+| `codex delete`, `/delete`, and app-server `thread/delete` can permanently delete sessions with safeguards and subagent cleanup | Destructive lifecycle operation outside this package's installed template surface. | Treat permanent thread deletion as an explicit user-authorized runtime action; do not automate it from package skills. |
+| `/import` selectively imports setup, project configuration, and recent chats from Claude Code | Helpful migration path for operators moving Claude context into Codex. | Keep `omcustomcodex init/update` as the package-owned template path; mention import only as a Codex runtime migration helper, not as a replacement for template sync. |
+| Typing `@` opens a unified mentions menu for files, plugins, and skills | Matches connector/plugin/skill routing vocabulary in current instructions. | No template change; continue to prefer exact file, plugin, and skill references when a task depends on them. |
+| Managed Amazon Bedrock API-key auth and encrypted local storage for CLI/MCP OAuth credentials | Improves Codex credential handling but does not change this package's credential boundary. | Keep R001 metadata-only credential diagnostics; never read or echo stored credential values. |
+| SQLite recovery, MCP startup/auth fixes, remote plugin uninstall fixes, update-dismissal persistence, stale hook cleanup, and interruptible non-TTY background commands | Runtime reliability improvements that reduce false blockers during package workflows. | No package dependency or config migration required beyond this compatibility record. |
+
 ## rust-v0.139.0 / CLI 0.139.0
 
 Source: upstream OpenAI Codex release `rust-v0.139.0`, Codex-port issue #1498.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "requiresCC": ">=2.1.121",
   "claudeCode": {
     "minimumVersion": "2.1.121",
     "protectedPathBypassVersion": "2.1.126"
   },
-  "lastUpdated": "2026-06-11",
+  "lastUpdated": "2026-06-17",
   "components": [
     {
       "name": "rules",

--- a/wiki/.source-hashes.json
+++ b/wiki/.source-hashes.json
@@ -230,7 +230,7 @@
   "guides/multi-agent-debate-patterns": "b9146c41ce32ef98a50d8c0515eb2f91e42a5d29d4c2cfd0639838ed3f1591cf",
   "guides/multi-model-routing": "8614c9b9ac576cf4c56d8291b12bce96905c786f18227c60d39a5259aabafcb4",
   "guides/multi-provider-exec": "cc6f2e47ef2d53f1a9d0922835130021f2d5cf43a1abce51799d0257f917ae3e",
-  "guides/openai-codex": "7cdcde03ad9dc7fb52d37b43e688dee52ff3829d11fa6c0b820b689b989d9209",
+  "guides/openai-codex": "fdc024647018c0770173bb95b0445fef501481fb11758fa632faaf4396e72892",
   "guides/postgres": "679a0b942439d7559621633b6cd5692554cec2c6a3895a2511733ee6bd3e5f83",
   "guides/professor-triage": "8a0664b4d49164d9c85183ebaaf8062db781ad8cf2ddbae425b00763ea316f1e",
   "guides/python": "ee2886668f13786ae5bbb90a48aab4269a9c4b0c272bb378624a381dd74a5b51",

--- a/wiki/guides/openai-codex.md
+++ b/wiki/guides/openai-codex.md
@@ -1,7 +1,7 @@
 ---
 title: "OpenAI Codex Compatibility Guide"
 type: guide
-updated: 2026-06-11
+updated: 2026-06-17
 sources:
   - guides/openai-codex/01-version-compatibility.md
 related:
@@ -29,7 +29,9 @@ This guide tracks Codex/OMX runtime compatibility notes separately from Claude C
 
 ## Current Release Note
 
-`rust-v0.139.0` is tracked for #1498. The package records impact for web search from code mode, richer connector schema preservation, redacted `codex doctor` metadata, plugin marketplace JSON, resume/fork prompt handling, MCP warning scoping, exact image-edit paths, URL linkification, thread-reset config preservation, and sandbox escalation/proxy consistency. No package dependency or runtime migration is required.
+`rust-v0.140.0` is tracked for #1522. The package records impact for `/usage` token activity views, native `/goal` large-input preservation, permanent session deletion, Claude Code `/import`, unified `@` mentions, managed Bedrock/OAuth credential storage, SQLite recovery, MCP reliability, remote plugin uninstall fixes, stale hook cleanup, and interruptible non-TTY background commands.
+
+No package dependency or runtime migration is required. `omcustomcodex:goal` remains namespaced beside native `/goal`, destructive `codex delete`/`/delete` actions stay explicitly user-authorized, and credential diagnostics remain metadata-only under R001.
 
 ## Relationships
 


### PR DESCRIPTION
## Summary

- Record the v1.0.3 auto-dev scope for upstream release-monitor issues #1520 and #1522.
- Add OpenAI Codex rust-v0.140.0 compatibility notes to source/template/wiki guidance.
- Document why `Yeachan-Heo/oh-my-codex` v0.18.12 does not require a package code port or minimum OMX baseline bump.
- Bump package/template/lock metadata to 1.0.3 and promote the changelog.

## Verification

- `bun install`
- `bash .github/scripts/verify-version-sync.sh`
- `bash .github/scripts/verify-template-sync.sh`
- `bash .github/scripts/verify-wiki-sync.sh`
- `bun run .github/scripts/validate-docs.ts --programmatic-only`
- `bun run lint`
- `bun run typecheck`
- `bun test` (1850 pass, 0 fail)
- `bun run build`
- pre-commit hook stable batches (passed)

## Release notes

- Fixes #1520
- Fixes #1522

## Publish note

`npm whoami` returned E401 during preflight, so npm publish may require registry auth restoration before final release completion.

